### PR TITLE
fix: conversion errors featureCatalogueCitation title and serviceType…

### DIFF
--- a/src/main/plugin/iso19115-3.2018.che/convert/ISO19139/mapping/CHE_MD_FeatureCatalogueDescription.xsl
+++ b/src/main/plugin/iso19115-3.2018.che/convert/ISO19139/mapping/CHE_MD_FeatureCatalogueDescription.xsl
@@ -28,11 +28,12 @@
                 <xsl:element name="mrc:featureCatalogue">
                     <xsl:element name="gfc:FC_FeatureCatalogue">
                         <xsl:choose>
-                            <xsl:when test="./gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:title">
-                                <xsl:call-template name="writeCharacterStringElement">
-                                    <xsl:with-param name="elementName" select="'cat:name'"/>
-                                    <xsl:with-param name="nodeWithStringToWrite" select="./gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:title"/>
-                                </xsl:call-template>
+                            <xsl:when test="./gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:title/gcoold:CharacterString">
+                                <xsl:element name="cat:name">
+                                    <xsl:element name="gco:CharacterString">
+                                        <xsl:value-of select="./gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:title/gcoold:CharacterString"/>
+                                    </xsl:element>
+                                </xsl:element>
                             </xsl:when>
                             <xsl:otherwise>
                                 <xsl:element name="cat:name">

--- a/src/main/plugin/iso19115-3.2018.che/convert/ISO19139/mapping/core.xsl
+++ b/src/main/plugin/iso19115-3.2018.che/convert/ISO19139/mapping/core.xsl
@@ -307,10 +307,11 @@
               <xsl:with-param name="elementName" select="'cit:title'"/>
               <xsl:with-param name="nodeWithStringToWrite" select="."/>
             </xsl:call-template>
-            <xsl:call-template name="writeCharacterStringElement">
-              <xsl:with-param name="elementName" select="'cit:edition'"/>
-              <xsl:with-param name="nodeWithStringToWrite" select="../gmd:metadataStandardVersion"/>
-            </xsl:call-template>
+            <cit:edition>
+              <xsl:for-each select="../gmd:metadataStandardVersion/gcoold:CharacterString">
+                <gco:CharacterString><xsl:value-of select="."/></gco:CharacterString>
+              </xsl:for-each>
+            </cit:edition>
           </xsl:otherwise>
         </xsl:choose>
       </cit:CI_Citation>

--- a/src/test/java/org/fao/geonet/schema/Iso19139cheToIso19115cheConversionTest.java
+++ b/src/test/java/org/fao/geonet/schema/Iso19139cheToIso19115cheConversionTest.java
@@ -242,6 +242,16 @@ public class Iso19139cheToIso19115cheConversionTest {
         transformAndCompare("giebenach", true);
     }
 
+    @Test
+    public void convertFeatureCatalogueCitationMultilingualTitle() throws Exception {
+        transformAndCompare("featureCatalogueCitation-multilingual-title", false);
+    }
+
+    @Test
+    public void convertWmsWithTwoServiceTypeVersion() throws Exception {
+        transformAndCompare("wms-with-2-serviceTypeVersion", false);
+    }
+
     private void assertNamespacePresent(List<?> namespaces, String nsLocation, String prefix) {
         Namespace ns = namespaces.stream() //
                 .filter(n -> prefix.equals(((Namespace) n).getPrefix()))

--- a/src/test/resources/featureCatalogueCitation-multilingual-title-19115-3.che.xml
+++ b/src/test/resources/featureCatalogueCitation-multilingual-title-19115-3.che.xml
@@ -1,0 +1,809 @@
+<che:CHE_MD_Metadata xmlns:che="http://geocat.ch/che" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0" xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1" xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0" xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0" xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0" xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0" xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0" xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0" xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0" xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0" xmlns:md1="http://standards.iso.org/iso/19115/-3/md1/2.0" xmlns:md2="http://standards.iso.org/iso/19115/-3/md2/2.0" xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/2.0" xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0" xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/2.0" xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/2.0" xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0" xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0" xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0" xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0" xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0" xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0" xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0" xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0" xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0" xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0" xmlns:dqm="http://standards.iso.org/iso/19157/-2/dqm/1.0" xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0" xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink" gco:isoType="mdb:MD_Metadata">
+  <mdb:metadataIdentifier>
+    <mcc:MD_Identifier>
+      <mcc:code>
+        <gco:CharacterString>be080b9d-bbac-40ce-bc69-cdd1e8d7ae50</gco:CharacterString>
+      </mcc:code>
+    </mcc:MD_Identifier>
+  </mdb:metadataIdentifier>
+  <mdb:defaultLocale>
+    <lan:PT_Locale id="FR">
+      <lan:language>
+        <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="fre">fre</lan:LanguageCode>
+      </lan:language>
+      <lan:characterEncoding>
+        <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
+      </lan:characterEncoding>
+    </lan:PT_Locale>
+  </mdb:defaultLocale>
+  <mdb:metadataScope>
+    <mdb:MD_MetadataScope>
+      <mdb:resourceScope>
+        <mcc:MD_ScopeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode" codeListValue="dataset">dataset</mcc:MD_ScopeCode>
+      </mdb:resourceScope>
+    </mdb:MD_MetadataScope>
+  </mdb:metadataScope>
+  <mdb:contact>
+    <cit:CI_Responsibility>
+      <cit:role>
+        <cit:CI_RoleCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</cit:CI_RoleCode>
+      </cit:role>
+      <cit:party>
+        <che:CHE_CI_Organisation gco:isoType="cit:CI_Organisation">
+          <cit:name xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Service des forêts et de la nature</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">Service des forêts et de la nature</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Amt für Wald und Natur</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </cit:name>
+          <cit:contactInfo>
+            <cit:CI_Contact>
+              <cit:phone>
+                <cit:CI_Telephone>
+                  <cit:number>
+                    <gco:CharacterString>026 / 305 23 43</gco:CharacterString>
+                  </cit:number>
+                  <cit:numberType>
+                    <cit:CI_TelephoneTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_TelephoneTypeCode" codeListValue="voice">voice</cit:CI_TelephoneTypeCode>
+                  </cit:numberType>
+                </cit:CI_Telephone>
+              </cit:phone>
+              <cit:address>
+                <cit:CI_Address>
+                  <cit:deliveryPoint>
+                    <gco:CharacterString>Route du Mont Carmel 5</gco:CharacterString>
+                  </cit:deliveryPoint>
+                  <cit:city>
+                    <gco:CharacterString>Givisiez</gco:CharacterString>
+                  </cit:city>
+                  <cit:postalCode>
+                    <gco:CharacterString>1762</gco:CharacterString>
+                  </cit:postalCode>
+                  <cit:electronicMailAddress>
+                    <gco:CharacterString>sfn@fr.ch</gco:CharacterString>
+                  </cit:electronicMailAddress>
+                </cit:CI_Address>
+              </cit:address>
+              <cit:onlineResource>
+                <cit:CI_OnlineResource>
+                  <cit:linkage xsi:type="lan:PT_FreeText_PropertyType">
+                    <gco:CharacterString>http://www.fr.ch/sfn</gco:CharacterString>
+                    <lan:PT_FreeText>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#FR">http://www.fr.ch/sfn</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#DE">https://www.fr.ch/de/ilfd/wna</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                    </lan:PT_FreeText>
+                  </cit:linkage>
+                  <cit:protocol>
+                    <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                  </cit:protocol>
+                </cit:CI_OnlineResource>
+              </cit:onlineResource>
+            </cit:CI_Contact>
+          </cit:contactInfo>
+          <cit:individual>
+            <cit:CI_Individual>
+              <cit:name>
+                <gco:CharacterString>Michel Spicher</gco:CharacterString>
+              </cit:name>
+            </cit:CI_Individual>
+          </cit:individual>
+          <che:organisationAcronym xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>SFN</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">SFN</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">WNA</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </che:organisationAcronym>
+        </che:CHE_CI_Organisation>
+      </cit:party>
+    </cit:CI_Responsibility>
+  </mdb:contact>
+  <mdb:dateInfo>
+    <cit:CI_Date>
+      <cit:date>
+        <gco:DateTime>2024-08-28T12:30:08.7Z</gco:DateTime>
+      </cit:date>
+      <cit:dateType>
+        <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="revision">revision</cit:CI_DateTypeCode>
+      </cit:dateType>
+    </cit:CI_Date>
+  </mdb:dateInfo>
+  <mdb:metadataStandard>
+    <cit:CI_Citation>
+      <cit:title>
+        <gco:CharacterString>GM03 2+</gco:CharacterString>
+      </cit:title>
+      <cit:edition />
+    </cit:CI_Citation>
+  </mdb:metadataStandard>
+  <mdb:otherLocale>
+    <lan:PT_Locale id="DE">
+      <lan:language>
+        <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="ger">ger</lan:LanguageCode>
+      </lan:language>
+      <lan:characterEncoding>
+        <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
+      </lan:characterEncoding>
+    </lan:PT_Locale>
+  </mdb:otherLocale>
+  <mdb:otherLocale>
+    <lan:PT_Locale id="IT">
+      <lan:language>
+        <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="ita">ita</lan:LanguageCode>
+      </lan:language>
+      <lan:characterEncoding>
+        <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
+      </lan:characterEncoding>
+    </lan:PT_Locale>
+  </mdb:otherLocale>
+  <mdb:otherLocale>
+    <lan:PT_Locale id="EN">
+      <lan:language>
+        <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="eng">eng</lan:LanguageCode>
+      </lan:language>
+      <lan:characterEncoding>
+        <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
+      </lan:characterEncoding>
+    </lan:PT_Locale>
+  </mdb:otherLocale>
+  <mdb:spatialRepresentationInfo>
+    <msr:MD_VectorSpatialRepresentation>
+      <msr:geometricObjects>
+        <msr:MD_GeometricObjects>
+          <msr:geometricObjectType>
+            <msr:MD_GeometricObjectTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="surface" />
+          </msr:geometricObjectType>
+        </msr:MD_GeometricObjects>
+      </msr:geometricObjects>
+      <msr:geometricObjects>
+        <msr:MD_GeometricObjects>
+          <msr:geometricObjectType>
+            <msr:MD_GeometricObjectTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="point" />
+          </msr:geometricObjectType>
+        </msr:MD_GeometricObjects>
+      </msr:geometricObjects>
+    </msr:MD_VectorSpatialRepresentation>
+  </mdb:spatialRepresentationInfo>
+  <mdb:referenceSystemInfo>
+    <mrs:MD_ReferenceSystem>
+      <mrs:referenceSystemIdentifier>
+        <mcc:MD_Identifier>
+          <mcc:code xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>CH1903+/MN95, Système de coordonnées nationales (EPSG:2056)</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">CH1903+/MN95, Système de coordonnées nationales (EPSG:2056)</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mcc:code>
+        </mcc:MD_Identifier>
+      </mrs:referenceSystemIdentifier>
+    </mrs:MD_ReferenceSystem>
+  </mdb:referenceSystemInfo>
+  <mdb:identificationInfo>
+    <che:CHE_MD_DataIdentification gco:isoType="mri:MD_DataIdentification">
+      <mri:citation>
+        <cit:CI_Citation>
+          <cit:title xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Forfaits en forêt protectrice</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">Forfaits en forêt protectrice</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </cit:title>
+          <cit:date>
+            <cit:CI_Date>
+              <cit:date>
+                <gco:Date>2023-08-25</gco:Date>
+              </cit:date>
+              <cit:dateType>
+                <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="creation">creation</cit:CI_DateTypeCode>
+              </cit:dateType>
+            </cit:CI_Date>
+          </cit:date>
+          <cit:presentationForm>
+            <cit:CI_PresentationFormCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_PresentationFormCode" codeListValue="mapDigital" />
+          </cit:presentationForm>
+        </cit:CI_Citation>
+      </mri:citation>
+      <mri:abstract xsi:type="lan:PT_FreeText_PropertyType">
+        <gco:CharacterString>Cette géodonnée fournit une estimation du montant forfaitaire de subvention qu'il est possible d'obtenir dans le cadre de traitements sylvicoles en forêt protectrice. Les forfaits propres à chacune des méthodes de débardage reconnues sont calculé sur la base de la carte des peuplements (SFF1500S_PEUPLEMENTS). Ainsi, lors de la planification pluriannuelle des programmes d'interventions, les forestiers de triage sont en mesure d'estimer le montant de subvention qu'il pourront percevoir.
+Les forfaits sont définis selon la directive 1301.1 du Service des forêts et de la nature (SFN) de l'Etat de Fribourg.</gco:CharacterString>
+        <lan:PT_FreeText>
+          <lan:textGroup>
+            <lan:LocalisedCharacterString locale="#FR">Cette géodonnée fournit une estimation du montant forfaitaire de subvention qu'il est possible d'obtenir dans le cadre de traitements sylvicoles en forêt protectrice. Les forfaits propres à chacune des méthodes de débardage reconnues sont calculé sur la base de la carte des peuplements (SFF1500S_PEUPLEMENTS). Ainsi, lors de la planification pluriannuelle des programmes d'interventions, les forestiers de triage sont en mesure d'estimer le montant de subvention qu'il pourront percevoir.
+Les forfaits sont définis selon la directive 1301.1 du Service des forêts et de la nature (SFN) de l'Etat de Fribourg.</lan:LocalisedCharacterString>
+          </lan:textGroup>
+        </lan:PT_FreeText>
+      </mri:abstract>
+      <mri:status>
+        <mcc:MD_ProgressCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ProgressCode" codeListValue="onGoing">onGoing</mcc:MD_ProgressCode>
+      </mri:status>
+      <mri:pointOfContact>
+        <cit:CI_Responsibility>
+          <cit:role>
+            <cit:CI_RoleCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</cit:CI_RoleCode>
+          </cit:role>
+          <cit:party>
+            <che:CHE_CI_Organisation gco:isoType="cit:CI_Organisation">
+              <cit:name xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>Service des forêts et de la nature</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">Service des forêts et de la nature</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">Amt für Wald und Natur</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:name>
+              <cit:contactInfo>
+                <cit:CI_Contact>
+                  <cit:phone>
+                    <cit:CI_Telephone>
+                      <cit:number>
+                        <gco:CharacterString>026 / 305 23 43</gco:CharacterString>
+                      </cit:number>
+                      <cit:numberType>
+                        <cit:CI_TelephoneTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_TelephoneTypeCode" codeListValue="voice">voice</cit:CI_TelephoneTypeCode>
+                      </cit:numberType>
+                    </cit:CI_Telephone>
+                  </cit:phone>
+                  <cit:address>
+                    <cit:CI_Address>
+                      <cit:deliveryPoint>
+                        <gco:CharacterString>Route du Mont Carmel 5</gco:CharacterString>
+                      </cit:deliveryPoint>
+                      <cit:city>
+                        <gco:CharacterString>Givisiez</gco:CharacterString>
+                      </cit:city>
+                      <cit:postalCode>
+                        <gco:CharacterString>1762</gco:CharacterString>
+                      </cit:postalCode>
+                      <cit:electronicMailAddress>
+                        <gco:CharacterString>sfn@fr.ch</gco:CharacterString>
+                      </cit:electronicMailAddress>
+                    </cit:CI_Address>
+                  </cit:address>
+                  <cit:onlineResource>
+                    <cit:CI_OnlineResource>
+                      <cit:linkage xsi:type="lan:PT_FreeText_PropertyType">
+                        <gco:CharacterString>http://www.fr.ch/sfn</gco:CharacterString>
+                        <lan:PT_FreeText>
+                          <lan:textGroup>
+                            <lan:LocalisedCharacterString locale="#FR">http://www.fr.ch/sfn</lan:LocalisedCharacterString>
+                          </lan:textGroup>
+                          <lan:textGroup>
+                            <lan:LocalisedCharacterString locale="#DE">https://www.fr.ch/de/ilfd/wna</lan:LocalisedCharacterString>
+                          </lan:textGroup>
+                        </lan:PT_FreeText>
+                      </cit:linkage>
+                      <cit:protocol>
+                        <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                      </cit:protocol>
+                    </cit:CI_OnlineResource>
+                  </cit:onlineResource>
+                </cit:CI_Contact>
+              </cit:contactInfo>
+              <cit:individual>
+                <cit:CI_Individual>
+                  <cit:name>
+                    <gco:CharacterString>Michel Spicher</gco:CharacterString>
+                  </cit:name>
+                </cit:CI_Individual>
+              </cit:individual>
+              <che:organisationAcronym xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>SFN</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">SFN</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">WNA</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </che:organisationAcronym>
+            </che:CHE_CI_Organisation>
+          </cit:party>
+        </cit:CI_Responsibility>
+      </mri:pointOfContact>
+      <mri:spatialRepresentationType>
+        <mcc:MD_SpatialRepresentationTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_SpatialRepresentationTypeCode" codeListValue="vector">vector</mcc:MD_SpatialRepresentationTypeCode>
+      </mri:spatialRepresentationType>
+      <mri:spatialResolution>
+        <mri:MD_Resolution>
+          <mri:equivalentScale>
+            <mri:MD_RepresentativeFraction>
+              <mri:denominator>
+                <gco:Integer>100000</gco:Integer>
+              </mri:denominator>
+            </mri:MD_RepresentativeFraction>
+          </mri:equivalentScale>
+        </mri:MD_Resolution>
+      </mri:spatialResolution>
+      <mri:topicCategory>
+        <mri:MD_TopicCategoryCode>biota</mri:MD_TopicCategoryCode>
+      </mri:topicCategory>
+      <mri:topicCategory>
+        <mri:MD_TopicCategoryCode>geoscientificInformation</mri:MD_TopicCategoryCode>
+      </mri:topicCategory>
+      <mri:topicCategory>
+        <mri:MD_TopicCategoryCode>environment</mri:MD_TopicCategoryCode>
+      </mri:topicCategory>
+      <mri:extent>
+        <gex:EX_Extent>
+          <gex:description xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Canton de Fribourg (FR)</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">Canton de Fribourg (FR)</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Kanton Freiburg (FR)</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">Cantone di Friburgo (FR)</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">Canton of Fribourg (FR)</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </gex:description>
+          <gex:geographicElement>
+            <gex:EX_GeographicBoundingBox>
+              <gex:westBoundLongitude>
+                <gco:Decimal>6.742307</gco:Decimal>
+              </gex:westBoundLongitude>
+              <gex:eastBoundLongitude>
+                <gco:Decimal>7.380268</gco:Decimal>
+              </gex:eastBoundLongitude>
+              <gex:southBoundLatitude>
+                <gco:Decimal>46.438047</gco:Decimal>
+              </gex:southBoundLatitude>
+              <gex:northBoundLatitude>
+                <gco:Decimal>47.006881</gco:Decimal>
+              </gex:northBoundLatitude>
+            </gex:EX_GeographicBoundingBox>
+          </gex:geographicElement>
+          <gex:geographicElement>
+            <gex:EX_BoundingPolygon>
+              <gex:polygon>
+                <gml:MultiSurface gml:id="d14680479e77" srsDimension="2">
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="d14680479e79">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>6.7730657 46.7514186 6.7761526 46.7494396 6.7786819 46.7512984 6.7862383 46.7476716 6.7844497 46.7354721 6.7774959 46.7295847 6.7774076 46.7261208 6.770738 46.7206844 6.7624999 46.7173523 6.7586221 46.7219891 6.7590792 46.7251493 6.7517271 46.7282447 6.7486202 46.7318063 6.7526151 46.7365892 6.7590313 46.7372394 6.7681791 46.7444542 6.7730657 46.7514186</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="d14680479e85">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>6.8577401 46.7627038 6.8592496 46.7611102 6.8638491 46.7631036 6.8677943 46.7601818 6.8769761 46.7558646 6.8757274 46.7538614 6.8820782 46.7497816 6.8664207 46.733026 6.8655342 46.7290454 6.867935 46.7284098 6.8618011 46.7245917 6.8463591 46.727517 6.8384408 46.7325401 6.8283343 46.735401 6.8173562 46.7331916 6.8113339 46.7279141 6.8062033 46.7270041 6.7929817 46.7255535 6.7884657 46.7279567 6.7936318 46.7357134 6.7965155 46.7363774 6.7980484 46.7340022 6.803992 46.737031 6.8061178 46.7353967 6.8121023 46.7372019 6.8165358 46.7385126 6.8150604 46.7405016 6.8304676 46.7538716 6.8290849 46.7557713 6.844425 46.7652618 6.848864 46.7711321 6.8462574 46.7712355 6.8490402 46.7753609 6.8601606 46.7664763 6.8577401 46.7627038</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="d14680479e91">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>6.8917181 46.8867769 6.9036657 46.8794212 6.9053359 46.8803286 6.9069534 46.878618 6.9108692 46.8806332 6.9210084 46.8713153 6.9114884 46.8670169 6.9094052 46.869454 6.8918749 46.8649546 6.8962781 46.8614134 6.912811 46.8658896 6.9301326 46.8538691 6.9193532 46.8471729 6.9109896 46.8390385 6.9052002 46.827672 6.9108043 46.8125458 6.9049291 46.8064734 6.9073419 46.8049284 6.9113289 46.8031758 6.9195776 46.8103911 6.9233946 46.8085734 6.9277403 46.8090067 6.9314424 46.805443 6.9261322 46.7990324 6.9211772 46.7966712 6.916608 46.7869981 6.9159355 46.7834237 6.9109948 46.7798027 6.9083012 46.7820571 6.9098061 46.7834944 6.9064815 46.783326 6.9050454 46.7815651 6.8991915 46.7816095 6.8998873 46.7801195 6.8949877 46.7790438 6.8941939 46.7772589 6.8881992 46.7783095 6.8796004 46.7753891 6.8638005 46.7811306 6.8618532 46.7832078 6.8639752 46.7843879 6.8591559 46.7880337 6.8515098 46.7858797 6.848553 46.7809573 6.8431112 46.7786855 6.8400105 46.7808012 6.8331922 46.7746122 6.8274837 46.7768936 6.8254052 46.7731492 6.8187541 46.777674 6.8131639 46.7793237 6.8045965 46.7856742 6.7980562 46.782822 6.7825333 46.7928719 6.7759709 46.7897034 6.7790334 46.7941561 6.7873115 46.7995651 6.7840849 46.8031359 6.7788632 46.80056 6.7768608 46.8025365 6.7673365 46.8088587 6.7423068 46.8274557 6.780046 46.8526428 6.8658995 46.9095048 6.8917181 46.8867769</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="d14680479e97">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>7.234894 46.933018 7.234619 46.9294277 7.2306397 46.9295735 7.2186332 46.9243786 7.2167024 46.9277121 7.217429 46.9330117 7.2293115 46.9368032 7.2281874 46.9387801 7.2301661 46.9399171 7.2353083 46.9380554 7.234894 46.933018</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="d14680479e103">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>7.2130334 47.0068805 7.2154325 47.005491 7.2172548 47.0068078 7.223299 46.9981931 7.225859 46.9991424 7.2267364 46.9967243 7.2236191 46.9937951 7.234926 46.9866827 7.2355113 46.9848667 7.2297037 46.9809253 7.2212987 46.9760162 7.2225399 46.9745794 7.2147211 46.97129 7.2142925 46.9669625 7.2075616 46.9677047 7.2067373 46.9638531 7.1954245 46.9638205 7.1971589 46.9609008 7.2065938 46.9605965 7.2110514 46.9566476 7.2077999 46.9490221 7.209628 46.9485041 7.2097557 46.9432242 7.203709 46.9383724 7.2116188 46.9313092 7.2111116 46.9270624 7.211159 46.9251915 7.2062903 46.924606 7.2054626 46.9217168 7.2078796 46.9092633 7.1879704 46.900244 7.1954173 46.8989828 7.2000348 46.9023568 7.208236 46.9026975 7.212466 46.9017615 7.2174443 46.8975435 7.2230012 46.9026185 7.2303846 46.9040624 7.2325291 46.8993078 7.2369039 46.8980563 7.243138 46.8979143 7.244049 46.9000118 7.2568111 46.8982788 7.2810098 46.8895535 7.290156 46.8940005 7.3074415 46.8925375 7.3256121 46.8940143 7.3494109 46.8890702 7.3535618 46.8861589 7.3530456 46.8726566 7.3573781 46.8701411 7.3588972 46.8629549 7.3511086 46.8541248 7.3381621 46.8495444 7.3342624 46.8524464 7.325741 46.8517635 7.3228759 46.854864 7.330646 46.8576603 7.3236101 46.8609906 7.3173819 46.8605343 7.3164068 46.8625662 7.3126999 46.8606732 7.312043 46.8556351 7.302165 46.8520705 7.3081445 46.8465274 7.3226182 46.8407141 7.3309094 46.8335383 7.3283912 46.8287831 7.3196774 46.8250142 7.3214173 46.8204554 7.3188033 46.8173942 7.320904 46.8155074 7.3114838 46.8096502 7.3057522 46.7963305 7.3020384 46.7939243 7.3029284 46.7890049 7.3015874 46.7858908 7.3042136 46.7831054 7.2904916 46.7730134 7.2951984 46.7657152 7.3007283 46.7635811 7.3043747 46.7502363 7.2962961 46.7368862 7.2984771 46.7234587 7.3077797 46.717173 7.3267978 46.7167076 7.3488434 46.7122835 7.3489988 46.7054291 7.3452442 46.6989133 7.3597977 46.6980159 7.3626069 46.6992772 7.3686039 46.6926514 7.3769446 46.6926653 7.3802679 46.6901843 7.375996 46.6877892 7.3777655 46.6835713 7.3729335 46.6801233 7.3757237 46.6748355 7.3715876 46.6694628 7.3684963 46.655257 7.3758508 46.6557561 7.3587801 46.644177 7.3557576 46.6391823 7.3548184 46.6467469 7.3491072 46.6486046 7.349638 46.6514566 7.3446415 46.6550237 7.322106 46.6550027 7.3297494 46.6417059 7.3222885 46.6371558 7.3132525 46.6365794 7.3121253 46.6216905 7.317838 46.6185033 7.3182874 46.616057 7.3148511 46.600356 7.3207562 46.5916546 7.3125283 46.589145 7.3080457 46.5813227 7.2986972 46.5791526 7.2817998 46.5846897 7.2680181 46.5735781 7.2597688 46.5634004 7.2457626 46.555866 7.2370204 46.5537998 7.2232878 46.5477294 7.207328 46.5327922 7.2008237 46.5416574 7.1921706 46.5466224 7.1827558 46.5386944 7.1710789 46.5327483 7.1591025 46.52725 7.1483824 46.5284914 7.144717 46.5266378 7.1357365 46.508191 7.1264107 46.5032001 7.1242057 46.4993078 7.1103337 46.4948066 7.1003921 46.4869781 7.097973 46.4885181 7.0888145 46.4869159 7.0776926 46.488815 7.0724993 46.4863965 7.0658651 46.4890376 7.0610977 46.4872586 7.0278736 46.4667677 7.0202488 46.4594802 7.0168398 46.4476201 6.9928224 46.4388831 6.9839551 46.4380472 6.9920904 46.4487396 6.9896614 46.452868 6.9798724 46.4591618 6.9778914 46.4731872 6.9804302 46.4747537 6.9736832 46.4810593 6.9733499 46.4895135 6.962045 46.4968794 6.9504403 46.5024614 6.9337734 46.5015787 6.9302274 46.5046215 6.9268393 46.5046962 6.9247259 46.5077452 6.9147982 46.5103985 6.9119587 46.5129851 6.9013508 46.5131242 6.8960785 46.5074407 6.8977079 46.5203755 6.8833006 46.513451 6.8815636 46.5125789 6.8663136 46.5007364 6.8627654 46.4938456 6.8581869 46.4932465 6.847801 46.4936696 6.8454625 46.496671 6.8419983 46.4965989 6.8367619 46.5000976 6.832759 46.5050689 6.8301104 46.5123504 6.8244315 46.5121579 6.8178923 46.5165392 6.8107939 46.5252082 6.8122175 46.5260707 6.8254328 46.543343 6.827553 46.5426258 6.8251805 46.5380071 6.8324614 46.5374165 6.854789 46.5413209 6.8565303 46.5370118 6.8594096 46.5359471 6.8584151 46.531444 6.8611745 46.5305945 6.8665311 46.5404901 6.868342 46.5418396 6.8879941 46.5579492 6.8913919 46.557246 6.8934323 46.5592349 6.9024633 46.5612031 6.8987722 46.5651437 6.9016486 46.5696912 6.897974 46.5706183 6.888143 46.5676474 6.8845103 46.5619444 6.8794225 46.567119 6.8744626 46.5649625 6.8718062 46.5695191 6.8655286 46.577224 6.8526918 46.5820162 6.8514236 46.5810651 6.8471571 46.5834718 6.8427725 46.5823604 6.8347618 46.5753553 6.8287276 46.5771582 6.8237281 46.5774191 6.8205642 46.583708 6.814123 46.5856068 6.8117013 46.5806727 6.8130336 46.5782872 6.8048709 46.5779361 6.7993199 46.5740817 6.7951059 46.5752184 6.7991686 46.5835535 6.8013099 46.5922555 6.7982958 46.59993 6.8019276 46.6007331 6.8034663 46.6219179 6.8022748 46.6277316 6.796883 46.6331257 6.8034861 46.6446325 6.7988204 46.6492482 6.8112045 46.6503427 6.8145694 46.6474286 6.8184674 46.6481067 6.8172524 46.6492515 6.8279698 46.6602844 6.8313358 46.6595648 6.8334476 46.6623198 6.8384225 46.662616 6.8440732 46.6608826 6.8421755 46.6588126 6.853552 46.6555163 6.8594751 46.6599275 6.8649021 46.6582549 6.8680243 46.6607534 6.8683144 46.6629768 6.8644019 46.6647293 6.8718502 46.6734026 6.8647094 46.6763443 6.8627908 46.6809944 6.8654804 46.6812689 6.8665826 46.6845669 6.868557 46.6857373 6.8731053 46.6833221 6.8811529 46.6900457 6.8837298 46.6898963 6.8879449 46.6944597 6.8896103 46.693973 6.8934729 46.6998567 6.8923864 46.7025592 6.8980677 46.7084336 6.9045234 46.7141583 6.9160169 46.719825 6.917081 46.7179947 6.9204445 46.7218603 6.9221419 46.7235502 6.9342888 46.7324833 6.9356687 46.7332271 6.9360312 46.7378345 6.9412514 46.7449729 6.9372188 46.7493991 6.9302262 46.7539828 6.9205681 46.7511506 6.9168731 46.7542822 6.9146323 46.7532195 6.9118697 46.754655 6.9105617 46.7532366 6.9081894 46.7575525 6.9143686 46.7628166 6.920024 46.7600718 6.9287767 46.7674428 6.9354155 46.7714933 6.9312163 46.7725002 6.9330551 46.7746763 6.9315301 46.7753262 6.938831 46.7815295 6.9456524 46.7845097 6.9500821 46.7826937 6.9586575 46.7902595 6.9564555 46.7904481 6.9560228 46.7934148 6.966682 46.8026529 6.957854 46.8112697 6.9593653 46.8122296 6.9565238 46.8149522 6.9616308 46.8182661 6.958665 46.8202146 6.9656064 46.8281057 6.9717863 46.8242991 6.9851592 46.8221132 6.9924144 46.8305886 6.9923659 46.8332691 6.9860213 46.8348903 6.987024 46.8372331 6.9828983 46.8399063 6.9860052 46.8401773 6.9885664 46.8435638 6.9845 46.8466752 6.9813991 46.8458453 6.9774771 46.8501655 6.9805181 46.8580321 6.9770246 46.8606124 6.9801135 46.8662956 6.9890579 46.8733964 6.986155 46.8762721 6.9736911 46.8873651 6.9661295 46.8833491 6.9622124 46.8841784 6.958052 46.8813993 6.9698917 46.8671998 6.9651224 46.8651561 6.9599781 46.8713865 6.9572812 46.8708084 6.954 46.8753912 6.9516729 46.8745178 6.9511432 46.8779518 6.9419029 46.8841458 6.9386246 46.8896007 6.9360987 46.8888969 6.9331787 46.8924373 6.9259599 46.892612 6.9239013 46.8951844 6.9297645 46.8996184 6.9220451 46.9053409 6.8962094 46.9253259 6.9279018 46.9531746 6.9614044 46.9278117 6.9719822 46.920911 6.9781183 46.9234006 6.9861429 46.9200055 6.9875233 46.9182209 6.9819304 46.91362 6.9845302 46.9120022 6.9812444 46.9093984 6.9841717 46.9078359 7.0094842 46.8890436 6.9948645 46.8782387 6.9996184 46.8744604 7.0077733 46.8733491 7.013316 46.8774089 7.0156395 46.8772106 7.0163848 46.8808475 7.0216419 46.8762612 7.0251053 46.877938 7.0353833 46.873603 7.0299308 46.8661534 7.0396777 46.8605927 7.0332235 46.8573856 7.0340647 46.8553916 7.0299537 46.8528132 7.0318665 46.8478366 7.0331708 46.8487408 7.0373774 46.8456279 7.0395569 46.8482338 7.0429139 46.8469212 7.0502123 46.8546202 7.0539629 46.856387 7.0625691 46.8670483 7.0666628 46.8687169 7.0706695 46.8735334 7.0692195 46.8764702 7.0646676 46.8783444 7.0669996 46.8787838 7.0662126 46.8806523 7.0616933 46.8796929 7.0619795 46.8837777 7.0798186 46.8941529 7.0746348 46.8942265 7.0745998 46.8955127 7.0833094 46.8960889 7.0889154 46.8997223 7.0867112 46.9016316 7.0912665 46.9034626 7.0931493 46.9066077 7.0900838 46.9077317 7.0842069 46.9131738 7.0598092 46.9365552 7.0579168 46.9385819 7.061383 46.9424523 7.0596626 46.9517028 7.0564713 46.9552633 7.0596071 46.9558314 7.0580549 46.9653612 7.0608727 46.9663871 7.0631907 46.9712431 7.0518468 46.9771152 7.0935408 46.9762592 7.1381056 46.9834644 7.1465624 46.9849346 7.1537453 46.986266 7.1605215 46.9875241 7.1710708 46.9913992 7.1788664 46.9941158 7.1872525 46.9972199 7.1967051 47.0002267 7.1963818 47.0019441 7.1997752 47.0017083 7.2049617 47.0063426 7.2102974 47.0039876 7.2130334 47.0068805</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                      <gml:interior>
+                        <gml:LinearRing>
+                          <gml:posList>7.1348812 46.9193828 7.1266875 46.9173817 7.1252473 46.9189699 7.114829 46.9158555 7.1132329 46.9106336 7.1187761 46.905585 7.1186242 46.9024632 7.1195936 46.9005499 7.1230079 46.9001996 7.1284523 46.905072 7.1387243 46.9082838 7.1348812 46.9193828</gml:posList>
+                        </gml:LinearRing>
+                      </gml:interior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                </gml:MultiSurface>
+              </gex:polygon>
+            </gex:EX_BoundingPolygon>
+          </gex:geographicElement>
+        </gex:EX_Extent>
+      </mri:extent>
+      <mri:resourceMaintenance>
+        <che:CHE_MD_MaintenanceInformation gco:isoType="mmi:MD_MaintenanceInformation">
+          <mmi:maintenanceAndUpdateFrequency>
+            <mmi:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="annually" />
+          </mmi:maintenanceAndUpdateFrequency>
+        </che:CHE_MD_MaintenanceInformation>
+      </mri:resourceMaintenance>
+      <mri:resourceFormat>
+        <mrd:MD_Format>
+          <mrd:formatSpecificationCitation>
+            <cit:CI_Citation>
+              <cit:title>
+                <gco:CharacterString>ESRI Enterprise Geodatabase</gco:CharacterString>
+              </cit:title>
+              <cit:date gco:nilReason="unknown" />
+              <cit:edition gco:nilReason="unknown" />
+            </cit:CI_Citation>
+          </mrd:formatSpecificationCitation>
+        </mrd:MD_Format>
+      </mri:resourceFormat>
+      <mri:descriptiveKeywords>
+        <mri:MD_Keywords>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>forêt</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">forêt</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Forst</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">foresta</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">forest</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>planification</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">planification</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Planung</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">pianificazione</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">planning</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>sylviculture</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">sylviculture</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Forstwirtschaft</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">forestazione</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">forestry</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>surveillance</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">surveillance</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Monitoring</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">monitoraggio</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">monitoring</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>analyse</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">analyse</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Untersuchung</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">saggio</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">assay</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:type>
+            <mri:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </mri:type>
+          <mri:thesaurusName>
+            <cit:CI_Citation>
+              <cit:title>
+                <gco:CharacterString>GEMET</gco:CharacterString>
+              </cit:title>
+              <cit:date>
+                <cit:CI_Date>
+                  <cit:date>
+                    <gco:Date>2018-08-16</gco:Date>
+                  </cit:date>
+                  <cit:dateType>
+                    <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="publication">publication</cit:CI_DateTypeCode>
+                  </cit:dateType>
+                </cit:CI_Date>
+              </cit:date>
+              <cit:identifier>
+                <mcc:MD_Identifier>
+                  <mcc:code>
+                    <gcx:Anchor xlink:href="https://www.geocat.ch/geonetwork/srv/api/registries/vocabularies/external.theme.gemet">geonetwork.thesaurus.external.theme.gemet</gcx:Anchor>
+                  </mcc:code>
+                </mcc:MD_Identifier>
+              </cit:identifier>
+            </cit:CI_Citation>
+          </mri:thesaurusName>
+        </mri:MD_Keywords>
+      </mri:descriptiveKeywords>
+      <mri:resourceConstraints>
+        <che:CHE_MD_LegalConstraints gco:isoType="mco:MD_LegalConstraints">
+          <mco:otherConstraints xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Propriété de l'Etat de Fribourg, statut interne</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">Propriété de l'Etat de Fribourg, statut interne</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mco:otherConstraints>
+        </che:CHE_MD_LegalConstraints>
+      </mri:resourceConstraints>
+      <mri:defaultLocale>
+        <lan:PT_Locale>
+          <lan:language>
+            <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="fre">fre</lan:LanguageCode>
+          </lan:language>
+          <lan:characterEncoding>
+            <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
+          </lan:characterEncoding>
+        </lan:PT_Locale>
+      </mri:defaultLocale>
+      <mri:environmentDescription xsi:type="lan:PT_FreeText_PropertyType">
+        <gco:CharacterString>SDE: SFF1825S_FORFAITS_FP</gco:CharacterString>
+        <lan:PT_FreeText>
+          <lan:textGroup>
+            <lan:LocalisedCharacterString locale="#FR">SDE: SFF1825S_FORFAITS_FP</lan:LocalisedCharacterString>
+          </lan:textGroup>
+        </lan:PT_FreeText>
+      </mri:environmentDescription>
+      <che:subTopicCategory>
+        <che:CHE_MD_SubTopicCategoryCode codeList="subTopicCategory" codeListValue="geoscientificInformation_NaturalHazards" />
+      </che:subTopicCategory>
+      <che:subTopicCategory>
+        <che:CHE_MD_SubTopicCategoryCode codeList="subTopicCategory" codeListValue="environment_NatureProtection" />
+      </che:subTopicCategory>
+    </che:CHE_MD_DataIdentification>
+  </mdb:identificationInfo>
+  <mdb:contentInfo>
+    <mrc:MD_FeatureCatalogueDescription>
+      <mrc:includedWithDataset>
+        <gco:Boolean>true</gco:Boolean>
+      </mrc:includedWithDataset>
+      <mrc:featureCatalogueCitation>
+        <cit:CI_Citation>
+          <cit:title xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Forfaits à l'ha des subventions FP-S - Polygones</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">Forfaits à l'ha des subventions FP-S - Polygones</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </cit:title>
+          <cit:date>
+            <cit:CI_Date>
+              <cit:date>
+                <gco:Date>2024-08-28</gco:Date>
+              </cit:date>
+              <cit:dateType>
+                <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="creation">creation</cit:CI_DateTypeCode>
+              </cit:dateType>
+            </cit:CI_Date>
+          </cit:date>
+        </cit:CI_Citation>
+      </mrc:featureCatalogueCitation>
+      <mrc:featureCatalogueCitation>
+        <cit:CI_Citation>
+          <cit:title xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Monitoring des forêts protectrices - Point</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">Monitoring des forêts protectrices - Point</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </cit:title>
+          <cit:date>
+            <cit:CI_Date>
+              <cit:date>
+                <gco:Date>2024-08-28</gco:Date>
+              </cit:date>
+              <cit:dateType>
+                <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="creation">creation</cit:CI_DateTypeCode>
+              </cit:dateType>
+            </cit:CI_Date>
+          </cit:date>
+        </cit:CI_Citation>
+      </mrc:featureCatalogueCitation>
+      <mrc:featureCatalogueCitation />
+    </mrc:MD_FeatureCatalogueDescription>
+  </mdb:contentInfo>
+  <mdb:contentInfo>
+    <mrc:MD_FeatureCatalogue>
+      <mrc:featureCatalogue>
+        <gfc:FC_FeatureCatalogue>
+          <cat:name>
+            <gco:CharacterString>Forfaits à l'ha des subventions FP-S - Polygones Monitoring des forêts protectrices - Point</gco:CharacterString>
+          </cat:name>
+          <cat:scope gco:nilReason="missing" />
+          <cat:versionNumber gco:nilReason="missing" />
+          <cat:versionDate>
+            <gco:Date>2024-08-282024-08-28</gco:Date>
+          </cat:versionDate>
+          <gfc:producer gco:nilReason="missing" />
+          <gfc:featureType>
+            <gfc:FC_FeatureType>
+              <gfc:typeName>SFF1825S_FORFAITS_FP</gfc:typeName>
+              <gfc:definition>
+                <gco:CharacterString>Entités polygones</gco:CharacterString>
+              </gfc:definition>
+              <gfc:isAbstract gco:nilReason="missing" />
+              <gfc:featureCatalogue gco:nilReason="missing" />
+            </gfc:FC_FeatureType>
+          </gfc:featureType>
+        </gfc:FC_FeatureCatalogue>
+      </mrc:featureCatalogue>
+    </mrc:MD_FeatureCatalogue>
+  </mdb:contentInfo>
+  <mdb:distributionInfo>
+    <mrd:MD_Distribution>
+      <mrd:distributionFormat>
+        <mrd:MD_Format>
+          <mrd:formatSpecificationCitation>
+            <cit:CI_Citation>
+              <cit:title>
+                <gco:CharacterString>ESRI Enterprise Geodatabase</gco:CharacterString>
+              </cit:title>
+              <cit:date gco:nilReason="unknown" />
+              <cit:edition gco:nilReason="unknown" />
+            </cit:CI_Citation>
+          </mrd:formatSpecificationCitation>
+        </mrd:MD_Format>
+      </mrd:distributionFormat>
+      <mrd:transferOptions>
+        <mrd:MD_DigitalTransferOptions>
+          <mrd:onLine>
+            <cit:CI_OnlineResource>
+              <cit:linkage xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>https://www.fr.ch/energie-agriculture-et-environnement/forets/section-foret-et-dangers-naturels</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">https://www.fr.ch/energie-agriculture-et-environnement/forets/section-foret-et-dangers-naturels</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:linkage>
+              <cit:name>
+                <gcx:MimeFileType type="" />
+              </cit:name>
+              <cit:description xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>Page d'accueil de la section forêt et dangers naturels</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">Page d'accueil de la section forêt et dangers naturels</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:description>
+              <cit:function>
+                <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" />
+              </cit:function>
+            </cit:CI_OnlineResource>
+          </mrd:onLine>
+        </mrd:MD_DigitalTransferOptions>
+      </mrd:transferOptions>
+      <mrd:transferOptions>
+        <mrd:MD_DigitalTransferOptions>
+          <mrd:onLine>
+            <cit:CI_OnlineResource>
+              <cit:linkage xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>https://www.geocat.ch/geonetwork/srv/api/records/be080b9d-bbac-40ce-bc69-cdd1e8d7ae50/attachments/Metadonnees_Forfaits_FP.xlsx</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">https://www.geocat.ch/geonetwork/srv/api/records/be080b9d-bbac-40ce-bc69-cdd1e8d7ae50/attachments/Metadonnees_Forfaits_FP.xlsx</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">https://www.geocat.ch/geonetwork/srv/api/records/be080b9d-bbac-40ce-bc69-cdd1e8d7ae50/attachments/Metadonnees_Forfaits_FP.xlsx</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#IT">https://www.geocat.ch/geonetwork/srv/api/records/be080b9d-bbac-40ce-bc69-cdd1e8d7ae50/attachments/Metadonnees_Forfaits_FP.xlsx</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN">https://www.geocat.ch/geonetwork/srv/api/records/be080b9d-bbac-40ce-bc69-cdd1e8d7ae50/attachments/Metadonnees_Forfaits_FP.xlsx</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:linkage>
+              <cit:protocol>
+                <gco:CharacterString>WWW:LINK</gco:CharacterString>
+              </cit:protocol>
+              <cit:name xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>Métadonnées Forfaits_FP</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">Métadonnées Forfaits_FP</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">Metadonnees_Forfaits_FP.xlsx</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#IT">Metadonnees_Forfaits_FP.xlsx</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN">Metadonnees_Forfaits_FP.xlsx</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:name>
+              <cit:description gco:nilReason="missing" xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString />
+              </cit:description>
+            </cit:CI_OnlineResource>
+          </mrd:onLine>
+        </mrd:MD_DigitalTransferOptions>
+      </mrd:transferOptions>
+    </mrd:MD_Distribution>
+  </mdb:distributionInfo>
+  <mdb:resourceLineage>
+    <mrl:LI_Lineage>
+      <mrl:statement xsi:type="lan:PT_FreeText_PropertyType">
+        <gco:CharacterString>Donnée estimative donnant le forfait de subvention théorique lors d'interventions en forêts protectrices. Ce forfait est calculé selon la directive 1301.1 du Service des forêts et de la nature (SFN) de l'Etat de Fribourg.</gco:CharacterString>
+        <lan:PT_FreeText>
+          <lan:textGroup>
+            <lan:LocalisedCharacterString locale="#FR">Donnée estimative donnant le forfait de subvention théorique lors d'interventions en forêts protectrices. Ce forfait est calculé selon la directive 1301.1 du Service des forêts et de la nature (SFN) de l'Etat de Fribourg.</lan:LocalisedCharacterString>
+          </lan:textGroup>
+        </lan:PT_FreeText>
+      </mrl:statement>
+      <mrl:scope>
+        <mcc:MD_Scope>
+          <mcc:level>
+            <mcc:MD_ScopeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode" codeListValue="dataset">dataset</mcc:MD_ScopeCode>
+          </mcc:level>
+        </mcc:MD_Scope>
+      </mrl:scope>
+    </mrl:LI_Lineage>
+  </mdb:resourceLineage>
+</che:CHE_MD_Metadata>

--- a/src/test/resources/featureCatalogueCitation-multilingual-title-19139.che.xml
+++ b/src/test/resources/featureCatalogueCitation-multilingual-title-19139.che.xml
@@ -1,0 +1,763 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<che:CHE_MD_Metadata xmlns:che="http://www.geocat.ch/2008/che" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" gco:isoType="gmd:MD_Metadata" xsi:schemaLocation="http://www.geocat.ch/2008/che https://www.geocat.ch/geonetwork/xml/schemas/iso19139.che/schema/che/che.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>be080b9d-bbac-40ce-bc69-cdd1e8d7ae50</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language>
+    <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+  </gmd:language>
+  <gmd:characterSet>
+    <gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" />
+  </gmd:characterSet>
+  <gmd:hierarchyLevel>
+    <gmd:MD_ScopeCode codeListValue="dataset" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" />
+  </gmd:hierarchyLevel>
+  <gmd:contact>
+    <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+      <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Service des forêts et de la nature</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Service des forêts et de la nature</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Amt für Wald und Natur</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:organisationName>
+      <gmd:contactInfo>
+        <gmd:CI_Contact>
+          <gmd:phone>
+            <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+              <che:directNumber>
+                <gco:CharacterString>026 / 305 23 43</gco:CharacterString>
+              </che:directNumber>
+            </che:CHE_CI_Telephone>
+          </gmd:phone>
+          <gmd:address>
+            <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+              <gmd:city>
+                <gco:CharacterString>Givisiez</gco:CharacterString>
+              </gmd:city>
+              <gmd:postalCode>
+                <gco:CharacterString>1762</gco:CharacterString>
+              </gmd:postalCode>
+              <gmd:electronicMailAddress>
+                <gco:CharacterString>sfn@fr.ch</gco:CharacterString>
+              </gmd:electronicMailAddress>
+              <che:streetName>
+                <gco:CharacterString>Route du Mont Carmel</gco:CharacterString>
+              </che:streetName>
+              <che:streetNumber>
+                <gco:CharacterString>5</gco:CharacterString>
+              </che:streetNumber>
+            </che:CHE_CI_Address>
+          </gmd:address>
+          <gmd:onlineResource>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <gmd:URL>http://www.fr.ch/sfn</gmd:URL>
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://www.fr.ch/sfn</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">https://www.fr.ch/de/ilfd/wna</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK</gco:CharacterString>
+              </gmd:protocol>
+            </gmd:CI_OnlineResource>
+          </gmd:onlineResource>
+        </gmd:CI_Contact>
+      </gmd:contactInfo>
+      <gmd:role>
+        <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="pointOfContact" />
+      </gmd:role>
+      <che:individualFirstName>
+        <gco:CharacterString>Michel</gco:CharacterString>
+      </che:individualFirstName>
+      <che:individualLastName>
+        <gco:CharacterString>Spicher</gco:CharacterString>
+      </che:individualLastName>
+      <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>SFN</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">SFN</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">WNA</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </che:organisationAcronym>
+    </che:CHE_CI_ResponsibleParty>
+  </gmd:contact>
+  <gmd:dateStamp>
+    <gco:DateTime>2024-08-28T12:30:08.7Z</gco:DateTime>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName>
+    <gco:CharacterString>GM03 2+</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:locale>
+    <gmd:PT_Locale id="DE">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="IT">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="EN">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="FR">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:spatialRepresentationInfo>
+    <gmd:MD_VectorSpatialRepresentation>
+      <gmd:geometricObjects>
+        <gmd:MD_GeometricObjects>
+          <gmd:geometricObjectType>
+            <gmd:MD_GeometricObjectTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="surface" />
+          </gmd:geometricObjectType>
+        </gmd:MD_GeometricObjects>
+      </gmd:geometricObjects>
+      <gmd:geometricObjects>
+        <gmd:MD_GeometricObjects>
+          <gmd:geometricObjectType>
+            <gmd:MD_GeometricObjectTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_GeometricObjectTypeCode" codeListValue="point" />
+          </gmd:geometricObjectType>
+        </gmd:MD_GeometricObjects>
+      </gmd:geometricObjects>
+    </gmd:MD_VectorSpatialRepresentation>
+  </gmd:spatialRepresentationInfo>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>CH1903+/MN95, Système de coordonnées nationales (EPSG:2056)</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">CH1903+/MN95, Système de coordonnées nationales (EPSG:2056)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:identificationInfo>
+    <che:CHE_MD_DataIdentification gco:isoType="gmd:MD_DataIdentification">
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Forfaits en forêt protectrice</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Forfaits en forêt protectrice</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2023-08-25</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeListValue="creation" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:presentationForm>
+            <gmd:CI_PresentationFormCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_PresentationFormCode" codeListValue="mapDigital" />
+          </gmd:presentationForm>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Cette géodonnée fournit une estimation du montant forfaitaire de subvention qu'il est possible d'obtenir dans le cadre de traitements sylvicoles en forêt protectrice. Les forfaits propres à chacune des méthodes de débardage reconnues sont calculé sur la base de la carte des peuplements (SFF1500S_PEUPLEMENTS). Ainsi, lors de la planification pluriannuelle des programmes d'interventions, les forestiers de triage sont en mesure d'estimer le montant de subvention qu'il pourront percevoir.
+Les forfaits sont définis selon la directive 1301.1 du Service des forêts et de la nature (SFN) de l'Etat de Fribourg.</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Cette géodonnée fournit une estimation du montant forfaitaire de subvention qu'il est possible d'obtenir dans le cadre de traitements sylvicoles en forêt protectrice. Les forfaits propres à chacune des méthodes de débardage reconnues sont calculé sur la base de la carte des peuplements (SFF1500S_PEUPLEMENTS). Ainsi, lors de la planification pluriannuelle des programmes d'interventions, les forestiers de triage sont en mesure d'estimer le montant de subvention qu'il pourront percevoir.
+Les forfaits sont définis selon la directive 1301.1 du Service des forêts et de la nature (SFN) de l'Etat de Fribourg.</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:abstract>
+      <gmd:status>
+        <gmd:MD_ProgressCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ProgressCode" codeListValue="onGoing" />
+      </gmd:status>
+      <gmd:pointOfContact>
+        <che:CHE_CI_ResponsibleParty gco:isoType="gmd:CI_ResponsibleParty">
+          <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Service des forêts et de la nature</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Service des forêts et de la nature</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Amt für Wald und Natur</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:organisationName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:phone>
+                <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+                  <che:directNumber>
+                    <gco:CharacterString>026 / 305 23 43</gco:CharacterString>
+                  </che:directNumber>
+                </che:CHE_CI_Telephone>
+              </gmd:phone>
+              <gmd:address>
+                <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+                  <gmd:city>
+                    <gco:CharacterString>Givisiez</gco:CharacterString>
+                  </gmd:city>
+                  <gmd:postalCode>
+                    <gco:CharacterString>1762</gco:CharacterString>
+                  </gmd:postalCode>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>sfn@fr.ch</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                  <che:streetName>
+                    <gco:CharacterString>Route du Mont Carmel</gco:CharacterString>
+                  </che:streetName>
+                  <che:streetNumber>
+                    <gco:CharacterString>5</gco:CharacterString>
+                  </che:streetNumber>
+                </che:CHE_CI_Address>
+              </gmd:address>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                    <gmd:URL>http://www.fr.ch/sfn</gmd:URL>
+                    <che:PT_FreeURL>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#FR">http://www.fr.ch/sfn</che:LocalisedURL>
+                      </che:URLGroup>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#DE">https://www.fr.ch/de/ilfd/wna</che:LocalisedURL>
+                      </che:URLGroup>
+                    </che:PT_FreeURL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                  </gmd:protocol>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="pointOfContact" />
+          </gmd:role>
+          <che:individualFirstName>
+            <gco:CharacterString>Michel</gco:CharacterString>
+          </che:individualFirstName>
+          <che:individualLastName>
+            <gco:CharacterString>Spicher</gco:CharacterString>
+          </che:individualLastName>
+          <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>SFN</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">SFN</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">WNA</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </che:organisationAcronym>
+        </che:CHE_CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:resourceMaintenance>
+        <che:CHE_MD_MaintenanceInformation gco:isoType="gmd:MD_MaintenanceInformation">
+          <gmd:maintenanceAndUpdateFrequency>
+            <gmd:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_MaintenanceFrequencyCode" codeListValue="annually" />
+          </gmd:maintenanceAndUpdateFrequency>
+        </che:CHE_MD_MaintenanceInformation>
+      </gmd:resourceMaintenance>
+      <gmd:resourceFormat>
+        <gmd:MD_Format>
+          <gmd:name>
+            <gco:CharacterString>ESRI Enterprise Geodatabase</gco:CharacterString>
+          </gmd:name>
+          <gmd:version gco:nilReason="unknown" />
+        </gmd:MD_Format>
+      </gmd:resourceFormat>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>forêt</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">forêt</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Forst</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">foresta</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">forest</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>planification</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">planification</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Planung</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">pianificazione</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">planning</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>sylviculture</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">sylviculture</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Forstwirtschaft</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">forestazione</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">forestry</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>surveillance</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">surveillance</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Monitoring</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">monitoraggio</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">monitoring</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>analyse</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">analyse</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Untersuchung</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">saggio</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">assay</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>GEMET</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2018-08-16</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="https://www.geocat.ch/geonetwork/srv/api/registries/vocabularies/external.theme.gemet">geonetwork.thesaurus.external.theme.gemet</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:resourceConstraints>
+        <che:CHE_MD_LegalConstraints gco:isoType="gmd:MD_LegalConstraints">
+          <gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Propriété de l'Etat de Fribourg, statut interne</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Propriété de l'Etat de Fribourg, statut interne</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:otherConstraints>
+        </che:CHE_MD_LegalConstraints>
+      </gmd:resourceConstraints>
+      <gmd:spatialRepresentationType>
+        <gmd:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_SpatialRepresentationTypeCode" codeListValue="vector" />
+      </gmd:spatialRepresentationType>
+      <gmd:spatialResolution>
+        <gmd:MD_Resolution>
+          <gmd:equivalentScale>
+            <gmd:MD_RepresentativeFraction>
+              <gmd:denominator>
+                <gco:Integer>100000</gco:Integer>
+              </gmd:denominator>
+            </gmd:MD_RepresentativeFraction>
+          </gmd:equivalentScale>
+        </gmd:MD_Resolution>
+      </gmd:spatialResolution>
+      <gmd:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+      </gmd:language>
+      <gmd:characterSet>
+        <gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" />
+      </gmd:characterSet>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>biota</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>geoscientificInformation</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>geoscientificInformation_NaturalHazards</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>environment</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>environment_NatureProtection</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:environmentDescription xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>SDE: SFF1825S_FORFAITS_FP</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">SDE: SFF1825S_FORFAITS_FP</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:environmentDescription>
+      <gmd:extent>
+        <gmd:EX_Extent>
+          <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Canton de Fribourg (FR)</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Canton de Fribourg (FR)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Kanton Freiburg (FR)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Cantone di Friburgo (FR)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Canton of Fribourg (FR)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:description>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:westBoundLongitude>
+                <gco:Decimal>6.742307</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>7.380268</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>46.438047</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>47.006881</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+          <gmd:geographicElement>
+            <gmd:EX_BoundingPolygon>
+              <gmd:polygon>
+                <gml:MultiSurface xmlns="http://www.opengis.net/gml/3.2" gml:id="d14680479e77" srsDimension="2">
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="d14680479e79">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>6.7730657 46.7514186 6.7761526 46.7494396 6.7786819 46.7512984 6.7862383 46.7476716 6.7844497 46.7354721 6.7774959 46.7295847 6.7774076 46.7261208 6.770738 46.7206844 6.7624999 46.7173523 6.7586221 46.7219891 6.7590792 46.7251493 6.7517271 46.7282447 6.7486202 46.7318063 6.7526151 46.7365892 6.7590313 46.7372394 6.7681791 46.7444542 6.7730657 46.7514186</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="d14680479e85">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>6.8577401 46.7627038 6.8592496 46.7611102 6.8638491 46.7631036 6.8677943 46.7601818 6.8769761 46.7558646 6.8757274 46.7538614 6.8820782 46.7497816 6.8664207 46.733026 6.8655342 46.7290454 6.867935 46.7284098 6.8618011 46.7245917 6.8463591 46.727517 6.8384408 46.7325401 6.8283343 46.735401 6.8173562 46.7331916 6.8113339 46.7279141 6.8062033 46.7270041 6.7929817 46.7255535 6.7884657 46.7279567 6.7936318 46.7357134 6.7965155 46.7363774 6.7980484 46.7340022 6.803992 46.737031 6.8061178 46.7353967 6.8121023 46.7372019 6.8165358 46.7385126 6.8150604 46.7405016 6.8304676 46.7538716 6.8290849 46.7557713 6.844425 46.7652618 6.848864 46.7711321 6.8462574 46.7712355 6.8490402 46.7753609 6.8601606 46.7664763 6.8577401 46.7627038</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="d14680479e91">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>6.8917181 46.8867769 6.9036657 46.8794212 6.9053359 46.8803286 6.9069534 46.878618 6.9108692 46.8806332 6.9210084 46.8713153 6.9114884 46.8670169 6.9094052 46.869454 6.8918749 46.8649546 6.8962781 46.8614134 6.912811 46.8658896 6.9301326 46.8538691 6.9193532 46.8471729 6.9109896 46.8390385 6.9052002 46.827672 6.9108043 46.8125458 6.9049291 46.8064734 6.9073419 46.8049284 6.9113289 46.8031758 6.9195776 46.8103911 6.9233946 46.8085734 6.9277403 46.8090067 6.9314424 46.805443 6.9261322 46.7990324 6.9211772 46.7966712 6.916608 46.7869981 6.9159355 46.7834237 6.9109948 46.7798027 6.9083012 46.7820571 6.9098061 46.7834944 6.9064815 46.783326 6.9050454 46.7815651 6.8991915 46.7816095 6.8998873 46.7801195 6.8949877 46.7790438 6.8941939 46.7772589 6.8881992 46.7783095 6.8796004 46.7753891 6.8638005 46.7811306 6.8618532 46.7832078 6.8639752 46.7843879 6.8591559 46.7880337 6.8515098 46.7858797 6.848553 46.7809573 6.8431112 46.7786855 6.8400105 46.7808012 6.8331922 46.7746122 6.8274837 46.7768936 6.8254052 46.7731492 6.8187541 46.777674 6.8131639 46.7793237 6.8045965 46.7856742 6.7980562 46.782822 6.7825333 46.7928719 6.7759709 46.7897034 6.7790334 46.7941561 6.7873115 46.7995651 6.7840849 46.8031359 6.7788632 46.80056 6.7768608 46.8025365 6.7673365 46.8088587 6.7423068 46.8274557 6.780046 46.8526428 6.8658995 46.9095048 6.8917181 46.8867769</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="d14680479e97">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>7.234894 46.933018 7.234619 46.9294277 7.2306397 46.9295735 7.2186332 46.9243786 7.2167024 46.9277121 7.217429 46.9330117 7.2293115 46.9368032 7.2281874 46.9387801 7.2301661 46.9399171 7.2353083 46.9380554 7.234894 46.933018</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                  <gml:surfaceMember>
+                    <gml:Polygon gml:id="d14680479e103">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList>7.2130334 47.0068805 7.2154325 47.005491 7.2172548 47.0068078 7.223299 46.9981931 7.225859 46.9991424 7.2267364 46.9967243 7.2236191 46.9937951 7.234926 46.9866827 7.2355113 46.9848667 7.2297037 46.9809253 7.2212987 46.9760162 7.2225399 46.9745794 7.2147211 46.97129 7.2142925 46.9669625 7.2075616 46.9677047 7.2067373 46.9638531 7.1954245 46.9638205 7.1971589 46.9609008 7.2065938 46.9605965 7.2110514 46.9566476 7.2077999 46.9490221 7.209628 46.9485041 7.2097557 46.9432242 7.203709 46.9383724 7.2116188 46.9313092 7.2111116 46.9270624 7.211159 46.9251915 7.2062903 46.924606 7.2054626 46.9217168 7.2078796 46.9092633 7.1879704 46.900244 7.1954173 46.8989828 7.2000348 46.9023568 7.208236 46.9026975 7.212466 46.9017615 7.2174443 46.8975435 7.2230012 46.9026185 7.2303846 46.9040624 7.2325291 46.8993078 7.2369039 46.8980563 7.243138 46.8979143 7.244049 46.9000118 7.2568111 46.8982788 7.2810098 46.8895535 7.290156 46.8940005 7.3074415 46.8925375 7.3256121 46.8940143 7.3494109 46.8890702 7.3535618 46.8861589 7.3530456 46.8726566 7.3573781 46.8701411 7.3588972 46.8629549 7.3511086 46.8541248 7.3381621 46.8495444 7.3342624 46.8524464 7.325741 46.8517635 7.3228759 46.854864 7.330646 46.8576603 7.3236101 46.8609906 7.3173819 46.8605343 7.3164068 46.8625662 7.3126999 46.8606732 7.312043 46.8556351 7.302165 46.8520705 7.3081445 46.8465274 7.3226182 46.8407141 7.3309094 46.8335383 7.3283912 46.8287831 7.3196774 46.8250142 7.3214173 46.8204554 7.3188033 46.8173942 7.320904 46.8155074 7.3114838 46.8096502 7.3057522 46.7963305 7.3020384 46.7939243 7.3029284 46.7890049 7.3015874 46.7858908 7.3042136 46.7831054 7.2904916 46.7730134 7.2951984 46.7657152 7.3007283 46.7635811 7.3043747 46.7502363 7.2962961 46.7368862 7.2984771 46.7234587 7.3077797 46.717173 7.3267978 46.7167076 7.3488434 46.7122835 7.3489988 46.7054291 7.3452442 46.6989133 7.3597977 46.6980159 7.3626069 46.6992772 7.3686039 46.6926514 7.3769446 46.6926653 7.3802679 46.6901843 7.375996 46.6877892 7.3777655 46.6835713 7.3729335 46.6801233 7.3757237 46.6748355 7.3715876 46.6694628 7.3684963 46.655257 7.3758508 46.6557561 7.3587801 46.644177 7.3557576 46.6391823 7.3548184 46.6467469 7.3491072 46.6486046 7.349638 46.6514566 7.3446415 46.6550237 7.322106 46.6550027 7.3297494 46.6417059 7.3222885 46.6371558 7.3132525 46.6365794 7.3121253 46.6216905 7.317838 46.6185033 7.3182874 46.616057 7.3148511 46.600356 7.3207562 46.5916546 7.3125283 46.589145 7.3080457 46.5813227 7.2986972 46.5791526 7.2817998 46.5846897 7.2680181 46.5735781 7.2597688 46.5634004 7.2457626 46.555866 7.2370204 46.5537998 7.2232878 46.5477294 7.207328 46.5327922 7.2008237 46.5416574 7.1921706 46.5466224 7.1827558 46.5386944 7.1710789 46.5327483 7.1591025 46.52725 7.1483824 46.5284914 7.144717 46.5266378 7.1357365 46.508191 7.1264107 46.5032001 7.1242057 46.4993078 7.1103337 46.4948066 7.1003921 46.4869781 7.097973 46.4885181 7.0888145 46.4869159 7.0776926 46.488815 7.0724993 46.4863965 7.0658651 46.4890376 7.0610977 46.4872586 7.0278736 46.4667677 7.0202488 46.4594802 7.0168398 46.4476201 6.9928224 46.4388831 6.9839551 46.4380472 6.9920904 46.4487396 6.9896614 46.452868 6.9798724 46.4591618 6.9778914 46.4731872 6.9804302 46.4747537 6.9736832 46.4810593 6.9733499 46.4895135 6.962045 46.4968794 6.9504403 46.5024614 6.9337734 46.5015787 6.9302274 46.5046215 6.9268393 46.5046962 6.9247259 46.5077452 6.9147982 46.5103985 6.9119587 46.5129851 6.9013508 46.5131242 6.8960785 46.5074407 6.8977079 46.5203755 6.8833006 46.513451 6.8815636 46.5125789 6.8663136 46.5007364 6.8627654 46.4938456 6.8581869 46.4932465 6.847801 46.4936696 6.8454625 46.496671 6.8419983 46.4965989 6.8367619 46.5000976 6.832759 46.5050689 6.8301104 46.5123504 6.8244315 46.5121579 6.8178923 46.5165392 6.8107939 46.5252082 6.8122175 46.5260707 6.8254328 46.543343 6.827553 46.5426258 6.8251805 46.5380071 6.8324614 46.5374165 6.854789 46.5413209 6.8565303 46.5370118 6.8594096 46.5359471 6.8584151 46.531444 6.8611745 46.5305945 6.8665311 46.5404901 6.868342 46.5418396 6.8879941 46.5579492 6.8913919 46.557246 6.8934323 46.5592349 6.9024633 46.5612031 6.8987722 46.5651437 6.9016486 46.5696912 6.897974 46.5706183 6.888143 46.5676474 6.8845103 46.5619444 6.8794225 46.567119 6.8744626 46.5649625 6.8718062 46.5695191 6.8655286 46.577224 6.8526918 46.5820162 6.8514236 46.5810651 6.8471571 46.5834718 6.8427725 46.5823604 6.8347618 46.5753553 6.8287276 46.5771582 6.8237281 46.5774191 6.8205642 46.583708 6.814123 46.5856068 6.8117013 46.5806727 6.8130336 46.5782872 6.8048709 46.5779361 6.7993199 46.5740817 6.7951059 46.5752184 6.7991686 46.5835535 6.8013099 46.5922555 6.7982958 46.59993 6.8019276 46.6007331 6.8034663 46.6219179 6.8022748 46.6277316 6.796883 46.6331257 6.8034861 46.6446325 6.7988204 46.6492482 6.8112045 46.6503427 6.8145694 46.6474286 6.8184674 46.6481067 6.8172524 46.6492515 6.8279698 46.6602844 6.8313358 46.6595648 6.8334476 46.6623198 6.8384225 46.662616 6.8440732 46.6608826 6.8421755 46.6588126 6.853552 46.6555163 6.8594751 46.6599275 6.8649021 46.6582549 6.8680243 46.6607534 6.8683144 46.6629768 6.8644019 46.6647293 6.8718502 46.6734026 6.8647094 46.6763443 6.8627908 46.6809944 6.8654804 46.6812689 6.8665826 46.6845669 6.868557 46.6857373 6.8731053 46.6833221 6.8811529 46.6900457 6.8837298 46.6898963 6.8879449 46.6944597 6.8896103 46.693973 6.8934729 46.6998567 6.8923864 46.7025592 6.8980677 46.7084336 6.9045234 46.7141583 6.9160169 46.719825 6.917081 46.7179947 6.9204445 46.7218603 6.9221419 46.7235502 6.9342888 46.7324833 6.9356687 46.7332271 6.9360312 46.7378345 6.9412514 46.7449729 6.9372188 46.7493991 6.9302262 46.7539828 6.9205681 46.7511506 6.9168731 46.7542822 6.9146323 46.7532195 6.9118697 46.754655 6.9105617 46.7532366 6.9081894 46.7575525 6.9143686 46.7628166 6.920024 46.7600718 6.9287767 46.7674428 6.9354155 46.7714933 6.9312163 46.7725002 6.9330551 46.7746763 6.9315301 46.7753262 6.938831 46.7815295 6.9456524 46.7845097 6.9500821 46.7826937 6.9586575 46.7902595 6.9564555 46.7904481 6.9560228 46.7934148 6.966682 46.8026529 6.957854 46.8112697 6.9593653 46.8122296 6.9565238 46.8149522 6.9616308 46.8182661 6.958665 46.8202146 6.9656064 46.8281057 6.9717863 46.8242991 6.9851592 46.8221132 6.9924144 46.8305886 6.9923659 46.8332691 6.9860213 46.8348903 6.987024 46.8372331 6.9828983 46.8399063 6.9860052 46.8401773 6.9885664 46.8435638 6.9845 46.8466752 6.9813991 46.8458453 6.9774771 46.8501655 6.9805181 46.8580321 6.9770246 46.8606124 6.9801135 46.8662956 6.9890579 46.8733964 6.986155 46.8762721 6.9736911 46.8873651 6.9661295 46.8833491 6.9622124 46.8841784 6.958052 46.8813993 6.9698917 46.8671998 6.9651224 46.8651561 6.9599781 46.8713865 6.9572812 46.8708084 6.954 46.8753912 6.9516729 46.8745178 6.9511432 46.8779518 6.9419029 46.8841458 6.9386246 46.8896007 6.9360987 46.8888969 6.9331787 46.8924373 6.9259599 46.892612 6.9239013 46.8951844 6.9297645 46.8996184 6.9220451 46.9053409 6.8962094 46.9253259 6.9279018 46.9531746 6.9614044 46.9278117 6.9719822 46.920911 6.9781183 46.9234006 6.9861429 46.9200055 6.9875233 46.9182209 6.9819304 46.91362 6.9845302 46.9120022 6.9812444 46.9093984 6.9841717 46.9078359 7.0094842 46.8890436 6.9948645 46.8782387 6.9996184 46.8744604 7.0077733 46.8733491 7.013316 46.8774089 7.0156395 46.8772106 7.0163848 46.8808475 7.0216419 46.8762612 7.0251053 46.877938 7.0353833 46.873603 7.0299308 46.8661534 7.0396777 46.8605927 7.0332235 46.8573856 7.0340647 46.8553916 7.0299537 46.8528132 7.0318665 46.8478366 7.0331708 46.8487408 7.0373774 46.8456279 7.0395569 46.8482338 7.0429139 46.8469212 7.0502123 46.8546202 7.0539629 46.856387 7.0625691 46.8670483 7.0666628 46.8687169 7.0706695 46.8735334 7.0692195 46.8764702 7.0646676 46.8783444 7.0669996 46.8787838 7.0662126 46.8806523 7.0616933 46.8796929 7.0619795 46.8837777 7.0798186 46.8941529 7.0746348 46.8942265 7.0745998 46.8955127 7.0833094 46.8960889 7.0889154 46.8997223 7.0867112 46.9016316 7.0912665 46.9034626 7.0931493 46.9066077 7.0900838 46.9077317 7.0842069 46.9131738 7.0598092 46.9365552 7.0579168 46.9385819 7.061383 46.9424523 7.0596626 46.9517028 7.0564713 46.9552633 7.0596071 46.9558314 7.0580549 46.9653612 7.0608727 46.9663871 7.0631907 46.9712431 7.0518468 46.9771152 7.0935408 46.9762592 7.1381056 46.9834644 7.1465624 46.9849346 7.1537453 46.986266 7.1605215 46.9875241 7.1710708 46.9913992 7.1788664 46.9941158 7.1872525 46.9972199 7.1967051 47.0002267 7.1963818 47.0019441 7.1997752 47.0017083 7.2049617 47.0063426 7.2102974 47.0039876 7.2130334 47.0068805</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                      <gml:interior>
+                        <gml:LinearRing>
+                          <gml:posList>7.1348812 46.9193828 7.1266875 46.9173817 7.1252473 46.9189699 7.114829 46.9158555 7.1132329 46.9106336 7.1187761 46.905585 7.1186242 46.9024632 7.1195936 46.9005499 7.1230079 46.9001996 7.1284523 46.905072 7.1387243 46.9082838 7.1348812 46.9193828</gml:posList>
+                        </gml:LinearRing>
+                      </gml:interior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                </gml:MultiSurface>
+              </gmd:polygon>
+            </gmd:EX_BoundingPolygon>
+          </gmd:geographicElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+    </che:CHE_MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:contentInfo>
+    <che:CHE_MD_FeatureCatalogueDescription gco:isoType="gmd:MD_FeatureCatalogueDescription">
+      <gmd:includedWithDataset>
+        <gco:Boolean>true</gco:Boolean>
+      </gmd:includedWithDataset>
+      <gmd:featureCatalogueCitation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Forfaits à l'ha des subventions FP-S - Polygones</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Forfaits à l'ha des subventions FP-S - Polygones</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2024-08-28</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:featureCatalogueCitation>
+      <gmd:featureCatalogueCitation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Monitoring des forêts protectrices - Point</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Monitoring des forêts protectrices - Point</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2024-08-28</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:featureCatalogueCitation>
+      <gmd:featureCatalogueCitation />
+      <che:class />
+      <che:class />
+      <che:class />
+      <che:class>
+        <che:CHE_MD_Class>
+          <che:name>
+            <gco:CharacterString>SFF1825S_FORFAITS_FP</gco:CharacterString>
+          </che:name>
+          <che:description>
+            <gco:CharacterString>Entités polygones</gco:CharacterString>
+          </che:description>
+        </che:CHE_MD_Class>
+      </che:class>
+      <che:class />
+      <che:modelType>
+        <che:CHE_MD_modelTypeCode codeList="#CHE_MD_modelTypeCode" codeListValue="FeatureDescription" />
+      </che:modelType>
+    </che:CHE_MD_FeatureCatalogueDescription>
+  </gmd:contentInfo>
+  <gmd:distributionInfo xmlns:java="java:org.fao.geonet.util.XslUtil">
+    <gmd:MD_Distribution>
+      <gmd:distributionFormat>
+        <gmd:MD_Format>
+          <gmd:name>
+            <gco:CharacterString>ESRI Enterprise Geodatabase</gco:CharacterString>
+          </gmd:name>
+          <gmd:version gco:nilReason="unknown" />
+        </gmd:MD_Format>
+      </gmd:distributionFormat>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <gmd:URL>https://www.fr.ch/energie-agriculture-et-environnement/forets/section-foret-et-dangers-naturels</gmd:URL>
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">https://www.fr.ch/energie-agriculture-et-environnement/forets/section-foret-et-dangers-naturels</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:name>
+                <gmx:MimeFileType type="" />
+              </gmd:name>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Page d'accueil de la section forêt et dangers naturels</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Page d'accueil de la section forêt et dangers naturels</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+              <gmd:function>
+                <gmd:CI_OnLineFunctionCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_OnLineFunctionCode" codeListValue="information" />
+              </gmd:function>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <gmd:URL>https://www.geocat.ch/geonetwork/srv/api/records/be080b9d-bbac-40ce-bc69-cdd1e8d7ae50/attachments/Metadonnees_Forfaits_FP.xlsx</gmd:URL>
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">https://www.geocat.ch/geonetwork/srv/api/records/be080b9d-bbac-40ce-bc69-cdd1e8d7ae50/attachments/Metadonnees_Forfaits_FP.xlsx</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">https://www.geocat.ch/geonetwork/srv/api/records/be080b9d-bbac-40ce-bc69-cdd1e8d7ae50/attachments/Metadonnees_Forfaits_FP.xlsx</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#IT">https://www.geocat.ch/geonetwork/srv/api/records/be080b9d-bbac-40ce-bc69-cdd1e8d7ae50/attachments/Metadonnees_Forfaits_FP.xlsx</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#EN">https://www.geocat.ch/geonetwork/srv/api/records/be080b9d-bbac-40ce-bc69-cdd1e8d7ae50/attachments/Metadonnees_Forfaits_FP.xlsx</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Métadonnées Forfaits_FP</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Métadonnées Forfaits_FP</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Metadonnees_Forfaits_FP.xlsx</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#IT">Metadonnees_Forfaits_FP.xlsx</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">Metadonnees_Forfaits_FP.xlsx</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:name>
+              <gmd:description gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString />
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+  <gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset" />
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Donnée estimative donnant le forfait de subvention théorique lors d'interventions en forêts protectrices. Ce forfait est calculé selon la directive 1301.1 du Service des forêts et de la nature (SFN) de l'Etat de Fribourg.</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Donnée estimative donnant le forfait de subvention théorique lors d'interventions en forêts protectrices. Ce forfait est calculé selon la directive 1301.1 du Service des forêts et de la nature (SFN) de l'Etat de Fribourg.</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
+</che:CHE_MD_Metadata>
+

--- a/src/test/resources/wms-with-2-serviceTypeVersion-19115-3.che.xml
+++ b/src/test/resources/wms-with-2-serviceTypeVersion-19115-3.che.xml
@@ -1,0 +1,928 @@
+<che:CHE_MD_Metadata xmlns:che="http://geocat.ch/che" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0" xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1" xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0" xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0" xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0" xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0" xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0" xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0" xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0" xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0" xmlns:md1="http://standards.iso.org/iso/19115/-3/md1/2.0" xmlns:md2="http://standards.iso.org/iso/19115/-3/md2/2.0" xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/2.0" xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0" xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/2.0" xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/2.0" xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0" xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0" xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0" xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0" xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0" xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0" xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0" xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0" xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0" xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0" xmlns:dqm="http://standards.iso.org/iso/19157/-2/dqm/1.0" xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0" xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink" gco:isoType="mdb:MD_Metadata">
+  <mdb:metadataIdentifier>
+    <mcc:MD_Identifier>
+      <mcc:code>
+        <gco:CharacterString>07fb9011-362c-4c7d-a37a-7fe838ff5a13</gco:CharacterString>
+      </mcc:code>
+    </mcc:MD_Identifier>
+  </mdb:metadataIdentifier>
+  <mdb:defaultLocale>
+    <lan:PT_Locale id="DE">
+      <lan:language>
+        <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="ger">ger</lan:LanguageCode>
+      </lan:language>
+      <lan:characterEncoding>
+        <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
+      </lan:characterEncoding>
+    </lan:PT_Locale>
+  </mdb:defaultLocale>
+  <mdb:metadataScope>
+    <mdb:MD_MetadataScope>
+      <mdb:resourceScope>
+        <mcc:MD_ScopeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode" codeListValue="service">service</mcc:MD_ScopeCode>
+      </mdb:resourceScope>
+      <mdb:name>
+        <gco:CharacterString>Service</gco:CharacterString>
+      </mdb:name>
+    </mdb:MD_MetadataScope>
+  </mdb:metadataScope>
+  <mdb:contact xlink:show="embed">
+    <cit:CI_Responsibility>
+      <cit:role>
+        <cit:CI_RoleCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</cit:CI_RoleCode>
+      </cit:role>
+      <cit:party>
+        <che:CHE_CI_Organisation gco:isoType="cit:CI_Organisation">
+          <cit:name xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Bundesamt für Landestopografie swisstopo</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Bundesamt für Landestopografie swisstopo</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">Office fédéral de topographie swisstopo</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">Federal Office of Topography swisstopo</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">Ufficio federale di topografia swisstopo</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </cit:name>
+          <cit:contactInfo>
+            <cit:CI_Contact>
+              <cit:phone>
+                <cit:CI_Telephone>
+                  <cit:number>
+                    <gco:CharacterString>+41 58 469 01 11</gco:CharacterString>
+                  </cit:number>
+                  <cit:numberType>
+                    <cit:CI_TelephoneTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_TelephoneTypeCode" codeListValue="voice">voice</cit:CI_TelephoneTypeCode>
+                  </cit:numberType>
+                </cit:CI_Telephone>
+              </cit:phone>
+              <cit:address>
+                <cit:CI_Address>
+                  <cit:deliveryPoint>
+                    <gco:CharacterString>Seftigenstrasse 264</gco:CharacterString>
+                  </cit:deliveryPoint>
+                  <cit:city>
+                    <gco:CharacterString>Wabern</gco:CharacterString>
+                  </cit:city>
+                  <cit:postalCode>
+                    <gco:CharacterString>3084</gco:CharacterString>
+                  </cit:postalCode>
+                  <cit:country>
+                    <gco:CharacterString>CH</gco:CharacterString>
+                  </cit:country>
+                  <cit:electronicMailAddress>
+                    <gco:CharacterString>daniel.gechter@swisstopo.ch</gco:CharacterString>
+                  </cit:electronicMailAddress>
+                </cit:CI_Address>
+              </cit:address>
+              <cit:onlineResource>
+                <cit:CI_OnlineResource>
+                  <cit:linkage xsi:type="lan:PT_FreeText_PropertyType">
+                    <lan:PT_FreeText>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#EN">https://www.swisstopo.admin.ch/en/swiss-geological-survey</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#DE">https://www.swisstopo.admin.ch/de/landesgeologie</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#FR">https://www.swisstopo.admin.ch/fr/service-geologique-national</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#IT">https://www.swisstopo.admin.ch/it/servizio-geologico-nazionale</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                    </lan:PT_FreeText>
+                  </cit:linkage>
+                  <cit:protocol>
+                    <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                  </cit:protocol>
+                </cit:CI_OnlineResource>
+              </cit:onlineResource>
+            </cit:CI_Contact>
+          </cit:contactInfo>
+          <cit:individual>
+            <cit:CI_Individual>
+              <cit:name>
+                <gco:CharacterString>Daniel Gechter</gco:CharacterString>
+              </cit:name>
+              <cit:positionName xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>Landesgeologie</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">Landesgeologie</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">Service géologique national</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN">Swiss Geological Survey</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#IT">Servizio geologico nazionale</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:positionName>
+            </cit:CI_Individual>
+          </cit:individual>
+          <che:organisationAcronym xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>swisstopo</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">swisstopo</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">swisstopo</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">swisstopo</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">swisstopo</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </che:organisationAcronym>
+        </che:CHE_CI_Organisation>
+      </cit:party>
+    </cit:CI_Responsibility>
+  </mdb:contact>
+  <mdb:dateInfo>
+    <cit:CI_Date>
+      <cit:date>
+        <gco:DateTime>2019-08-13T23:50:53</gco:DateTime>
+      </cit:date>
+      <cit:dateType>
+        <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="revision">revision</cit:CI_DateTypeCode>
+      </cit:dateType>
+    </cit:CI_Date>
+  </mdb:dateInfo>
+  <mdb:metadataStandard>
+    <cit:CI_Citation>
+      <cit:title>
+        <gco:CharacterString>GM03_2</gco:CharacterString>
+      </cit:title>
+      <cit:edition>
+        <gco:CharacterString>1.0</gco:CharacterString>
+      </cit:edition>
+    </cit:CI_Citation>
+  </mdb:metadataStandard>
+  <mdb:otherLocale>
+    <lan:PT_Locale id="FR">
+      <lan:language>
+        <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="fre">fre</lan:LanguageCode>
+      </lan:language>
+      <lan:characterEncoding>
+        <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
+      </lan:characterEncoding>
+    </lan:PT_Locale>
+  </mdb:otherLocale>
+  <mdb:otherLocale>
+    <lan:PT_Locale id="EN">
+      <lan:language>
+        <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="eng">eng</lan:LanguageCode>
+      </lan:language>
+      <lan:characterEncoding>
+        <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
+      </lan:characterEncoding>
+    </lan:PT_Locale>
+  </mdb:otherLocale>
+  <mdb:otherLocale>
+    <lan:PT_Locale id="IT">
+      <lan:language>
+        <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="ita">ita</lan:LanguageCode>
+      </lan:language>
+      <lan:characterEncoding>
+        <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
+      </lan:characterEncoding>
+    </lan:PT_Locale>
+  </mdb:otherLocale>
+  <mdb:referenceSystemInfo>
+    <mrs:MD_ReferenceSystem>
+      <mrs:referenceSystemIdentifier>
+        <mcc:MD_Identifier>
+          <mcc:code xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>EPSG:21781, 4326, 2154, 32632, 2056, 21780, 3034, 3035, 4258, 900913, 3857</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">EPSG:21781, 4326, 2154, 32632, 2056, 21780, 3034, 3035, 4258, 900913, 3857</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mcc:code>
+        </mcc:MD_Identifier>
+      </mrs:referenceSystemIdentifier>
+    </mrs:MD_ReferenceSystem>
+  </mdb:referenceSystemInfo>
+  <mdb:identificationInfo>
+    <srv:SV_ServiceIdentification>
+      <mri:citation>
+        <cit:CI_Citation>
+          <cit:title xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>LG DE Geologie und Tektonik - OneGeology (WMS)</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">LG DE Geologie und Tektonik - OneGeology (WMS)</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">SGN FR Géologie et tectonique - OneGeology (WMS)</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">SGS EN Geology and tectonics - OneGeology (WMS)</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </cit:title>
+          <cit:date>
+            <cit:CI_Date>
+              <cit:date>
+                <gco:Date>2013-11-30</gco:Date>
+              </cit:date>
+              <cit:dateType>
+                <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="creation">creation</cit:CI_DateTypeCode>
+              </cit:dateType>
+            </cit:CI_Date>
+          </cit:date>
+        </cit:CI_Citation>
+      </mri:citation>
+      <mri:abstract xsi:type="lan:PT_FreeText_PropertyType">
+        <gco:CharacterString>Als erdwissenschaftliche Fachstelle des Bundes befasst sich der Bereich Landesgeologie vor allem mit folgenden Aufgaben: Organisation der geologischen Landesuntersuchung (Geologie, Geotechnik, Geophysik), Beschaffung der dafür notwendigen Daten, deren Kompilation und Umsetzung in geologische Karten sowie Herausgabe von Berichten, Empfehlungen und Richtlinien auf dem Gebiet der angewandten Geologie (Ingenieurgeologie, Umweltgeologie). Die präsentierten Layer (Tektonische Störungen, Tektonische Einheiten und Geologische Einheiten) geben einen grossräumigen Überblick über die Beschaffenheit und die Merkmale des Untergrundes der Schweiz</gco:CharacterString>
+        <lan:PT_FreeText>
+          <lan:textGroup>
+            <lan:LocalisedCharacterString locale="#DE">Als erdwissenschaftliche Fachstelle des Bundes befasst sich der Bereich Landesgeologie vor allem mit folgenden Aufgaben: Organisation der geologischen Landesuntersuchung (Geologie, Geotechnik, Geophysik), Beschaffung der dafür notwendigen Daten, deren Kompilation und Umsetzung in geologische Karten sowie Herausgabe von Berichten, Empfehlungen und Richtlinien auf dem Gebiet der angewandten Geologie (Ingenieurgeologie, Umweltgeologie). Die präsentierten Layer (Tektonische Störungen, Tektonische Einheiten und Geologische Einheiten) geben einen grossräumigen Überblick über die Beschaffenheit und die Merkmale des Untergrundes der Schweiz</lan:LocalisedCharacterString>
+          </lan:textGroup>
+          <lan:textGroup>
+            <lan:LocalisedCharacterString locale="#FR">En tant qu’organe de la Confédération spécialisé dans les sciences de la terre, le Service géologique national accomplit notamment les tâches suivantes: l’organisation du relevé géologique du territoire (géologie, géotechnique, géophysique), la collecte des données ainsi que leur compilation et leur traduction en cartes géologiques et enfin la publication de rapports, de recommandations et de directives relatives à la géologie appliquée (génie géologique, géologie environnementale). Les couches présentées (accidents tectoniques, unités tectoniques et unités géologiques) donnent une vue globale de la constitution et des caractéristiques du sous-sol de la Suisse</lan:LocalisedCharacterString>
+          </lan:textGroup>
+          <lan:textGroup>
+            <lan:LocalisedCharacterString locale="#EN">As the department of the Confederation responsible for earth sciences, the Swiss Geological Survey is principally concerned with the following tasks: organising national geological, geotechnical and geophysical surveys, gathering the necessary data, processing and compiling these data in the form of geological maps, and publishing reports, recommendations and guidelines in the fields to which geology is applied (engineering geology and environmental geology).The presented layers (tectonic lineaments, tectonic units and geological units) give a broad overview of the composition and major features of the underlying structure of Switzerland.</lan:LocalisedCharacterString>
+          </lan:textGroup>
+        </lan:PT_FreeText>
+      </mri:abstract>
+      <mri:pointOfContact xlink:show="embed">
+        <cit:CI_Responsibility>
+          <cit:role>
+            <cit:CI_RoleCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</cit:CI_RoleCode>
+          </cit:role>
+          <cit:party>
+            <che:CHE_CI_Organisation gco:isoType="cit:CI_Organisation">
+              <cit:name xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>Bundesamt für Landestopografie swisstopo</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">Bundesamt für Landestopografie swisstopo</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">Office fédéral de topographie swisstopo</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN">Federal Office of Topography swisstopo</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#IT">Ufficio federale di topografia swisstopo</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:name>
+              <cit:contactInfo>
+                <cit:CI_Contact>
+                  <cit:phone>
+                    <cit:CI_Telephone>
+                      <cit:number>
+                        <gco:CharacterString>+41 58 469 01 11</gco:CharacterString>
+                      </cit:number>
+                      <cit:numberType>
+                        <cit:CI_TelephoneTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_TelephoneTypeCode" codeListValue="voice">voice</cit:CI_TelephoneTypeCode>
+                      </cit:numberType>
+                    </cit:CI_Telephone>
+                  </cit:phone>
+                  <cit:address>
+                    <cit:CI_Address>
+                      <cit:deliveryPoint>
+                        <gco:CharacterString>Seftigenstrasse 264</gco:CharacterString>
+                      </cit:deliveryPoint>
+                      <cit:city>
+                        <gco:CharacterString>Wabern</gco:CharacterString>
+                      </cit:city>
+                      <cit:postalCode>
+                        <gco:CharacterString>3084</gco:CharacterString>
+                      </cit:postalCode>
+                      <cit:country>
+                        <gco:CharacterString>CH</gco:CharacterString>
+                      </cit:country>
+                      <cit:electronicMailAddress>
+                        <gco:CharacterString>daniel.gechter@swisstopo.ch</gco:CharacterString>
+                      </cit:electronicMailAddress>
+                    </cit:CI_Address>
+                  </cit:address>
+                  <cit:onlineResource>
+                    <cit:CI_OnlineResource>
+                      <cit:linkage xsi:type="lan:PT_FreeText_PropertyType">
+                        <lan:PT_FreeText>
+                          <lan:textGroup>
+                            <lan:LocalisedCharacterString locale="#EN">https://www.swisstopo.admin.ch/en/swiss-geological-survey</lan:LocalisedCharacterString>
+                          </lan:textGroup>
+                          <lan:textGroup>
+                            <lan:LocalisedCharacterString locale="#DE">https://www.swisstopo.admin.ch/de/landesgeologie</lan:LocalisedCharacterString>
+                          </lan:textGroup>
+                          <lan:textGroup>
+                            <lan:LocalisedCharacterString locale="#FR">https://www.swisstopo.admin.ch/fr/service-geologique-national</lan:LocalisedCharacterString>
+                          </lan:textGroup>
+                          <lan:textGroup>
+                            <lan:LocalisedCharacterString locale="#IT">https://www.swisstopo.admin.ch/it/servizio-geologico-nazionale</lan:LocalisedCharacterString>
+                          </lan:textGroup>
+                        </lan:PT_FreeText>
+                      </cit:linkage>
+                      <cit:protocol>
+                        <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                      </cit:protocol>
+                    </cit:CI_OnlineResource>
+                  </cit:onlineResource>
+                </cit:CI_Contact>
+              </cit:contactInfo>
+              <cit:individual>
+                <cit:CI_Individual>
+                  <cit:name>
+                    <gco:CharacterString>Daniel Gechter</gco:CharacterString>
+                  </cit:name>
+                  <cit:positionName xsi:type="lan:PT_FreeText_PropertyType">
+                    <gco:CharacterString>Landesgeologie</gco:CharacterString>
+                    <lan:PT_FreeText>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#DE">Landesgeologie</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#FR">Service géologique national</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#EN">Swiss Geological Survey</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#IT">Servizio geologico nazionale</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                    </lan:PT_FreeText>
+                  </cit:positionName>
+                </cit:CI_Individual>
+              </cit:individual>
+              <che:organisationAcronym xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>swisstopo</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">swisstopo</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">swisstopo</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN">swisstopo</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#IT">swisstopo</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </che:organisationAcronym>
+            </che:CHE_CI_Organisation>
+          </cit:party>
+        </cit:CI_Responsibility>
+      </mri:pointOfContact>
+      <mri:extent xlink:show="embed">
+        <gex:EX_Extent>
+          <gex:description xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Schweiz</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Schweiz</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">Suisse</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">Switzerland</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">Svizzera</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </gex:description>
+          <gex:geographicElement>
+            <gex:EX_GeographicBoundingBox>
+              <gex:westBoundLongitude>
+                <gco:Decimal>5.956088</gco:Decimal>
+              </gex:westBoundLongitude>
+              <gex:eastBoundLongitude>
+                <gco:Decimal>10.492036</gco:Decimal>
+              </gex:eastBoundLongitude>
+              <gex:southBoundLatitude>
+                <gco:Decimal>45.817970</gco:Decimal>
+              </gex:southBoundLatitude>
+              <gex:northBoundLatitude>
+                <gco:Decimal>47.808488</gco:Decimal>
+              </gex:northBoundLatitude>
+            </gex:EX_GeographicBoundingBox>
+          </gex:geographicElement>
+          <gex:geographicElement>
+            <gex:EX_BoundingPolygon>
+              <gex:polygon>
+                <MultiSurface xmlns="http://www.opengis.net/gml/3.2" gml:id="d25237359e60" srsName="EPSG:4326">
+                  <gml:surfaceMember>
+                    <Polygon gml:id="d25237359e62" srsName="EPSG:4326">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList srsDimension="2">47.80598999999998 8.573027 47.79972649999999 8.575219 47.80264399999996 8.5877555 47.79877049999999 8.592442 47.80288150000001 8.6013575 47.801079000000016 8.6138315 47.798326 8.618624 47.795939000000004 8.6178205 47.79466350000001 8.6220585 47.78876450000001 8.6204145 47.78705549999998 8.615677 47.78489550000003 8.615012 47.78019169999999 8.6176977 47.7779405 8.6188375 47.77717000000001 8.6231745 47.76733100000001 8.619267 47.759258999999986 8.627679 47.758245999999986 8.6315305 47.7601296 8.6332303 47.76514700000001 8.6423905 47.76502500000004 8.6454875 47.76697200000001 8.647669 47.768500500000016 8.645558 47.77336500000001 8.653031 47.77393599999999 8.648022 47.78128649999999 8.6499615 47.78684749999999 8.6454985 47.7946685 8.64654 47.79470700000002 8.6487665 47.79849300000001 8.6494255 47.8003655 8.6570145 47.79597849999999 8.660206 47.791607500000026 8.6574205 47.791627500000004 8.661782 47.78770850000001 8.667183 47.78569250000001 8.676155 47.78667100000001 8.680921 47.777164 8.68279 47.77365 8.6882535 47.7705095 8.6832075 47.75934749999999 8.687696 47.756156499999975 8.6926255 47.75677999999999 8.6976815 47.75974099999999 8.698987 47.76550150000003 8.714178 47.76270299999999 8.726105 47.75959449999999 8.7306555 47.75788399999999 8.72885 47.751852499999956 8.7410755 47.74642349999996 8.739402 47.745742500000006 8.723513 47.741075499999994 8.720122 47.738698 8.714344 47.73007150000001 8.71127 47.72142899999997 8.7181625 47.72135349999999 8.724546 47.72003049999998 8.7244335 47.718366 8.733205 47.716151499999995 8.7362945 47.71145999999996 8.7319325 47.696673000000004 8.726401 47.6926771 8.7279723 47.68963550000001 8.7565395 47.676462500000014 8.7856705 47.675598699999995 8.7956901 47.67992699999999 8.793337 47.689726500000006 8.798059 47.691731000000004 8.799774 47.6932645 8.809933 47.69644199999999 8.8061765 47.69733600000001 8.797798 47.7023145 8.7977205 47.704385 8.7933905 47.70672350000001 8.7694965 47.713194499999986 8.7728135 47.717948500000006 8.769904 47.72075749999999 8.7769995 47.72273050000001 8.7761315 47.721716500000014 8.7808025 47.72717699999998 8.78505 47.72732600000003 8.790547 47.728910499999984 8.7918245 47.72727849999998 8.7989955 47.73467199999999 8.7964365 47.73830699999999 8.806439 47.7310755 8.8084715 47.730426499999965 8.8123975 47.7244675 8.804927 47.723877500000015 8.812647 47.71764999999999 8.818586 47.717910500000045 8.826183 47.71287200000003 8.8188545 47.71092200000001 8.824128 47.714576499999964 8.8332615 47.71226250000001 8.843022 47.711033999999984 8.8455665 47.703491999999954 8.848522 47.70496 8.871377 47.70406349999999 8.8727505 47.701707999999996 8.869699 47.696741 8.8760135 47.6944005 8.8745325 47.692429000000004 8.8629345 47.69648600000002 8.8661425 47.698691499999995 8.863354 47.69645650000001 8.859979 47.698747999999995 8.858146 47.69766499999997 8.851325 47.694485499999985 8.8502855 47.692837 8.8571965 47.689089499999994 8.8560825 47.68571399999999 8.85099 47.680923199999995 8.8515408 47.680588 8.86033 47.6704575 8.873453 47.65596289999999 8.8749854 47.65466900000001 8.8748705 47.654664 8.882431 47.647838500000006 8.896779 47.656365499999964 8.9404975 47.66509999999997 8.964399 47.674586000000005 8.9819515 47.686621 9.0217825 47.68435550000001 9.0565765 47.6790005 9.07237 47.678916000000044 9.094917 47.675152499999996 9.1062685 47.66842100000002 9.1175945 47.66426100000001 9.138359 47.66465550000001 9.1425925 47.66757000000001 9.1478745 47.666018699999995 9.1577058 47.6604595 9.1630475 47.65470899999997 9.170492 47.655756999999994 9.175346 47.65393799999998 9.1758065 47.65588469999997 9.1821679 47.65745100000001 9.1871023 47.655095700000004 9.2148321 47.65870770000001 9.2565609 47.6203261 9.3947139 47.5514551 9.4956037 47.54973939999999 9.5069474 47.541893199999976 9.5587204 47.49918149999996 9.5611046 47.493604000000005 9.564142000000002 47.4866145 9.576391999999998 47.481221500000004 9.5834 47.46362199999999 9.594817499999998 47.461591 9.6008665 47.46238099999999 9.603570500000002 47.47032850000002 9.607249 47.46944400000001 9.611599 47.45748600000002 9.622324500000001 47.454251 9.654435 47.451382499999994 9.659449499999997 47.4477895 9.658005 47.442744000000005 9.6508025 47.43521649999997 9.644318 47.416431999999986 9.650899 47.404626500000035 9.6516355 47.40439999999998 9.6543925 47.397546000000034 9.660106499999998 47.391290999999995 9.673578500000001 47.38151049999999 9.6733705 47.377436999999986 9.670270999999998 47.371081000000004 9.662428 47.367446 9.649545500000002 47.367369999999994 9.635391500000003 47.365080500000005 9.6262925 47.36614500000002 9.6244795 47.362435000000005 9.619674000000002 47.346901 9.600727 47.33752000000001 9.596352500000002 47.31754400000003 9.588288500000003 47.31112250000001 9.5815595 47.30418399999999 9.5657325 47.30019150000001 9.559226 47.27820300000002 9.5434582 47.27058099999999 9.530749 47.26938150000001 9.529812 47.262595000000005 9.5294405 47.244045 9.520324 47.23178050000001 9.510388 47.22279350000002 9.5027225 47.20670749999999 9.49612 47.19824700000001 9.4902235 47.19029449999999 9.487608 47.17795649999999 9.486198 47.15694399999998 9.495433 47.147221 9.5037375 47.14005 9.5092235 47.12194600000001 9.51522 47.1151265 9.5171565 47.100149999999985 9.520344000000001 47.08535950000001 9.512247 47.065890499999995 9.474910999999999 47.061295 9.472234999999998 47.05179749999999 9.4760475 47.054996000000045 9.476301 47.056464000000005 9.482308 47.05296049999998 9.482489999999999 47.04968500000001 9.486025 47.05727400000001 9.4923715 47.05454550000002 9.497507 47.05764450000001 9.5003255 47.0572195 9.511909 47.06069500000004 9.517270999999997 47.06303650000001 9.530543 47.0651445 9.5397515 47.05884399999999 9.5516185 47.050505499999986 9.554383500000002 47.04932650000001 9.556851500000002 47.04857049999998 9.5597835 47.052526 9.569208999999999 47.054013 9.5782605 47.052808 9.5811355 47.05517750000004 9.587708000000001 47.059098000000006 9.596016500000001 47.05898250000001 9.599764 47.061893999999995 9.602818000000001 47.06077450000001 9.607078 47.05362850000003 9.617226 47.05133000000001 9.6263505 47.0517055 9.636565 47.05392549999999 9.641348500000001 47.059777999999994 9.6450805 47.05818550000001 9.658238 47.06210149999998 9.6818635 47.058955 9.682047 47.055229999999995 9.6882145 47.052392499999996 9.697583 47.05383900000001 9.7073265 47.04804999999999 9.707033499999998 47.043379000000016 9.718233999999999 47.042599999999965 9.741353999999998 47.04110750000001 9.745223 47.03692799999999 9.7481005 47.03845849999996 9.783335499999998 47.03169199999999 9.7919115 47.02909299999999 9.8014225 47.0217385 9.812349 47.0225495 9.815469499999999 47.019623499999994 9.824151999999998 47.014332000000024 9.8307265 47.01253700000001 9.836141 47.01512500000001 9.841029999999998 47.016418999999985 9.85275 47.02331449999997 9.8606815 47.021330500000005 9.867207 47.021232999999995 9.8762675 47.018024 9.8803515 47.013063999999986 9.871172000000001 47.00964449999998 9.870725 47.0065285 9.8729565 47.0007358 9.8887649 46.990365499999996 9.892325 46.98328000000001 9.883027 46.98085449999999 9.88457 46.9736595 9.875722 46.967501999999996 9.8756045 46.963100999999995 9.871269 46.95707350000001 9.878741 46.95039700000004 9.8748995 46.94071300000002 9.876591999999999 46.94011849999998 9.880727499999999 46.934635499999985 9.8761485 46.935024 9.8807465 46.931651999999985 9.894506499999999 46.925308 9.906342000000002 46.9260625 9.912331 46.91883100000001 9.9215515 46.913249500000006 9.937601999999998 46.91235649999999 9.946142000000002 46.9160315 9.959091 46.91240450000001 9.963132 46.912229999999994 9.966587 46.91588999999999 9.977887 46.91337800000002 9.980803 46.906206 9.982453999999999 46.90241549999999 9.99013 46.90226799999999 9.9958355 46.89880700000003 10.005929 46.901622 10.0178385 46.895812999999976 10.026487500000002 46.88658749999999 10.034674 46.88581400000001 10.039329 46.880446999999975 10.0424575 46.875754 10.052619500000002 46.86394949999999 10.0512175 46.860782 10.059581 46.86118999999999 10.087351499999999 46.8581805 10.092616 46.851706500000006 10.092319 46.84879050000001 10.096797 46.8409092 10.105171000000002 46.844177 10.119142999999998 46.847384500000004 10.119945000000001 46.848483499999986 10.1231145 46.847385 10.13943 46.851410499999986 10.147293000000001 46.85032749999999 10.154601499999998 46.84786700000001 10.1574305 46.85099649999998 10.1627105 46.85066649999999 10.169082 46.85367099999999 10.171776 46.85497699999996 10.1810105 46.86644949999999 10.1936785 46.866634000000005 10.1990325 46.864621 10.2038435 46.86729100000002 10.219248 46.86630549999998 10.232689 46.86944349999999 10.2308575 46.871613499999995 10.2328275 46.88468900000001 10.2348505 46.89021300000002 10.2276225 46.895946500000036 10.2257375 46.901647499999996 10.2333175 46.91570800000002 10.237051 46.918835 10.242031 46.931257500000015 10.2405795 46.929778500000026 10.257510499999999 46.92181199999999 10.293611999999998 46.91995650000001 10.2968845 46.924660500000016 10.300806 46.925184 10.316069 46.930958000000004 10.3171775 46.94014800000002 10.3061795 46.95020600000001 10.309367 46.9539805 10.3278315 46.96393549999996 10.329621 46.978380000000016 10.340722 46.981311000000005 10.339996999999999 46.982714999999956 10.344552 46.989592000000016 10.3465225 46.99236400000001 10.3549985 46.990673500000014 10.3720565 46.99927600000001 10.3833845 47.00052449999998 10.389318 46.9968825 10.398715999999999 46.990859 10.402183999999998 46.98264899999998 10.412506 46.97568650000002 10.426589 46.972702 10.4275045 46.965505500000006 10.4229745 46.959952499999986 10.4223805 46.9561535 10.428640500000002 46.9562765 10.432948 46.95231949999999 10.449156 46.95288450000004 10.4554815 46.947100500000005 10.468824 46.9410785 10.476588500000002 46.937790500000006 10.489350499999999 46.931449500000014 10.485296 46.926285500000006 10.4883075 46.91546149999999 10.4862185 46.910596500000025 10.4785425 46.894293000000005 10.475092 46.884281499999986 10.464697 46.88110600000002 10.4692315 46.872963500000026 10.471266 46.86211399999996 10.468009 46.84877349999999 10.471811 46.84142750000001 10.4639585 46.835894999999994 10.4665325 46.83408499999999 10.463073500000002 46.834686000000005 10.4601305 46.830247499999984 10.456666 46.82454050000001 10.4603565 46.822040000000015 10.455957 46.81647000000001 10.4577825 46.8042605 10.450775 46.7976395 10.4389925 46.79678050000001 10.429557 46.79423650000001 10.4267385 46.789406499999984 10.4266435 46.788242999999994 10.4227195 46.781878499999976 10.4338075 46.777613 10.4351105 46.77192600000001 10.4416585 46.75729100000004 10.443800999999999 46.752107000000024 10.4417075 46.75260750000001 10.435468 46.732820000000004 10.400201000000001 46.72847100000001 10.408970000000002 46.7238375 10.410960500000002 46.719054 10.4187305 46.709003499999994 10.416007 46.705465000000004 10.40999 46.705501500000025 10.4033275 46.68920750000001 10.393321500000003 46.68728249999998 10.3835695 46.68430649999999 10.381822 46.67137149999999 10.3924155 46.658861 10.3910135 46.65463750000001 10.3940885 46.64598699999996 10.4002825 46.640567000000004 10.401711 46.63858400000001 10.399859 46.63681199999999 10.402288 46.635058500000014 10.409127500000002 46.63831099999999 10.420209499999999 46.63937899999996 10.443446 46.64127149999999 10.446075499999997 46.633050500000024 10.462565 46.61742050000001 10.484266 46.6153415 10.4920355 46.611053999999996 10.491134000000002 46.6050285 10.4844785 46.59798749999999 10.487394500000002 46.59208449999997 10.483887999999999 46.589471 10.487898999999999 46.580902500000036 10.4835605 46.57719799999998 10.4848455 46.56646649999999 10.474751 46.56257949999994 10.474093 46.55710399999998 10.477748500000002 46.54833049999999 10.471074000000002 46.54350500000001 10.472213499999999 46.541266500000035 10.465685499999998 46.54131899999999 10.459112 46.53654949999995 10.4585785 46.53068300000001 10.452801 46.537391000000014 10.436687999999998 46.551320000000004 10.4181315 46.5439355 10.3973255 46.55004549999998 10.3842675 46.549972499999996 10.3792665 46.55393599999999 10.370484 46.55568599999998 10.352083 46.549454499999996 10.350209499999998 46.542688 10.3384775 46.55166700000001 10.324802 46.546626499999974 10.31066 46.54942299999999 10.3073725 46.549893499999996 10.295437000000002 46.551754500000044 10.293766999999999 46.55510699999999 10.296605000000001 46.55871849999997 10.2952105 46.56459799999999 10.288592 46.57025300000001 10.2866415 46.573953000000046 10.271122 46.5775185 10.268708999999998 46.576956999999965 10.263027 46.57124349999998 10.2535785 46.5745895 10.245915 46.57780149999999 10.243598 46.591571000000016 10.2415625 46.610442500000005 10.2588905 46.62210110000001 10.2448826 46.63533050000001 10.239202999999998 46.628994000000006 10.2239705 46.61694000000003 10.21532 46.620766 10.2063705 46.62313549999999 10.1934005 46.625934 10.1927655 46.62396949999999 10.183067 46.61570849999998 10.162274 46.610761999999994 10.137400000000001 46.607755999999995 10.136514 46.60550699999999 10.128460000000002 46.60710549999996 10.1132595 46.610652000000016 10.1067345 46.61072000000004 10.102353799999998 46.605433500000004 10.098879 46.60097649999997 10.1013495 46.59319850000003 10.0970915 46.58899349999999 10.1011545 46.582847500000014 10.100215 46.57734399999998 10.0953665 46.57514549999996 10.078619 46.571368500000005 10.0796715 46.56715650000004 10.085295 46.56071600000001 10.077671 46.55864199999996 10.071155000000001 46.550325499999985 10.0677165 46.54584999999997 10.061517 46.544044499999984 10.046766999999997 46.53753100000003 10.043919500000001 46.53183999999999 10.053245 46.528711499999986 10.0505365 46.522670000000005 10.0539345 46.513341 10.051483999999999 46.51006050000001 10.0423825 46.50189350000002 10.0450405 46.49984349999997 10.049049499999999 46.49368700000002 10.0449335 46.49039100000002 10.0451295 46.487814000000014 10.048532 46.48306650000001 10.0439165 46.476962499999985 10.045188 46.47177549999995 10.051756 46.46382849999998 10.053769 46.460406999999975 10.052492 46.45241849999999 10.0419855 46.44884400000004 10.0423705 46.446842000000004 10.039349499999998 46.44261850000004 10.0419729 46.43969899999999 10.052583 46.44086849999999 10.056279 46.42838900000001 10.060247999999998 46.425871 10.064393500000001 46.428057499999994 10.077308 46.42594 10.080132499999998 46.421036000000015 10.080472 46.422668999999985 10.092485499999999 46.421358999999995 10.100514500000001 46.4283015 10.1080895 46.42599050000001 10.1172095 46.42909499999996 10.119180499999999 46.4317365 10.129236499999998 46.429081 10.1329865 46.42827750000001 10.1431985 46.42297400000004 10.147088499999999 46.41422449999999 10.14767 46.41282050000001 10.1493865 46.415842999999995 10.157123 46.415445000000005 10.161034000000003 46.407647999999995 10.1666815 46.40346550000001 10.162032 46.390626 10.163860500000002 46.38766749999999 10.162031500000001 46.385009 10.156046 46.3868885 10.147427 46.38622299999997 10.142626 46.37768249999999 10.1273735 46.37427450000001 10.128527499999999 46.36989150000002 10.126140999999999 46.360990000000015 10.1292005 46.3573365 10.119382000000002 46.35267049999999 10.11361 46.35319599999997 10.110085499999999 46.35082200000002 10.108009499999998 46.34631300000001 10.1094305 46.34224450000002 10.1060915 46.33366749999999 10.1042735 46.323493499999984 10.1127215 46.31411249999999 10.116387 46.30461650000001 10.138353499999997 46.3010865 10.137526 46.29559149999997 10.1455545 46.292721 10.1542675 46.289255 10.156594500000002 46.28479800000002 10.154819 46.282354 10.162424 46.27718450000003 10.161245 46.27142599999999 10.1633465 46.266613500000005 10.171935999999999 46.25827650000002 10.1765245 46.25461250000001 10.1749335 46.239642 10.150873500000001 46.230482499999994 10.145949 46.22487699999999 10.132324 46.225594 10.128616 46.223787499999986 10.1232815 46.2257195 10.1091725 46.22856999999999 10.103486 46.228192000000035 10.091609500000002 46.22475299999999 10.0801875 46.2171185 10.0705935 46.22019450000002 10.0630825 46.224974 10.058612500000002 46.22974449999998 10.04367 46.23521099999999 10.052921 46.24151500000002 10.053437000000002 46.244080499999995 10.056963499999998 46.247152 10.0573545 46.24822899999998 10.060568500000002 46.26705750000002 10.053717 46.277417000000014 10.029061999999998 46.28066000000001 10.0092285 46.28476549999999 9.996015 46.29613500000002 9.991741 46.301444000000004 10.00061 46.30354 10.0009425 46.307491 9.996341 46.31307400000003 10.0001955 46.31403599999996 9.994912 46.32314650000001 9.9802195 46.33428549999999 9.985631 46.342343 9.9961245 46.34836100000001 9.9949785 46.350934499999994 9.996764 46.35240750000003 9.993776 46.351787 9.9852395 46.3638 9.9645725 46.37346450000001 9.9560175 46.37812450000001 9.959241 46.379155999999995 9.953191500000003 46.374870999999985 9.934299 46.371533 9.929784999999999 46.367841 9.9306265 46.36591150000001 9.9247885 46.37062700000004 9.9225675 46.37053999999998 9.916729499999999 46.38066210000002 9.9079115 46.37342849999999 9.884071000000002 46.3684475 9.880631999999999 46.362412000000006 9.8682245 46.36464699999999 9.865182 46.36279050000002 9.856281000000001 46.364611999999966 9.8495165 46.36184850000001 9.8461805 46.36098799999999 9.832073500000002 46.35812100000001 9.8309345 46.350685 9.8199985 46.34854949999999 9.809403999999999 46.34420299999999 9.802398 46.34099470000001 9.7845034 46.33546100000001 9.778579499999998 46.335913500000004 9.769648 46.344415 9.7576285 46.34789249999997 9.747367 46.35182000000003 9.7435325 46.35031299999997 9.7358385 46.344268 9.726695 46.34074000000001 9.7231505 46.332697499999995 9.727061499999998 46.331259999999986 9.7233375 46.323980500000005 9.7173255 46.321668999999986 9.7182685 46.319694 9.726010999999998 46.3132755 9.7258225 46.31001499999999 9.7244755 46.30628150000001 9.718219 46.29291839999999 9.7144511 46.29173500000002 9.710146 46.29081049999999 9.7027055 46.293959 9.6940995 46.293835 9.6886605 46.297094500000014 9.681814 46.299980500000004 9.6812475 46.30304850000002 9.6765125 46.29989950000001 9.670003000000001 46.29631199999997 9.669252500000002 46.296052 9.659976 46.29254700000001 9.651024 46.28981350000001 9.6497065 46.28615400000001 9.639238 46.28843050000003 9.624501000000002 46.287364499999995 9.618829 46.294648000000024 9.6104395 46.295710000000014 9.599309500000002 46.29350549999998 9.592726 46.29492450000001 9.589966500000001 46.294904 9.579259 46.29905600000001 9.5730955 46.3027075 9.562162 46.30629299999998 9.55982 46.30597 9.5543925 46.302379099999996 9.5495294 46.3080995 9.5391325 46.326842500000026 9.5186675 46.33260250000001 9.516721 46.33234200000001 9.5142325 46.35148050000001 9.5084725 46.3561665 9.5005305 46.36410299999997 9.496424 46.367335 9.483018999999999 46.37123750000001 9.479331 46.370653000000004 9.476028500000002 46.375970499999994 9.4608135 46.379039000000006 9.462817 46.38349149999999 9.461739 46.38426199999998 9.465143 46.38894049999999 9.4686535 46.412181000000004 9.461561 46.41591600000004 9.4563035 46.420777499999986 9.4542615 46.43670850000001 9.4570765 46.44253549999999 9.4606775 46.463333999999975 9.4590355 46.46964750000001 9.465402 46.48047199999999 9.462247499999998 46.47998049999998 9.449702499999999 46.484376999999995 9.449096 46.48484450000004 9.461036499999999 46.49764299999998 9.4628085 46.505487500000015 9.461066 46.50778249999999 9.464343 46.508351000000005 9.458546 46.50532150000001 9.455071 46.497975999999994 9.4341325 46.48860049999999 9.424823500000002 46.485938000000004 9.4264305 46.476665499999996 9.424429 46.46721250000002 9.413625 46.466791 9.4107885 46.47308850000002 9.3897835 46.48214300000001 9.3851645 46.483948 9.377788 46.489419 9.371252 46.49446649999999 9.3683745 46.49977150000001 9.37333 46.503551000000044 9.3734335 46.50950500000002 9.3623465 46.50426399999998 9.355109 46.505368000000004 9.351115 46.503804 9.3390805 46.50597549999998 9.3375045 46.50413800000001 9.311049 46.497075499999994 9.290703 46.49669499999999 9.2827395 46.48746299999999 9.278994 46.483698000000004 9.274375 46.479103500000036 9.2775535 46.466132500000015 9.2736405 46.4610055 9.277897 46.45153299999998 9.266221 46.44947749999997 9.252794 46.44679450000004 9.2470025 46.43101250000001 9.249851 46.425004 9.260832 46.420585500000044 9.263527 46.418180999999976 9.2696465 46.4188455 9.274534 46.4130615 9.280476 46.40509700000001 9.2821175 46.403434499999975 9.278612 46.401535499999994 9.2816925 46.39495149999999 9.2754055 46.38907649999999 9.27849 46.38629499999999 9.2835185 46.383651499999985 9.283506 46.37346400000001 9.27519 46.37142549999999 9.2771495 46.36781100000002 9.2760725 46.366607999999985 9.278838 46.3578435 9.28253 46.35565249999999 9.2965085 46.35146099999997 9.297838 46.34911249999999 9.2961445 46.343647000000004 9.2999765 46.33588750000004 9.292313 46.331871500000005 9.2935145 46.326456500000035 9.3001415 46.32325 9.295892 46.317239 9.294728 46.31438850000001 9.2852885 46.30922100000001 9.281611 46.29691249999999 9.285065 46.28954250000001 9.2719655 46.28216599999999 9.2677635 46.27856299999999 9.259212 46.26943850000001 9.2570475 46.26739199999997 9.2521175 46.262388999999985 9.2531475 46.25617350000002 9.2490965 46.2514085 9.2513415 46.2475335 9.248358 46.23970350000002 9.249802 46.23203750000002 9.2464385 46.233416500000004 9.2355305 46.2288935 9.2209065 46.223839999999996 9.2229975 46.2142705 9.2188305 46.210748499999994 9.2144015 46.20830599999999 9.202173 46.193625 9.1948445 46.187010499999985 9.198089 46.184056 9.194925 46.178438 9.1940385 46.1691725 9.1810995 46.17094350000002 9.1727465 46.17174299999999 9.1704465 46.17136299999996 9.1686665 46.169601 9.1593775 46.16216349999999 9.156579 46.1533225 9.1345095 46.134817999999996 9.1214755 46.13540649999996 9.117079 46.131970499999994 9.10471 46.12671850000001 9.0997915 46.125782000000044 9.089215 46.1212415 9.078689 46.11810299999999 9.0725175 46.090069 9.089146 46.08569349999999 9.0894325 46.07874100000001 9.0841955 46.075916000000035 9.0790725 46.06520169999999 9.0783211 46.062513499999994 9.073897 46.060667499999994 9.060423 46.06236400000003 9.0502305 46.058971499999984 9.044785 46.05894249999997 9.039377 46.05303200000003 9.028804 46.052694 9.022682 46.04973099999998 9.017218 46.043188499999985 9.0169695 46.03728799999999 9.009525 46.029799000000025 9.007594 46.015908800000005 9.0226588 46.00092749999996 9.0244898 45.993626000000006 9.028461 45.992751999999996 9.02289 45.98953899999998 9.022502 45.98765 9.0180785 45.98790249999999 9.0113585 45.9831815 9.0111415 45.980297500000006 9.0073435 45.98051100000001 8.995348 45.97281200000003 8.995821 45.971641500000004 8.99107 45.972932000000014 8.9885445 45.96655150000001 8.9940255 45.96054800000002 9.013964 45.94917649999999 9.017267 45.943843199999975 9.0122889 45.94151099999999 9.013568 45.93714800000001 9.0224785 45.928442099999984 9.0191952 45.928747499999986 9.0261575 45.926429799999994 9.0298123 45.9274935 9.0427355 45.92208099999996 9.049433 45.920428500000014 9.0490875 45.92094800000001 9.059905 45.916484 9.0590625 45.91279340000003 9.0684974 45.910634500000015 9.0678085 45.912833000000006 9.072649 45.911417 9.076576 45.90338550000001 9.0763465 45.899299499999984 9.0769315 45.90220500000001 9.086842 45.9006622 9.089026 45.89689699999997 9.0888035 45.895962999999966 9.085173 45.891796 9.0816435 45.89202800000001 9.0779545 45.8884645 9.079459 45.8850807 9.0778376 45.88175849999999 9.07146 45.87539050000004 9.0663865 45.8751575 9.0572345 45.873565499999984 9.054807 45.86800100000002 9.053696 45.8626175 9.0491785 45.85552150000001 9.051365 45.85318300000006 9.048236 45.85221250000001 9.0507745 45.849594499999995 9.0453995 45.84659149999999 9.0438115 45.84649250000001 9.0406285 45.842029999999994 9.038652 45.839658499999985 9.0354315 45.83552399999999 9.0378315 45.8246905 9.0309525 45.82301699999999 9.034462 45.82083349999999 9.0313895 45.8219225 9.022372 45.820693500000004 9.0213315 45.81797000000003 9.016526 45.82291649999999 8.998435 45.82197049999999 8.9939145 45.82620850000001 8.994115 45.834944500000006 8.9974875 45.83533700000001 8.9898905 45.838618499999995 8.9867485 45.8357115 8.981385 45.8366345 8.9761725 45.83304050000001 8.9742075 45.83235350000001 8.969984 45.836374000000006 8.9614595 45.83912749999996 8.9619675 45.84290899999999 8.9557735 45.84277799999998 8.946799 45.83890499999998 8.9328775 45.83337549999999 8.9290345 45.83419649999999 8.920476 45.830445 8.912147 45.842229 8.914226 45.860962 8.9325365 45.8637143 8.9393655 45.866978500000016 8.9453015 45.87034299999999 8.9420595 45.867305999999985 8.937027 45.870576700000015 8.9341441 45.885099999999966 8.9319025 45.895763999999986 8.9215375 45.90370249999995 8.924843 45.908998 8.9202431 45.914422599999995 8.9161879 45.91777250000001 8.914312 45.91774000000001 8.907148 45.93301450000001 8.892732 45.947788 8.898775 45.959014999999994 8.893755 45.9568515 8.881602 45.9628352 8.8665315 45.965405000000004 8.864875 45.96623249999999 8.8599296 45.97038649999999 8.8537154 45.97617500000001 8.8468215 45.97734650000004 8.8435515 45.981471 8.842698 45.98165949999998 8.8401025 45.98413249999999 8.8393015 45.985194500000006 8.834186 45.98795999999999 8.831639 45.98766699999999 8.8235925 45.987296000000015 8.8218605 45.99037799999999 8.813912 45.99205950000001 8.795799 45.99188549999997 8.792432 45.988609499999995 8.790857 45.98907550000001 8.785907 46.00810849999996 8.7930945 46.0121905 8.797105 46.02193349999999 8.805911 46.025497 8.819678 46.034227999999985 8.8281665 46.04161099999999 8.8300335 46.040569500000004 8.8327085 46.04377499999998 8.835439 46.046469 8.828817 46.05136949999999 8.8345335 46.04851400000001 8.8441915 46.06159149999996 8.8545945 46.07564150000002 8.852114 46.07575299999996 8.8475165 46.080498500000004 8.8414395 46.08286100000001 8.833761 46.09728499999997 8.8153575 46.101283499999994 8.806036 46.09471099999999 8.7997835 46.094183500000014 8.783036 46.10071450000004 8.7683025 46.1014175 8.7602275 46.10515179999999 8.7556759 46.12222249999999 8.7423305 46.110326999999984 8.724405 46.097272000000004 8.713936 46.101609499999995 8.698031 46.10210249999997 8.6858525 46.110379999999964 8.6792735 46.108826499999964 8.6700255 46.11269149999998 8.657714 46.1225345 8.6478995 46.12332649999999 8.648031 46.122331 8.6288925 46.121669499999996 8.6118585 46.1245275 8.611172 46.13287500000001 8.6097165 46.14277849999999 8.595678 46.14296999999999 8.592897 46.146004000000005 8.593127 46.149557500000014 8.599627 46.15312 8.5999015 46.153539999999964 8.6033675 46.15536900000001 8.603007 46.15668149999999 8.5879885 46.16159700000003 8.5873235 46.16264150000001 8.576414 46.166930500000035 8.572122 46.17705849999999 8.569695 46.1837975 8.5637275 46.186147000000005 8.55405 46.192027999999965 8.553586 46.19737649999999 8.542448 46.20426599999999 8.536403 46.21828249999999 8.532443 46.221850500000016 8.521686 46.2201585 8.515136 46.22910200000001 8.492382 46.23037150000002 8.477527 46.23289500000001 8.4686835 46.24455050000003 8.4641065 46.24789899999999 8.4472735 46.250625000000014 8.4431735 46.254151500000006 8.4422765 46.25801949999999 8.4478905 46.26139499999999 8.4484915 46.2637555 8.4558805 46.27432400000001 8.449771 46.28566599999999 8.4363045 46.291818000000006 8.433995 46.29830050000001 8.4277395 46.302209000000005 8.4330205 46.304119000000014 8.4405335 46.30805000000001 8.43912 46.310137 8.441792 46.31949449999999 8.4437215 46.32126199999996 8.453846 46.32725049999999 8.455656 46.32840899999999 8.4604155 46.333762500000006 8.465357 46.33681300000001 8.463289 46.34465399999999 8.464363 46.353256499999986 8.4615615 46.362551499999995 8.4702345 46.36831749999999 8.466813 46.3800555 8.466513 46.38667649999999 8.4608375 46.39592300000001 8.471172 46.40486799999999 8.4630535 46.41174399999997 8.4683155 46.4231795 8.45687 46.42839950000001 8.4607595 46.43476049999998 8.4575325 46.442679 8.4662415 46.44623899999999 8.4615545 46.450645699999995 8.4619988 46.45535100000001 8.452797 46.461844499999984 8.4500125 46.46371600000003 8.445719 46.46266650000001 8.4386375 46.46429549999999 8.4385285 46.458763000000005 8.4170995 46.458736999999985 8.408417 46.45474200000001 8.402231 46.454560000000015 8.3959535 46.45157549999999 8.392958 46.45215849999997 8.384717 46.45080300000001 8.379003 46.453126499999996 8.3752945 46.45192249999997 8.366936 46.44696299999998 8.355762 46.441643 8.352464 46.42571400000003 8.325441 46.42363149999997 8.3149635 46.425850999999994 8.3074915 46.417438000000004 8.2988965 46.41424600000002 8.298948 46.408109499999995 8.288934 46.40245049999996 8.3035475 46.402026000000006 8.3066035 46.40402450000002 8.3096725 46.3989655 8.3157325 46.394000000000005 8.317292 46.389825 8.3141565 46.386444599999976 8.3186947 46.383949 8.3149465 46.37706600000001 8.3128995 46.374074500000006 8.3000135 46.36913849999999 8.2897935 46.3636305 8.2842825 46.366862 8.273075 46.36402300000003 8.2637725 46.360849 8.260755 46.35710900000001 8.265034 46.3518435 8.2658795 46.34866249999999 8.2599275 46.3459665 8.2628835 46.3464415 8.2529435 46.340757999999994 8.2500425 46.340363999999965 8.235424 46.33444800000001 8.2239955 46.33286050000001 8.225024 46.33024649999999 8.221613 46.32641050000001 8.22507 46.319661999999994 8.214654 46.316227999999995 8.2149275 46.312589 8.2112405 46.30927700000001 8.212012 46.30602249999998 8.2053895 46.302250499999985 8.1987505 46.30423300000001 8.192956 46.29738950000001 8.178897 46.295884 8.1614215 46.301537499999995 8.1470015 46.301929 8.141117 46.301766999999984 8.1375635 46.29475350000001 8.1288565 46.29187350000001 8.120857 46.281143499999985 8.113563 46.27964700000004 8.105455 46.27370100000002 8.1004975 46.266617499999995 8.085928 46.2621135 8.0860575 46.260628999999994 8.080412 46.25428299999999 8.086245 46.25241250000002 8.1013505 46.249468500000035 8.1016175 46.24950449999997 8.1101545 46.23873800000004 8.113034 46.23600299999998 8.1153275 46.236031499999996 8.120479 46.229622000000006 8.1242735 46.226147999999995 8.1388775 46.21159549999999 8.1435255 46.202821 8.1513925 46.1911035 8.153295 46.18222750000004 8.1655095 46.17689060000001 8.1651559 46.17406399999996 8.1585815 46.162503000000015 8.1498785 46.1569375 8.1497415 46.14763099999999 8.1553445 46.13682300000002 8.1443895 46.135271999999986 8.125187 46.130346 8.1154155 46.11743949999999 8.113807 46.111628499999995 8.108233 46.11098999999999 8.099867 46.1084075 8.0971445 46.10545000000002 8.081798 46.10599549999998 8.069219 46.10129549999999 8.0543095 46.10227549999999 8.0491265 46.09992549999998 8.0430585 46.1008406 8.0343476 46.09525099999999 8.0339015 46.08960050000002 8.029584 46.08092149999996 8.029099 46.074708499999986 8.022531 46.06936600000003 8.021662 46.067544500000025 8.024564 46.062984 8.0238735 46.04404499999998 8.0354145 46.03896550000002 8.0220525 46.03120999999999 8.0118915 46.024704499999984 8.017501 46.018853500000006 8.0107585 46.01586350000002 8.0132475 46.01196999999999 8.012413 46.01221100000001 8.001084 45.99987350000001 7.993937 45.99593350000001 7.989094500000001 45.99945349999999 7.977114 45.996072999999996 7.957335 45.99760650000002 7.949491500000001 45.99597850000001 7.9326335 45.996967299999994 7.9086896 45.978635 7.893849000000001 45.97386 7.877425 45.964009000000004 7.8818114999999995 45.95793199999997 7.874891500000001 45.954369499999984 7.878907 45.94911350000001 7.877206500000001 45.947363499999994 7.8703745000000005 45.9363415 7.868500000000001 45.927091700000005 7.8770243 45.920466000000005 7.873073499999999 45.91957249999999 7.8663385 45.91669950000002 7.863576300000001 45.92086950000001 7.858500500000001 45.92172450000001 7.8367205 45.92496399999996 7.831447000000001 45.92696000000001 7.820390500000001 45.91739089999999 7.799501900000001 45.920000500000015 7.793984000000001 45.924949 7.790812999999999 45.93106649999996 7.7765605 45.93711749999997 7.769268 45.94100849999998 7.747751499999999 45.934878 7.745828999999999 45.92829900000001 7.736870999999999 45.9239905 7.7350975 45.923790000000025 7.7204805 45.927734499999985 7.7163335 45.92822799999999 7.712673500000001 45.932908999999995 7.711274 45.93477549999997 7.7073705 45.948155499999984 7.709769999999999 45.9540255 7.6996915 45.95490749999999 7.6876185 45.957772000000034 7.67963 45.96504749999997 7.676995 45.9739855 7.6681735 45.976631999999995 7.657467 45.9701115 7.6395005 45.972368500000016 7.619635 45.96939090000001 7.610003299999999 45.9705165 7.588791 45.974389 7.581727500000001 45.986012500000015 7.5786074999999995 45.987573999999995 7.574703 45.98568750000001 7.561997000000001 45.986556500000006 7.550134 45.9837665 7.545698500000001 45.97617700000001 7.541536999999999 45.96313950000001 7.546722000000001 45.9569425 7.542764 45.95494600000001 7.538433999999999 45.9568615 7.535464499999999 45.95649349999999 7.527978500000001 45.96232450000002 7.5176275 45.957967999999994 7.5075315 45.96241850000004 7.499186 45.95568850000001 7.4934395 45.955809999999985 7.487446 45.952406999999994 7.477937 45.947190000000006 7.471459499999999 45.93662749999996 7.4749315 45.93405949999999 7.471644000000001 45.93555700000002 7.458733999999999 45.932147999999984 7.4558995 45.9317465 7.444620500000001 45.920225000000016 7.434416999999999 45.915402 7.427056500000001 45.90871150000001 7.410806 45.909088499999996 7.405508 45.911474999999996 7.401733 45.908473000000015 7.397882999999999 45.90486099999998 7.3971965 45.897155500000025 7.386337499999999 45.89650449999999 7.382384500000001 45.90413799999999 7.3660675 45.90332749999999 7.3612165 45.907242000000025 7.356449499999999 45.910642499999994 7.3564625 45.91158950000002 7.350535999999999 45.91524050000001 7.344303 45.9105165 7.3307235 45.910229500000014 7.323765 45.91167200000001 7.318111999999999 45.91657950000001 7.3161745 45.91722149999998 7.301557 45.921795900000006 7.294512299999999 45.9157505 7.285315 45.900667999999996 7.2767715 45.89985150000001 7.271476 45.888217999999995 7.256877500000001 45.888465499999995 7.2531435 45.893134 7.2494865 45.890063999999995 7.24054 45.89202 7.228292 45.88976800000003 7.225684000000001 45.8887795 7.2164395 45.883872 7.215700499999999 45.88018099999999 7.206093000000001 45.87647749999999 7.203609 45.87551350000004 7.200118000000001 45.87034299999999 7.197700500000001 45.86308249999999 7.200823499999999 45.8602745 7.196588500000001 45.85867950000002 7.1906025 45.863512000000014 7.1789075 45.86285499999997 7.175214500000001 45.87149950000003 7.161742 45.87668450000001 7.164098999999999 45.879249500000014 7.153543499999999 45.872709499999985 7.1352765 45.866735000000006 7.131419 45.859192500000006 7.117904 45.85927050000004 7.101174999999999 45.87206599999996 7.092142999999999 45.8758335 7.095292 45.88529299999999 7.0799395 45.89017899999999 7.076461500000001 45.895182000000005 7.0766055 45.89992799999999 7.064193 45.909366000000006 7.064455499999999 45.91338300000001 7.060583500000001 45.915546000000006 7.053107000000001 45.922413000000006 7.044886 45.930950499999994 7.041839 45.9384115 7.035671999999999 45.944796999999994 7.038539 45.95427299999997 7.0376 45.960174499999994 7.018369 45.969391 7.009050000000001 45.973304499999955 7.010733 45.976249499999966 7.020972 45.98054100000002 7.022241499999999 45.98670950000002 7.015547 45.98735450000004 7.012056 45.9972765 7.010530999999999 46.001209500000016 7.005619 45.999138000000016 6.999714 46.005127000000044 6.984753000000001 46.02024850000004 6.980931000000001 46.025795000000016 6.971083 46.03118899999998 6.966569 46.03053649999998 6.962905999999999 46.05173099999999 6.949742 46.050956499999984 6.943008 46.05513400000001 6.935878 46.06403749999998 6.937628 46.06672299999997 6.933152999999999 46.06417099999999 6.928431 46.06472400000001 6.923767 46.050640499999986 6.908989000000001 46.04809149999997 6.894678 46.04246150000003 6.890639000000001 46.044479499999994 6.882988999999999 46.047695000000004 6.875638500000001 46.05556849999999 6.873080999999999 46.06945399999998 6.880819000000001 46.07388320000001 6.8914787 46.078670500000015 6.888369 46.08504500000001 6.891781000000001 46.095207000000016 6.8829555 46.10822300000001 6.895308 46.11293799999996 6.893258 46.124055099999964 6.8994739 46.1253815 6.890419 46.1229285 6.882292 46.125782000000044 6.876219 46.1265525 6.851372 46.128963500000026 6.843121999999999 46.13202989999999 6.8415572 46.13106899999997 6.819328 46.129323400000004 6.8152311999999995 46.136101 6.807956 46.13538349999999 6.8009390000000005 46.136798999999996 6.797889 46.154315999999994 6.790425000000001 46.16319649999997 6.792314000000001 46.17280199999999 6.805625000000001 46.17784900000001 6.807331 46.181419500000004 6.812422 46.19646850000001 6.8069749999999996 46.2031365 6.803564 46.2138865 6.810092 46.223460999999986 6.821667 46.22996899999998 6.820745 46.232177500000006 6.821311 46.234245499999986 6.830511 46.240696000000014 6.837019000000001 46.24830650000001 6.840119 46.25465 6.855108500000001 46.25889600000002 6.854517 46.26587299999997 6.859961 46.273799999999994 6.859064 46.28059400000001 6.864807999999999 46.29043200000001 6.858923500000001 46.292381500000005 6.854228 46.28998200000004 6.847147 46.299792999999994 6.834328 46.29984300000001 6.830533000000001 46.30277649999999 6.828208 46.30605299999999 6.830028000000001 46.315338 6.819344000000001 46.320651999999995 6.806631 46.319851 6.8006585 46.332802000000015 6.796461 46.3329315 6.784402999999999 46.34440599999999 6.779319499999999 46.34728770000001 6.774688499999999 46.35520550000001 6.770442 46.36118299999998 6.771636 46.36647049999999 6.780803 46.367142 6.791786 46.37670149999997 6.803819 46.3831175 6.805885999999999 46.38694000000001 6.8017935000000005 46.394070699999986 6.8052021 46.42715450000003 6.821064 46.454334500000016 6.681858 46.4563675 6.519104 46.415806 6.425619 46.403717 6.3351895 46.36042000000003 6.252957 46.3435825 6.24136 46.3294295 6.231694 46.31187800000001 6.219547 46.304564399999975 6.2413903 46.301552000000015 6.248842 46.3002625 6.247178000000001 46.294456499999995 6.248481 46.29167949999999 6.251883 46.2878915 6.251224999999999 46.285083499999985 6.244290000000001 46.28179549999999 6.237864 46.27661899999998 6.237747 46.26229500000002 6.250052 46.25487500000003 6.260860999999999 46.251705000000044 6.260172 46.24769950000001 6.266508000000001 46.25452050000001 6.284622 46.25623700000003 6.284043999999999 46.264599000000004 6.294877999999999 46.263679999999994 6.296544 46.25595450000003 6.295236 46.2548635 6.300889 46.25618000000003 6.310281 46.25502399999999 6.308533 46.251243500000015 6.306055499999999 46.2499655 6.309328 46.2440455 6.310210999999999 46.22493 6.2944640000000005 46.223464999999976 6.2917275 46.215248 6.276372 46.213390499999974 6.265539000000001 46.20499050000001 6.24875 46.20655450000004 6.2450079999999994 46.204822500000006 6.243419 46.20636350000001 6.234133 46.2035635 6.230119 46.201415999999966 6.223854000000001 46.193794499999996 6.214244 46.192184499999996 6.206817 46.18377749999999 6.198424999999999 46.18142299999997 6.189075 46.178226499999994 6.186103 46.16619450000002 6.188839 46.158142 6.175417 46.151527500000014 6.152244 46.14591999999999 6.146694 46.14481749999999 6.1449 46.147007 6.141611 46.14115899999999 6.135542 46.1404685 6.126619 46.1426735 6.121164 46.143966500000005 6.099131 46.1516685 6.091844 46.14930749999996 6.0745585 46.151268000000044 6.051922 46.147414999999995 6.048703 46.14094549999999 6.047811 46.14106749999999 6.042919 46.134765000000016 6.035725 46.139365999999995 6.031981000000001 46.14070400000003 6.0243864 46.14294449999997 6.015263999999999 46.14194500000002 6.003766999999999 46.144428500000004 5.993983 46.1421349 5.9827235 46.13587949999999 5.980358 46.13262950000001 5.976353 46.12958549999999 5.965283 46.130302 5.960917000000001 46.12794809999997 5.957313200000001 46.1320887 5.9560876 46.13718399999999 5.965939 46.14469550000001 5.964661 46.15617510000001 5.973363000000001 46.16032400000003 5.9762293 46.172680000000014 5.981867 46.173564999999996 5.984863999999999 46.1707375 5.988297 46.17686119999999 5.9923112 46.179328999999996 5.99165 46.18289549999997 5.995222 46.1874315 5.991342 46.196968200000015 5.9637 46.19802770000001 5.9642155 46.202526000000006 5.972953 46.2066385 5.969278 46.214751999999976 5.974414 46.21690750000002 5.978375 46.21550350000001 5.993136000000001 46.22239300000001 5.9914325 46.22240049999999 5.996338999999999 46.220115899999996 6.0000851 46.223468999999994 6.006867 46.22915649999999 6.010006 46.228992500000004 6.013508 46.2305825 6.012864 46.2318305 6.016677999999999 46.233238 6.0251925 46.238426000000004 6.033722 46.233104499999996 6.042397 46.2314375 6.046336 46.24517800000001 6.061139 46.24561649999998 6.0634575 46.24107749999999 6.069625000000001 46.24704349999999 6.088136 46.2375375 6.101817 46.240688499999976 6.106342 46.23966200000001 6.109014 46.250572000000034 6.12358 46.261150499999985 6.120089999999999 46.26358400000001 6.1182 46.264759 6.120130999999999 46.26566300000002 6.116042 46.27021400000001 6.110389 46.27246099999999 6.113458 46.278385000000014 6.103639 46.2839735 6.10455 46.28485499999999 6.102367 46.294182000000006 6.1132555 46.29430399999998 6.118958 46.2971685 6.121142 46.3077165 6.119092000000001 46.312404500000014 6.119808000000001 46.31726850000001 6.124369 46.317509099999995 6.1257606000000004 46.32118600000001 6.126711000000001 46.32466010000002 6.1314595 46.3331263 6.1377108 46.33463710000001 6.1392202000000005 46.33558249999999 6.137258 46.3393135 6.138619 46.342712500000005 6.149157999999999 46.34727849999999 6.151547 46.35096500000003 6.1580323 46.35758200000001 6.15935 46.36643219999999 6.170156500000001 46.37953949999999 6.158578000000001 46.37761699999999 6.156664 46.377395500000006 6.149839 46.387817499999954 6.135853 46.399925499999995 6.113564 46.396698000000015 6.114083 46.39971550000001 6.105511 46.408607500000016 6.098221499999999 46.416223900000006 6.064025899999999 46.431843000000015 6.074907999999999 46.43956399999999 6.084172 46.44314600000001 6.086244 46.44737650000002 6.084431 46.4533275 6.074894 46.457325 6.076842 46.459934000000004 6.073467 46.46575150000001 6.0728275 46.481587899999994 6.0971403 46.50990349999998 6.112961 46.53057499999997 6.137494 46.52801149999999 6.144202999999999 46.536617500000006 6.153417 46.53935599999997 6.148575000000001 46.545252000000005 6.1564804 46.57665650000001 6.1109610000000005 46.584014999999965 6.121743999999999 46.5894735 6.126113999999999 46.59711849999999 6.138842 46.603759999999994 6.153778 46.60990150000001 6.161225 46.616161500000004 6.179136 46.620205 6.180358000000001 46.62818149999998 6.196011 46.634254500000026 6.19985 46.6360665 6.208083 46.644899699999996 6.2194419 46.64811700000001 6.227711 46.6549455 6.233578 46.67647199999999 6.267544 46.67923350000001 6.270553 46.68272000000002 6.269439000000001 46.69045650000001 6.2831085 46.698581700000034 6.3074067 46.706039499999974 6.324135999999999 46.710376999999966 6.342011 46.71514500000001 6.352424499999999 46.72308749999999 6.360242 46.72191650000002 6.364485999999999 46.724357499999996 6.371761 46.728816999999964 6.371478 46.729255499999994 6.368117 46.730365999999975 6.370067000000001 46.73210900000001 6.3854845 46.738151000000016 6.391610999999999 46.743209999999976 6.388475 46.7478715 6.394511 46.75069450000001 6.400689 46.75001550000002 6.404272 46.75276550000001 6.417144000000001 46.75708800000001 6.430822 46.762573 6.439425 46.76637249999999 6.438902 46.773987000000005 6.4516915 46.778572499999996 6.451786 46.78831099999999 6.458442499999999 46.802040000000005 6.43463 46.81232850000001 6.430997 46.81626499999999 6.440680999999999 46.824123499999985 6.439606 46.831878500000045 6.442506 46.8515515 6.460010999999999 46.8755415 6.462804 46.89041499999996 6.464458 46.900982 6.4578 46.92165 6.435789 46.928455499999956 6.432750000000001 46.933410699999996 6.444752199999999 46.9430735 6.459481 46.95561810000001 6.471642 46.9671635 6.486020300000001 46.974178600000045 6.4966990000000004 46.966140499999995 6.5059640000000005 46.97080600000001 6.518606 46.979416000000015 6.563492 46.99078750000004 6.5919305 46.992526999999995 6.596142 46.991626499999995 6.616914 46.99840950000001 6.6337105 47.006561500000004 6.643747 47.0263405 6.658475000000001 47.035229000000015 6.677939 47.038803 6.698958499999999 47.0523225 6.7197439999999995 47.053458500000005 6.7124925 47.057998500000025 6.708872 47.05888749999997 6.700968999999999 47.06640999999999 6.691792 47.073868000000004 6.705781000000001 47.079155000000014 6.707525000000001 47.081501 6.702785999999999 47.08847800000001 6.715808 47.091792999999996 6.725930999999999 47.08961099999999 6.731325 47.090482399999985 6.7390397 47.09238449999998 6.743385999999999 47.09645450000002 6.746044 47.1086425 6.739968999999999 47.109610299999986 6.7441387 47.12033450000001 6.765146999999999 47.1210595 6.775303000000001 47.127027999999996 6.792348 47.130206999999984 6.804992000000001 47.13538349999996 6.808631 47.135479000000004 6.815083 47.14635099999998 6.8285860000000005 47.15034850000001 6.839611 47.154289000000006 6.841661000000001 47.15646000000001 6.849975 47.16528890000001 6.8589121 47.1664045 6.845239 47.17139799999998 6.841327999999999 47.180000500000006 6.8637809999999995 47.185287500000015 6.867591999999999 47.18533350000004 6.873894 47.18956749999998 6.873714 47.200031499999994 6.879939 47.205070500000005 6.889444500000001 47.218192999999985 6.9103140000000005 47.222133499999984 6.923847000000001 47.228488999999996 6.927531 47.23088450000003 6.932999999999999 47.23106000000004 6.939418999999999 47.234526999999986 6.9427387000000005 47.238178500000004 6.943239 47.24297470000002 6.9554785 47.2534675 6.946507999999999 47.25967800000001 6.951108 47.26903949999999 6.951943999999999 47.2865065 6.940742000000001 47.292392500000005 6.953224999999999 47.29275100000004 6.9685109999999995 47.291424000000006 6.973294 47.296367499999974 6.976575000000001 47.29612749999998 6.996572 47.30140699999998 7.003336000000001 47.30129609999997 7.007402700000001 47.313984000000005 7.016214 47.31991199999999 7.013608 47.3208315 7.009719 47.324367499999994 7.009739 47.3284075 7.034439 47.32672099999999 7.045719000000001 47.33439250000001 7.056631000000001 47.33689900000002 7.052925 47.339878 7.059147 47.34373449999998 7.061636 47.34722149999999 7.0499245 47.351661500000006 7.052586 47.36184299999999 7.048925 47.364029000000016 7.043322000000001 47.36358949999999 7.0344750000000005 47.36787749999999 7.0336515 47.3695185 7.033335999999999 47.370311499999985 7.020406 47.372883 7.017908 47.37149449999998 7.013417 47.372794999999996 7.012343999999999 47.367558 7.006125 47.363449 6.995997 47.3635065 6.983092 47.35985949999997 6.974433 47.359768 6.951407999999999 47.35755549999999 6.941756 47.3584065 6.932978000000001 47.3553125 6.921100000000001 47.35940550000001 6.901847 47.35770400000001 6.899225 47.358611999999994 6.895747 47.35639549999999 6.894472 47.352810000000005 6.8847689999999995 47.35244 6.879806000000001 47.35743350000004 6.878969 47.36701199999996 6.884849999999999 47.37315749999999 6.883669 47.379940000000005 6.895586 47.38166799999999 6.894963999999999 47.382942000000014 6.905180499999999 47.38618450000001 6.9119395 47.38945749999999 6.913669 47.39618300000001 6.909542 47.39736199999999 6.915439 47.40323999999998 6.917817 47.40465950000001 6.9136169999999995 47.40650199999999 6.919436 47.405204999999995 6.920874999999999 47.40647899999999 6.9385995 47.416027000000014 6.941681000000001 47.433704500000005 6.939186000000001 47.435077500000034 6.954618999999999 47.4337275 6.957753000000001 47.4356995 6.96365 47.44705999999999 6.970293999999999 47.44899000000001 6.981431 47.447895000000045 6.990261 47.4537435 7.00155 47.456028 7.000947 47.45663450000001 6.997528000000001 47.46007900000001 6.9980530000000005 47.461761499999994 7.001092 47.46687750000001 7.000361 47.46642700000001 6.991778000000001 47.4712485 6.992925 47.476211500000005 6.986539 47.487262499999986 6.988467 47.4942705 6.982913999999999 47.49358000000001 6.986303 47.49995050000001 7.000853 47.504222999999996 7.024406 47.50133149999999 7.0272395 47.4975015 7.036975000000001 47.49817300000001 7.044802999999999 47.49519350000003 7.051317000000001 47.49521200000001 7.060406 47.4922675 7.071342 47.488167000000004 7.074877999999999 47.494834999999995 7.091671999999999 47.495105499999994 7.111858 47.503589500000004 7.128017 47.5020945 7.138075 47.497116000000005 7.1504829999999995 47.49077199999999 7.159363500000001 47.48934550000001 7.169347 47.49388099999999 7.201083 47.49170699999999 7.202327999999999 47.488201000000004 7.190864 47.46813950000001 7.177603 47.4641762 7.178829400000001 47.45813990000002 7.178262199999999 47.4434545 7.170422 47.438755000000015 7.192267 47.43542099999999 7.196180499999999 47.434894499999956 7.206239 47.43977749999999 7.225569 47.43688950000001 7.235908 47.43383800000001 7.238603 47.42879499999998 7.2385744999999995 47.42684550000001 7.245017000000001 47.4202995 7.245588999999999 47.423992 7.254164 47.427043999999995 7.270469 47.434627499999976 7.282563999999999 47.43312049999997 7.292203 47.43873199999999 7.302975 47.438961000000035 7.324572 47.4398535 7.326465999999999 47.44143300000002 7.329825 47.4409105 7.338706 47.43535600000001 7.347222 47.43189250000003 7.380894 47.43539799999999 7.400356000000001 47.43551249999999 7.402983000000001 47.437862499999994 7.402847 47.440201 7.406581000000001 47.442039499999964 7.413942 47.44638800000001 7.421139500000001 47.4508285 7.423344000000001 47.453521499999994 7.428478 47.459282 7.430072 47.461723500000005 7.445019 47.47036 7.4552475 47.47279 7.455797 47.475307999999984 7.450483000000001 47.4742205 7.447819 47.478473500000035 7.443783 47.48246 7.4293689999999994 47.48018250000001 7.421236 47.488387999999986 7.4255439999999995 47.49797049999998 7.434775 47.48943700000001 7.454636000000001 47.489093999999994 7.462125 47.48044949999999 7.470896999999999 47.48230749999999 7.487628 47.48925400000002 7.497505999999999 47.490440500000034 7.502 47.49351899999999 7.501919 47.496826 7.510972 47.501945500000005 7.508725 47.50258250000002 7.5109055 47.50958249999999 7.509197 47.515987499999994 7.499164 47.521233000000024 7.497817 47.51462150000003 7.503519 47.517044 7.516753 47.515067999999985 7.518808 47.515232 7.523900000000001 47.51867300000001 7.523786 47.527717499999994 7.531475000000001 47.532306500000004 7.527814 47.53195199999999 7.524439000000001 47.534534500000035 7.519208 47.53260800000004 7.5161964999999995 47.5285265 7.509817 47.52848449999999 7.502432999999999 47.535240499999986 7.499042 47.53983299999999 7.499239 47.54297249999999 7.504519000000001 47.54476149999999 7.507889 47.546131 7.519233 47.55164350000001 7.525233 47.56339250000002 7.551786 47.56456399999996 7.5551595 47.56939299999999 7.558861000000001 47.57120499999996 7.556386 47.57261649999998 7.557483 47.57740849999999 7.566267 47.576145 7.574818999999999 47.575657000000035 7.584828 47.589878 7.589039 47.58482650000002 7.6049385 47.57779199999999 7.6045105 47.57683 7.619065 47.57944599999999 7.624522999999999 47.59131550000001 7.643203 47.59422250000003 7.6419325 47.5969685 7.645815999999999 47.59621799999999 7.64904 47.592044500000014 7.667261 47.592040499999996 7.675051 47.59849199999999 7.682847 47.600644999999986 7.693370000000001 47.58735999999999 7.6717545000000005 47.5850925 7.6720429999999995 47.58269250000001 7.680725 47.58092049999996 7.681114 47.57398549999999 7.6837435 47.57150050000001 7.6895305 47.5656175 7.6859705 47.571181000000024 7.6834375 47.565447000000006 7.675219499999999 47.56384800000001 7.677368999999999 47.563770999999974 7.6723384999999995 47.56588099999999 7.6701595 47.56242900000001 7.654705999999999 47.559883499999984 7.648155999999999 47.56401149999999 7.6362285 47.561113500000005 7.634097 47.552615 7.6453055 47.546996500000006 7.6515245 47.54484500000001 7.6613955 47.53661500000001 7.666803999999999 47.53355450000001 7.67529 47.532498000000004 7.6862235 47.5329035 7.6969815 47.539405000000016 7.713784499999999 47.54222900000002 7.72405 47.545027000000005 7.7526765 47.54837650000002 7.757851999999999 47.553296999999986 7.783334000000001 47.5574455 7.795672500000001 47.562637499999965 7.799482 47.5707525 7.8119955 47.587106000000006 7.8188200000000005 47.58656100000002 7.832744 47.58263649999998 7.837581000000001 47.582381 7.8472075 47.58735250000001 7.860485 47.588516 7.868769999999999 47.588872500000036 7.885044999999999 47.586371499999984 7.8940966 47.584053900000015 7.8979583 47.576923599999986 7.906522699999999 47.569016500000004 7.911530000000001 47.560816999999986 7.9073875 47.55542249999999 7.908518 47.54772650000001 7.917205500000001 47.54691650000001 7.932319 47.54448099999999 7.9404995000000005 47.54396500000004 7.9455505 47.545548 7.948642999999999 47.557116000000036 7.955421 47.558276000000035 7.960036499999999 47.557180500000015 7.964700999999999 47.555215000000004 7.977975999999999 47.556397499999974 7.999166 47.55497350000002 8.0072325 47.55454950000001 8.0082015 47.5504545 8.0195435 47.55529999999999 8.0460355 47.56342000000001 8.0592765 47.564490500000005 8.067313 47.56411299999999 8.071343 47.557436499999994 8.083569 47.557901999999984 8.090359 47.56102899999999 8.0971805 47.566363499999966 8.101439 47.57609900000003 8.102989 47.580723000000006 8.107204 47.583541 8.1127155 47.583286499999986 8.1261005 47.58404999999999 8.1364095 47.59078149999999 8.1383625 47.59498450000004 8.1472935 47.594154 8.159201 47.59430850000001 8.1655465 47.60195199999998 8.174452 47.60480949999999 8.184461 47.6162745 8.193912 47.62035850000001 8.201661 47.6199805 8.214005 47.6155119 8.2212491 47.60684979999999 8.2240473 47.605135500000046 8.225893 47.605396499999955 8.2293505 47.6127285 8.2382285 47.615223499999985 8.258417 47.613464300000004 8.2611483 47.609419 8.2651135 47.611617499999966 8.279824 47.6103195 8.2884835 47.60548 8.297631 47.594603500000034 8.2950295 47.58874500000002 8.298266 47.58364850000001 8.31029 47.578940999999986 8.3163515 47.572606500000006 8.324458 47.57039800000001 8.337175 47.569488500000006 8.3621045 47.565495 8.3835395 47.575016000000005 8.392099 47.577068 8.3995065 47.570742499999994 8.416288 47.567548999999985 8.4264345 47.567102000000006 8.437169 47.572355000000016 8.4558925 47.572212500000006 8.4641205 47.57786149999998 8.476828 47.577242600000034 8.4837482 47.577717699999994 8.4869211 47.5812014 8.4945405 47.587851 8.488619 47.587354000000005 8.4870125 47.583950000000016 8.468808 47.588036999999986 8.4648145 47.58830549999999 8.460419 47.59257199999999 8.461227 47.59728500000003 8.457047 47.60235549999999 8.4565995 47.603658499999995 8.468109 47.606893000000014 8.4713795 47.60847250000003 8.4702785 47.60769749999997 8.474989 47.61073099999999 8.4778125 47.615163499999994 8.4791385 47.613639500000005 8.483242 47.614475 8.493896 47.61750749999999 8.5082515 47.623845500000016 8.507306 47.62336500000001 8.514944 47.625587499999966 8.512608 47.63195000000002 8.5164495 47.63391999999999 8.515533 47.63447450000001 8.520817 47.63176849999999 8.5257255 47.63113849999999 8.538118 47.626094499999994 8.5385565 47.6269575 8.5430435 47.6252245 8.5441355 47.624562 8.557338 47.61676750000004 8.562801 47.61726949999999 8.5692955 47.612491500000004 8.5710365 47.611931 8.574408 47.60987399999999 8.566406 47.60537399999998 8.5660625 47.601382 8.561473 47.599432500000006 8.562841 47.59710300000003 8.5664905 47.598161000000005 8.5714195 47.59552149999999 8.574658 47.596823 8.577079 47.596134500000005 8.582355 47.6017765 8.587799 47.602226 8.5913965 47.60615899999999 8.592694 47.6055389 8.595596 47.611261799999994 8.6034488 47.6159825 8.6049595 47.628964999999994 8.5973905 47.64262750000003 8.595324 47.65242599999996 8.6077065 47.6493485 8.6126925 47.644137 8.613848 47.64209499999998 8.611146 47.641547 8.6044635 47.639467999999994 8.602787 47.637061500000044 8.606523 47.63801200000003 8.616754 47.641021499999994 8.623423 47.64872359999998 8.6282974 47.653306999999984 8.6279875 47.66152840000001 8.6144855 47.66075749999999 8.612818 47.66342349999999 8.608964 47.669003799999984 8.6063557 47.67212950000001 8.6066495 47.672807000000006 8.598066 47.66706049999999 8.593828 47.66640800000002 8.5873725 47.6616085 8.577711 47.66470699999999 8.570951 47.66533200000001 8.5646325 47.66994399999996 8.563654 47.66705999999999 8.5471585 47.66507200000001 8.540051 47.65706 8.5414315 47.65992399999999 8.533774 47.6632075 8.533378 47.660394999999994 8.5270095 47.65061399999996 8.533424 47.64578850000001 8.531527 47.6449815 8.522713 47.64749849999998 8.5133275 47.647055499999965 8.4931125 47.642104500000045 8.4942035 47.64206999999999 8.4923425 47.64509699999999 8.4873385 47.64420200000001 8.482706 47.649231499999985 8.4805195 47.64982499999999 8.4737635 47.64794899999998 8.4729355 47.644675000000035 8.477685 47.642341500000015 8.471116 47.639707999999985 8.477887 47.638307 8.473507 47.641293500000046 8.4674745 47.648559999999975 8.4637715 47.656075500000014 8.4671755 47.657044499999984 8.4656325 47.65269200000003 8.4573885 47.654843 8.453655 47.654739500000005 8.449051 47.65378200000001 8.4450905 47.65739049999999 8.4367715 47.666814999999986 8.423684 47.66627449999996 8.412355 47.67451349999999 8.405566 47.67872349999999 8.408517 47.679632 8.4160395 47.683865 8.420668 47.694255999999996 8.4121365 47.69546700000001 8.4063995 47.69806350000002 8.404426 47.709968299999986 8.4167944 47.71113199999999 8.4258785 47.718233 8.436732 47.717668499999974 8.4415515 47.71975599999999 8.440226 47.722961 8.4452355 47.722635 8.4552019 47.72721999999999 8.4546655 47.72915810000001 8.4569668 47.73043150000001 8.4528545 47.73816600000001 8.4496835 47.74277699999999 8.4558505 47.74944000000002 8.456882 47.753784499999995 8.466608 47.764588 8.473712 47.7732685 8.4890275 47.77069149999997 8.4960265 47.773608499999995 8.502137 47.77431500000003 8.509297 47.776186199999984 8.5101076 47.770490499999994 8.520118 47.778133499999996 8.5264825 47.7779845 8.532663 47.784636500000005 8.5526745 47.780495 8.562975 47.77785399999999 8.5625445 47.777976800000005 8.5661975 47.781540300000046 8.5770821 47.789526499999994 8.5749215 47.792771500000015 8.5616945 47.8053185 8.5635385 47.80848800000001 8.5678585 47.80598999999998 8.573027</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </Polygon>
+                  </gml:surfaceMember>
+                </MultiSurface>
+              </gex:polygon>
+            </gex:EX_BoundingPolygon>
+          </gex:geographicElement>
+        </gex:EX_Extent>
+      </mri:extent>
+      <mri:resourceMaintenance>
+        <che:CHE_MD_MaintenanceInformation gco:isoType="mmi:MD_MaintenanceInformation">
+          <mmi:maintenanceAndUpdateFrequency>
+            <mmi:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_MaintenanceFrequencyCode" codeListValue="unknown" />
+          </mmi:maintenanceAndUpdateFrequency>
+        </che:CHE_MD_MaintenanceInformation>
+      </mri:resourceMaintenance>
+      <mri:descriptiveKeywords>
+        <mri:MD_Keywords>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Geologie</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Geologie</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">Géologie</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">Geology</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">Geologia</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:type>
+            <mri:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </mri:type>
+          <mri:thesaurusName>
+            <cit:CI_Citation>
+              <cit:title>
+                <gco:CharacterString>GEMET - INSPIRE themes, version 1.0</gco:CharacterString>
+              </cit:title>
+              <cit:date>
+                <cit:CI_Date>
+                  <cit:date>
+                    <gco:Date>2008-06-01</gco:Date>
+                  </cit:date>
+                  <cit:dateType>
+                    <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="publication">publication</cit:CI_DateTypeCode>
+                  </cit:dateType>
+                </cit:CI_Date>
+              </cit:date>
+              <cit:identifier>
+                <mcc:MD_Identifier>
+                  <mcc:code>
+                    <gcx:Anchor xlink:href="https://www.geocat.ch/geonetwork/srv/api/registries/vocabularies/external.theme.httpinspireeceuropaeutheme-theme">geonetwork.thesaurus.external.theme.httpinspireeceuropaeutheme-theme</gcx:Anchor>
+                  </mcc:code>
+                </mcc:MD_Identifier>
+              </cit:identifier>
+            </cit:CI_Citation>
+          </mri:thesaurusName>
+        </mri:MD_Keywords>
+      </mri:descriptiveKeywords>
+      <mri:descriptiveKeywords>
+        <mri:MD_Keywords>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Metamorphes Gestein</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Metamorphes Gestein</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">roche métamorphique</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">metamorphic rock</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">roccia metamorfica</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Stratigrafie</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Stratigrafie</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">stratigraphie</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">stratigraphy</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">stratigrafia</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Bruchlinie</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Bruchlinie</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">ligne de faille</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">faults</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">linee di faglia</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Lithologie</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Lithologie</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">lithologie</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">lithology</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">litologia</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Oberflächenablagerung</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Oberflächenablagerung</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">dépôt superficiel</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">superficial deposit</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">depositi superficiali</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Felsuntergrund</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Felsuntergrund</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">roche mère</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">bedrock</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">roccia in posto</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Oberflächengeologie</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Oberflächengeologie</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">géologie de la surface</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">surface geology</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">geologia superficiale</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Sedimentgestein</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Sedimentgestein</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">roche sédimentaire</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">sedimentary rock</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">roccia sedimentaria</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Chronostratigrafie</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Chronostratigrafie</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">chronostratigraphie</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">chronostratigraphy</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">cronostratigrafia</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Landesgeologie</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Landesgeologie</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">service géologique national</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">swiss geological survey</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">servizio geologico nazionale</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Magmatisches Gestein</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Magmatisches Gestein</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">roche magmatique</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">igneous rock</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">roccia magmatica</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>OneGeology</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">OneGeology</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">OneGeology</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">OneGeology</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">OneGeology</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:type>
+            <mri:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </mri:type>
+          <mri:thesaurusName>
+            <cit:CI_Citation>
+              <cit:title>
+                <gco:CharacterString>geocat.ch</gco:CharacterString>
+              </cit:title>
+              <cit:date>
+                <cit:CI_Date>
+                  <cit:date>
+                    <gco:Date>2025-12-10</gco:Date>
+                  </cit:date>
+                  <cit:dateType>
+                    <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="publication">publication</cit:CI_DateTypeCode>
+                  </cit:dateType>
+                </cit:CI_Date>
+              </cit:date>
+              <cit:identifier>
+                <mcc:MD_Identifier>
+                  <mcc:code>
+                    <gcx:Anchor xlink:href="https://www.geocat.ch/geonetwork/srv/api/registries/vocabularies/local.theme.geocat.ch">geonetwork.thesaurus.local.theme.geocat.ch</gcx:Anchor>
+                  </mcc:code>
+                </mcc:MD_Identifier>
+              </cit:identifier>
+            </cit:CI_Citation>
+          </mri:thesaurusName>
+        </mri:MD_Keywords>
+      </mri:descriptiveKeywords>
+      <mri:descriptiveKeywords>
+        <mri:MD_Keywords>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>infoMapAccessService</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">infoMapAccessService</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">infoMapAccessService</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">infoMapAccessService</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">infoMapAccessService</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:type>
+            <mri:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </mri:type>
+          <mri:thesaurusName>
+            <cit:CI_Citation>
+              <cit:title>
+                <gco:CharacterString>INSPIRE Service taxonomy</gco:CharacterString>
+              </cit:title>
+              <cit:date>
+                <cit:CI_Date>
+                  <cit:date>
+                    <gco:Date>2010-04-22</gco:Date>
+                  </cit:date>
+                  <cit:dateType>
+                    <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="publication">publication</cit:CI_DateTypeCode>
+                  </cit:dateType>
+                </cit:CI_Date>
+              </cit:date>
+              <cit:identifier>
+                <mcc:MD_Identifier>
+                  <mcc:code>
+                    <gcx:Anchor xlink:href="https://www.geocat.ch/geonetwork/srv/api/registries/vocabularies/external.theme.inspire-service-taxonomy">geonetwork.thesaurus.external.theme.inspire-service-taxonomy</gcx:Anchor>
+                  </mcc:code>
+                </mcc:MD_Identifier>
+              </cit:identifier>
+            </cit:CI_Citation>
+          </mri:thesaurusName>
+        </mri:MD_Keywords>
+      </mri:descriptiveKeywords>
+      <mri:descriptiveKeywords>
+        <mri:MD_Keywords>
+          <mri:keyword xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Tektonik</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Tektonik</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">tectonique</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">tectonics</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#IT">tettonica</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:type>
+            <mri:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </mri:type>
+          <mri:thesaurusName>
+            <cit:CI_Citation>
+              <cit:title>
+                <gco:CharacterString>GEMET</gco:CharacterString>
+              </cit:title>
+              <cit:date>
+                <cit:CI_Date>
+                  <cit:date>
+                    <gco:Date>2018-08-16</gco:Date>
+                  </cit:date>
+                  <cit:dateType>
+                    <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="publication">publication</cit:CI_DateTypeCode>
+                  </cit:dateType>
+                </cit:CI_Date>
+              </cit:date>
+              <cit:identifier>
+                <mcc:MD_Identifier>
+                  <mcc:code>
+                    <gcx:Anchor xlink:href="https://www.geocat.ch/geonetwork/srv/api/registries/vocabularies/external.theme.gemet">geonetwork.thesaurus.external.theme.gemet</gcx:Anchor>
+                  </mcc:code>
+                </mcc:MD_Identifier>
+              </cit:identifier>
+            </cit:CI_Citation>
+          </mri:thesaurusName>
+        </mri:MD_Keywords>
+      </mri:descriptiveKeywords>
+      <srv:serviceType>
+        <gco:ScopedName>OGC:WMS</gco:ScopedName>
+      </srv:serviceType>
+      <srv:serviceTypeVersion>
+        <gco:CharacterString>1.1.1</gco:CharacterString>
+        <gco:CharacterString>1.3.0</gco:CharacterString>
+      </srv:serviceTypeVersion>
+      <srv:couplingType>
+        <srv:SV_CouplingType codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#SV_CouplingType" codeListValue="tight">tight</srv:SV_CouplingType>
+      </srv:couplingType>
+      <srv:containsOperations>
+        <srv:SV_OperationMetadata>
+          <srv:operationName>
+            <gco:CharacterString>GetCapabilities</gco:CharacterString>
+          </srv:operationName>
+          <srv:distributedComputingPlatform>
+            <srv:DCPList codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DCPList" codeListValue="WebServices">WebServices</srv:DCPList>
+          </srv:distributedComputingPlatform>
+          <srv:connectPoint>
+            <cit:CI_OnlineResource>
+              <cit:linkage xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>http://wms.ga.admin.ch/LG_DE_Geologie_und_Tektonik/wms?service=wms&amp;request=getcapabilities</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">http://wms.ga.admin.ch/LG_DE_Geologie_und_Tektonik/wms?service=wms&amp;request=getcapabilities</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">http://wms.ga.admin.ch/SGN_FR_Geologie_et_Tectonique/wms?service=wms&amp;request=getcapabilities</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:linkage>
+              <cit:protocol>
+                <gco:CharacterString>OGC:WMS</gco:CharacterString>
+              </cit:protocol>
+            </cit:CI_OnlineResource>
+          </srv:connectPoint>
+        </srv:SV_OperationMetadata>
+      </srv:containsOperations>
+      <srv:containsOperations>
+        <srv:SV_OperationMetadata>
+          <srv:operationName>
+            <gco:CharacterString>GetMap</gco:CharacterString>
+          </srv:operationName>
+          <srv:distributedComputingPlatform>
+            <srv:DCPList codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DCPList" codeListValue="WebServices">WebServices</srv:DCPList>
+          </srv:distributedComputingPlatform>
+          <srv:connectPoint>
+            <cit:CI_OnlineResource>
+              <cit:linkage xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>http://wms.ga.admin.ch/LG_DE_Geologie_und_Tektonik/wms</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">http://wms.ga.admin.ch/LG_DE_Geologie_und_Tektonik/wms</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">http://wms.ga.admin.ch/SGN_FR_Geologie_et_Tectonique/wms</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN">http://wms.ga.admin.ch/exows/?language=eng</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:linkage>
+              <cit:protocol>
+                <gco:CharacterString>OGC:WMS</gco:CharacterString>
+              </cit:protocol>
+            </cit:CI_OnlineResource>
+          </srv:connectPoint>
+        </srv:SV_OperationMetadata>
+      </srv:containsOperations>
+      <srv:containsOperations>
+        <srv:SV_OperationMetadata>
+          <srv:operationName>
+            <gco:CharacterString>GetFeatureInfo</gco:CharacterString>
+          </srv:operationName>
+          <srv:distributedComputingPlatform>
+            <srv:DCPList codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DCPList" codeListValue="WebServices">WebServices</srv:DCPList>
+          </srv:distributedComputingPlatform>
+          <srv:connectPoint>
+            <cit:CI_OnlineResource>
+              <cit:linkage xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>http://wms.ga.admin.ch/LG_DE_Geologie_und_Tektonik/wms</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">http://wms.ga.admin.ch/LG_DE_Geologie_und_Tektonik/wms</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:linkage>
+              <cit:protocol>
+                <gco:CharacterString>OGC:WMS</gco:CharacterString>
+              </cit:protocol>
+            </cit:CI_OnlineResource>
+          </srv:connectPoint>
+        </srv:SV_OperationMetadata>
+      </srv:containsOperations>
+      <srv:operatesOn uuidref="7d60efcf-5997-4124-9340-a6c5178a6dee" xlink:href="http://www.geocat.ch/geonetwork/srv/eng/csw?service=CSW&amp;request=GetRecordById&amp;version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=7d60efcf-5997-4124-9340-a6c5178a6dee" />
+      <srv:operatesOn uuidref="3373ea93-ed63-4ff6-a43a-e15a7bf1f24b" xlink:href="http://www.geocat.ch/geonetwork/srv/eng/csw?service=CSW&amp;request=GetRecordById&amp;version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=3373ea93-ed63-4ff6-a43a-e15a7bf1f24b" />
+      <srv:operatesOn uuidref="b4c3f648-6778-4701-a5c7-31e764d12127" xlink:href="http://www.geocat.ch/geonetwork/srv/eng/csw?service=CSW&amp;request=GetRecordById&amp;version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=b4c3f648-6778-4701-a5c7-31e764d12127" />
+    </srv:SV_ServiceIdentification>
+  </mdb:identificationInfo>
+</che:CHE_MD_Metadata>

--- a/src/test/resources/wms-with-2-serviceTypeVersion-19139.che.xml
+++ b/src/test/resources/wms-with-2-serviceTypeVersion-19139.che.xml
@@ -1,0 +1,942 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<che:CHE_MD_Metadata xmlns:che="http://www.geocat.ch/2008/che" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" gco:isoType="gmd:MD_Metadata" xsi:schemaLocation="http://www.geocat.ch/2008/che https://www.geocat.ch/geonetwork/xml/schemas/iso19139.che/schema/che/che.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>07fb9011-362c-4c7d-a37a-7fe838ff5a13</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language>
+    <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger" />
+  </gmd:language>
+  <gmd:characterSet>
+    <gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" />
+  </gmd:characterSet>
+  <gmd:hierarchyLevel>
+    <gmd:MD_ScopeCode codeListValue="service" codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_ScopeCode" />
+  </gmd:hierarchyLevel>
+  <gmd:hierarchyLevelName>
+    <gco:CharacterString>Service</gco:CharacterString>
+  </gmd:hierarchyLevelName>
+  <gmd:contact xlink:show="embed">
+    <che:CHE_CI_ResponsibleParty xmlns:geonet="http://www.fao.org/geonetwork" gco:isoType="gmd:CI_ResponsibleParty">
+      <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Bundesamt für Landestopografie swisstopo</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Bundesamt für Landestopografie swisstopo</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Office fédéral de topographie swisstopo</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">Federal Office of Topography swisstopo</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">Ufficio federale di topografia swisstopo</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:organisationName>
+      <gmd:positionName xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Landesgeologie</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Landesgeologie</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Service géologique national</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">Swiss Geological Survey</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">Servizio geologico nazionale</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:positionName>
+      <gmd:contactInfo>
+        <gmd:CI_Contact>
+          <gmd:phone>
+            <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+              <gmd:voice>
+                <gco:CharacterString>+41 58 469 01 11</gco:CharacterString>
+              </gmd:voice>
+            </che:CHE_CI_Telephone>
+          </gmd:phone>
+          <gmd:address>
+            <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+              <gmd:city>
+                <gco:CharacterString>Wabern</gco:CharacterString>
+              </gmd:city>
+              <gmd:postalCode>
+                <gco:CharacterString>3084</gco:CharacterString>
+              </gmd:postalCode>
+              <gmd:country>
+                <gco:CharacterString>CH</gco:CharacterString>
+              </gmd:country>
+              <gmd:electronicMailAddress>
+                <gco:CharacterString>daniel.gechter@swisstopo.ch</gco:CharacterString>
+              </gmd:electronicMailAddress>
+              <che:streetName>
+                <gco:CharacterString>Seftigenstrasse</gco:CharacterString>
+              </che:streetName>
+              <che:streetNumber>
+                <gco:CharacterString>264</gco:CharacterString>
+              </che:streetNumber>
+            </che:CHE_CI_Address>
+          </gmd:address>
+          <gmd:onlineResource>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#EN">https://www.swisstopo.admin.ch/en/swiss-geological-survey</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">https://www.swisstopo.admin.ch/de/landesgeologie</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">https://www.swisstopo.admin.ch/fr/service-geologique-national</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#IT">https://www.swisstopo.admin.ch/it/servizio-geologico-nazionale</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK</gco:CharacterString>
+              </gmd:protocol>
+            </gmd:CI_OnlineResource>
+          </gmd:onlineResource>
+        </gmd:CI_Contact>
+      </gmd:contactInfo>
+      <gmd:role>
+        <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="pointOfContact" />
+      </gmd:role>
+      <che:individualFirstName>
+        <gco:CharacterString>Daniel</gco:CharacterString>
+      </che:individualFirstName>
+      <che:individualLastName>
+        <gco:CharacterString>Gechter</gco:CharacterString>
+      </che:individualLastName>
+      <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>swisstopo</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">swisstopo</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">swisstopo</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">swisstopo</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#IT">swisstopo</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </che:organisationAcronym>
+    </che:CHE_CI_ResponsibleParty>
+  </gmd:contact>
+  <gmd:dateStamp>
+    <gco:DateTime>2019-08-13T23:50:53</gco:DateTime>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName>
+    <gco:CharacterString>GM03_2</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:metadataStandardVersion>
+    <gco:CharacterString>1.0</gco:CharacterString>
+  </gmd:metadataStandardVersion>
+  <gmd:locale>
+    <gmd:PT_Locale id="FR">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="EN">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="IT">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ita" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="DE">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:referenceSystemInfo>
+    <gmd:MD_ReferenceSystem>
+      <gmd:referenceSystemIdentifier>
+        <gmd:RS_Identifier>
+          <gmd:code xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>EPSG:21781, 4326, 2154, 32632, 2056, 21780, 3034, 3035, 4258, 900913, 3857</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">EPSG:21781, 4326, 2154, 32632, 2056, 21780, 3034, 3035, 4258, 900913, 3857</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:code>
+        </gmd:RS_Identifier>
+      </gmd:referenceSystemIdentifier>
+    </gmd:MD_ReferenceSystem>
+  </gmd:referenceSystemInfo>
+  <gmd:identificationInfo>
+    <srv:SV_ServiceIdentification>
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>LG DE Geologie und Tektonik - OneGeology (WMS)</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">LG DE Geologie und Tektonik - OneGeology (WMS)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">SGN FR Géologie et tectonique - OneGeology (WMS)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">SGS EN Geology and tectonics - OneGeology (WMS)</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2013-11-30</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_DateTypeCode" codeListValue="creation" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Als erdwissenschaftliche Fachstelle des Bundes befasst sich der Bereich Landesgeologie vor allem mit folgenden Aufgaben: Organisation der geologischen Landesuntersuchung (Geologie, Geotechnik, Geophysik), Beschaffung der dafür notwendigen Daten, deren Kompilation und Umsetzung in geologische Karten sowie Herausgabe von Berichten, Empfehlungen und Richtlinien auf dem Gebiet der angewandten Geologie (Ingenieurgeologie, Umweltgeologie). Die präsentierten Layer (Tektonische Störungen, Tektonische Einheiten und Geologische Einheiten) geben einen grossräumigen Überblick über die Beschaffenheit und die Merkmale des Untergrundes der Schweiz</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Als erdwissenschaftliche Fachstelle des Bundes befasst sich der Bereich Landesgeologie vor allem mit folgenden Aufgaben: Organisation der geologischen Landesuntersuchung (Geologie, Geotechnik, Geophysik), Beschaffung der dafür notwendigen Daten, deren Kompilation und Umsetzung in geologische Karten sowie Herausgabe von Berichten, Empfehlungen und Richtlinien auf dem Gebiet der angewandten Geologie (Ingenieurgeologie, Umweltgeologie). Die präsentierten Layer (Tektonische Störungen, Tektonische Einheiten und Geologische Einheiten) geben einen grossräumigen Überblick über die Beschaffenheit und die Merkmale des Untergrundes der Schweiz</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">En tant qu’organe de la Confédération spécialisé dans les sciences de la terre, le Service géologique national accomplit notamment les tâches suivantes: l’organisation du relevé géologique du territoire (géologie, géotechnique, géophysique), la collecte des données ainsi que leur compilation et leur traduction en cartes géologiques et enfin la publication de rapports, de recommandations et de directives relatives à la géologie appliquée (génie géologique, géologie environnementale). Les couches présentées (accidents tectoniques, unités tectoniques et unités géologiques) donnent une vue globale de la constitution et des caractéristiques du sous-sol de la Suisse</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">As the department of the Confederation responsible for earth sciences, the Swiss Geological Survey is principally concerned with the following tasks: organising national geological, geotechnical and geophysical surveys, gathering the necessary data, processing and compiling these data in the form of geological maps, and publishing reports, recommendations and guidelines in the fields to which geology is applied (engineering geology and environmental geology).The presented layers (tectonic lineaments, tectonic units and geological units) give a broad overview of the composition and major features of the underlying structure of Switzerland.</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:abstract>
+      <gmd:pointOfContact xlink:show="embed">
+        <che:CHE_CI_ResponsibleParty xmlns:geonet="http://www.fao.org/geonetwork" gco:isoType="gmd:CI_ResponsibleParty">
+          <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Bundesamt für Landestopografie swisstopo</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Bundesamt für Landestopografie swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Office fédéral de topographie swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Federal Office of Topography swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Ufficio federale di topografia swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:organisationName>
+          <gmd:positionName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Landesgeologie</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Landesgeologie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Service géologique national</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Swiss Geological Survey</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Servizio geologico nazionale</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:positionName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:phone>
+                <che:CHE_CI_Telephone gco:isoType="gmd:CI_Telephone">
+                  <gmd:voice>
+                    <gco:CharacterString>+41 58 469 01 11</gco:CharacterString>
+                  </gmd:voice>
+                </che:CHE_CI_Telephone>
+              </gmd:phone>
+              <gmd:address>
+                <che:CHE_CI_Address gco:isoType="gmd:CI_Address">
+                  <gmd:city>
+                    <gco:CharacterString>Wabern</gco:CharacterString>
+                  </gmd:city>
+                  <gmd:postalCode>
+                    <gco:CharacterString>3084</gco:CharacterString>
+                  </gmd:postalCode>
+                  <gmd:country>
+                    <gco:CharacterString>CH</gco:CharacterString>
+                  </gmd:country>
+                  <gmd:electronicMailAddress>
+                    <gco:CharacterString>daniel.gechter@swisstopo.ch</gco:CharacterString>
+                  </gmd:electronicMailAddress>
+                  <che:streetName>
+                    <gco:CharacterString>Seftigenstrasse</gco:CharacterString>
+                  </che:streetName>
+                  <che:streetNumber>
+                    <gco:CharacterString>264</gco:CharacterString>
+                  </che:streetNumber>
+                </che:CHE_CI_Address>
+              </gmd:address>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                    <che:PT_FreeURL>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#EN">https://www.swisstopo.admin.ch/en/swiss-geological-survey</che:LocalisedURL>
+                      </che:URLGroup>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#DE">https://www.swisstopo.admin.ch/de/landesgeologie</che:LocalisedURL>
+                      </che:URLGroup>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#FR">https://www.swisstopo.admin.ch/fr/service-geologique-national</che:LocalisedURL>
+                      </che:URLGroup>
+                      <che:URLGroup>
+                        <che:LocalisedURL locale="#IT">https://www.swisstopo.admin.ch/it/servizio-geologico-nazionale</che:LocalisedURL>
+                      </che:URLGroup>
+                    </che:PT_FreeURL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                  </gmd:protocol>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#CI_RoleCode" codeListValue="pointOfContact" />
+          </gmd:role>
+          <che:individualFirstName>
+            <gco:CharacterString>Daniel</gco:CharacterString>
+          </che:individualFirstName>
+          <che:individualLastName>
+            <gco:CharacterString>Gechter</gco:CharacterString>
+          </che:individualLastName>
+          <che:organisationAcronym xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>swisstopo</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">swisstopo</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </che:organisationAcronym>
+        </che:CHE_CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Geologie</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Geologie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Géologie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Geology</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Geologia</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>GEMET - INSPIRE themes, version 1.0</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2008-06-01</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="https://www.geocat.ch/geonetwork/srv/api/registries/vocabularies/external.theme.httpinspireeceuropaeutheme-theme">geonetwork.thesaurus.external.theme.httpinspireeceuropaeutheme-theme</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Metamorphes Gestein</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Metamorphes Gestein</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">roche métamorphique</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">metamorphic rock</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">roccia metamorfica</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Stratigrafie</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Stratigrafie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">stratigraphie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">stratigraphy</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">stratigrafia</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Bruchlinie</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Bruchlinie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">ligne de faille</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">faults</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">linee di faglia</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Lithologie</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Lithologie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">lithologie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">lithology</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">litologia</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Oberflächenablagerung</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Oberflächenablagerung</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">dépôt superficiel</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">superficial deposit</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">depositi superficiali</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Felsuntergrund</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Felsuntergrund</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">roche mère</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">bedrock</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">roccia in posto</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Oberflächengeologie</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Oberflächengeologie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">géologie de la surface</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">surface geology</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">geologia superficiale</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Sedimentgestein</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Sedimentgestein</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">roche sédimentaire</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">sedimentary rock</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">roccia sedimentaria</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Chronostratigrafie</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Chronostratigrafie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">chronostratigraphie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">chronostratigraphy</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">cronostratigrafia</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Landesgeologie</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Landesgeologie</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">service géologique national</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">swiss geological survey</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">servizio geologico nazionale</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Magmatisches Gestein</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Magmatisches Gestein</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">roche magmatique</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">igneous rock</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">roccia magmatica</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>OneGeology</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">OneGeology</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">OneGeology</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">OneGeology</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">OneGeology</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>geocat.ch</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2025-12-10</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="https://www.geocat.ch/geonetwork/srv/api/registries/vocabularies/local.theme.geocat.ch">geonetwork.thesaurus.local.theme.geocat.ch</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>infoMapAccessService</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">infoMapAccessService</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">infoMapAccessService</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">infoMapAccessService</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">infoMapAccessService</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>INSPIRE Service taxonomy</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2010-04-22</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="https://www.geocat.ch/geonetwork/srv/api/registries/vocabularies/external.theme.inspire-service-taxonomy">geonetwork.thesaurus.external.theme.inspire-service-taxonomy</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Tektonik</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Tektonik</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">tectonique</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">tectonics</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">tettonica</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://www.isotc211.org/2005/resources/codeList.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title>
+                <gco:CharacterString>GEMET</gco:CharacterString>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2018-08-16</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="https://www.geocat.ch/geonetwork/srv/api/registries/vocabularies/external.theme.gemet">geonetwork.thesaurus.external.theme.gemet</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <srv:serviceType>
+        <gco:LocalName>OGC:WMS</gco:LocalName>
+      </srv:serviceType>
+      <srv:serviceTypeVersion>
+        <gco:CharacterString>1.1.1</gco:CharacterString>
+      </srv:serviceTypeVersion>
+      <srv:serviceTypeVersion>
+        <gco:CharacterString>1.3.0</gco:CharacterString>
+      </srv:serviceTypeVersion>
+      <srv:accessProperties>
+        <gmd:MD_StandardOrderProcess>
+          <gmd:fees>
+            <gco:CharacterString>kostenlos / free</gco:CharacterString>
+          </gmd:fees>
+        </gmd:MD_StandardOrderProcess>
+      </srv:accessProperties>
+      <srv:extent xlink:show="embed">
+        <gmd:EX_Extent>
+          <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Schweiz</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Schweiz</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Suisse</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Switzerland</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#IT">Svizzera</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:description>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:westBoundLongitude>
+                <gco:Decimal>5.956088</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>10.492036</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>45.817970</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>47.808488</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+          <gmd:geographicElement>
+            <gmd:EX_BoundingPolygon>
+              <gmd:polygon>
+                <MultiSurface xmlns="http://www.opengis.net/gml/3.2" gml:id="d25237359e60" srsName="EPSG:4326">
+                  <gml:surfaceMember>
+                    <Polygon gml:id="d25237359e62" srsName="EPSG:4326">
+                      <gml:exterior>
+                        <gml:LinearRing>
+                          <gml:posList srsDimension="2">47.80598999999998 8.573027 47.79972649999999 8.575219 47.80264399999996 8.5877555 47.79877049999999 8.592442 47.80288150000001 8.6013575 47.801079000000016 8.6138315 47.798326 8.618624 47.795939000000004 8.6178205 47.79466350000001 8.6220585 47.78876450000001 8.6204145 47.78705549999998 8.615677 47.78489550000003 8.615012 47.78019169999999 8.6176977 47.7779405 8.6188375 47.77717000000001 8.6231745 47.76733100000001 8.619267 47.759258999999986 8.627679 47.758245999999986 8.6315305 47.7601296 8.6332303 47.76514700000001 8.6423905 47.76502500000004 8.6454875 47.76697200000001 8.647669 47.768500500000016 8.645558 47.77336500000001 8.653031 47.77393599999999 8.648022 47.78128649999999 8.6499615 47.78684749999999 8.6454985 47.7946685 8.64654 47.79470700000002 8.6487665 47.79849300000001 8.6494255 47.8003655 8.6570145 47.79597849999999 8.660206 47.791607500000026 8.6574205 47.791627500000004 8.661782 47.78770850000001 8.667183 47.78569250000001 8.676155 47.78667100000001 8.680921 47.777164 8.68279 47.77365 8.6882535 47.7705095 8.6832075 47.75934749999999 8.687696 47.756156499999975 8.6926255 47.75677999999999 8.6976815 47.75974099999999 8.698987 47.76550150000003 8.714178 47.76270299999999 8.726105 47.75959449999999 8.7306555 47.75788399999999 8.72885 47.751852499999956 8.7410755 47.74642349999996 8.739402 47.745742500000006 8.723513 47.741075499999994 8.720122 47.738698 8.714344 47.73007150000001 8.71127 47.72142899999997 8.7181625 47.72135349999999 8.724546 47.72003049999998 8.7244335 47.718366 8.733205 47.716151499999995 8.7362945 47.71145999999996 8.7319325 47.696673000000004 8.726401 47.6926771 8.7279723 47.68963550000001 8.7565395 47.676462500000014 8.7856705 47.675598699999995 8.7956901 47.67992699999999 8.793337 47.689726500000006 8.798059 47.691731000000004 8.799774 47.6932645 8.809933 47.69644199999999 8.8061765 47.69733600000001 8.797798 47.7023145 8.7977205 47.704385 8.7933905 47.70672350000001 8.7694965 47.713194499999986 8.7728135 47.717948500000006 8.769904 47.72075749999999 8.7769995 47.72273050000001 8.7761315 47.721716500000014 8.7808025 47.72717699999998 8.78505 47.72732600000003 8.790547 47.728910499999984 8.7918245 47.72727849999998 8.7989955 47.73467199999999 8.7964365 47.73830699999999 8.806439 47.7310755 8.8084715 47.730426499999965 8.8123975 47.7244675 8.804927 47.723877500000015 8.812647 47.71764999999999 8.818586 47.717910500000045 8.826183 47.71287200000003 8.8188545 47.71092200000001 8.824128 47.714576499999964 8.8332615 47.71226250000001 8.843022 47.711033999999984 8.8455665 47.703491999999954 8.848522 47.70496 8.871377 47.70406349999999 8.8727505 47.701707999999996 8.869699 47.696741 8.8760135 47.6944005 8.8745325 47.692429000000004 8.8629345 47.69648600000002 8.8661425 47.698691499999995 8.863354 47.69645650000001 8.859979 47.698747999999995 8.858146 47.69766499999997 8.851325 47.694485499999985 8.8502855 47.692837 8.8571965 47.689089499999994 8.8560825 47.68571399999999 8.85099 47.680923199999995 8.8515408 47.680588 8.86033 47.6704575 8.873453 47.65596289999999 8.8749854 47.65466900000001 8.8748705 47.654664 8.882431 47.647838500000006 8.896779 47.656365499999964 8.9404975 47.66509999999997 8.964399 47.674586000000005 8.9819515 47.686621 9.0217825 47.68435550000001 9.0565765 47.6790005 9.07237 47.678916000000044 9.094917 47.675152499999996 9.1062685 47.66842100000002 9.1175945 47.66426100000001 9.138359 47.66465550000001 9.1425925 47.66757000000001 9.1478745 47.666018699999995 9.1577058 47.6604595 9.1630475 47.65470899999997 9.170492 47.655756999999994 9.175346 47.65393799999998 9.1758065 47.65588469999997 9.1821679 47.65745100000001 9.1871023 47.655095700000004 9.2148321 47.65870770000001 9.2565609 47.6203261 9.3947139 47.5514551 9.4956037 47.54973939999999 9.5069474 47.541893199999976 9.5587204 47.49918149999996 9.5611046 47.493604000000005 9.564142000000002 47.4866145 9.576391999999998 47.481221500000004 9.5834 47.46362199999999 9.594817499999998 47.461591 9.6008665 47.46238099999999 9.603570500000002 47.47032850000002 9.607249 47.46944400000001 9.611599 47.45748600000002 9.622324500000001 47.454251 9.654435 47.451382499999994 9.659449499999997 47.4477895 9.658005 47.442744000000005 9.6508025 47.43521649999997 9.644318 47.416431999999986 9.650899 47.404626500000035 9.6516355 47.40439999999998 9.6543925 47.397546000000034 9.660106499999998 47.391290999999995 9.673578500000001 47.38151049999999 9.6733705 47.377436999999986 9.670270999999998 47.371081000000004 9.662428 47.367446 9.649545500000002 47.367369999999994 9.635391500000003 47.365080500000005 9.6262925 47.36614500000002 9.6244795 47.362435000000005 9.619674000000002 47.346901 9.600727 47.33752000000001 9.596352500000002 47.31754400000003 9.588288500000003 47.31112250000001 9.5815595 47.30418399999999 9.5657325 47.30019150000001 9.559226 47.27820300000002 9.5434582 47.27058099999999 9.530749 47.26938150000001 9.529812 47.262595000000005 9.5294405 47.244045 9.520324 47.23178050000001 9.510388 47.22279350000002 9.5027225 47.20670749999999 9.49612 47.19824700000001 9.4902235 47.19029449999999 9.487608 47.17795649999999 9.486198 47.15694399999998 9.495433 47.147221 9.5037375 47.14005 9.5092235 47.12194600000001 9.51522 47.1151265 9.5171565 47.100149999999985 9.520344000000001 47.08535950000001 9.512247 47.065890499999995 9.474910999999999 47.061295 9.472234999999998 47.05179749999999 9.4760475 47.054996000000045 9.476301 47.056464000000005 9.482308 47.05296049999998 9.482489999999999 47.04968500000001 9.486025 47.05727400000001 9.4923715 47.05454550000002 9.497507 47.05764450000001 9.5003255 47.0572195 9.511909 47.06069500000004 9.517270999999997 47.06303650000001 9.530543 47.0651445 9.5397515 47.05884399999999 9.5516185 47.050505499999986 9.554383500000002 47.04932650000001 9.556851500000002 47.04857049999998 9.5597835 47.052526 9.569208999999999 47.054013 9.5782605 47.052808 9.5811355 47.05517750000004 9.587708000000001 47.059098000000006 9.596016500000001 47.05898250000001 9.599764 47.061893999999995 9.602818000000001 47.06077450000001 9.607078 47.05362850000003 9.617226 47.05133000000001 9.6263505 47.0517055 9.636565 47.05392549999999 9.641348500000001 47.059777999999994 9.6450805 47.05818550000001 9.658238 47.06210149999998 9.6818635 47.058955 9.682047 47.055229999999995 9.6882145 47.052392499999996 9.697583 47.05383900000001 9.7073265 47.04804999999999 9.707033499999998 47.043379000000016 9.718233999999999 47.042599999999965 9.741353999999998 47.04110750000001 9.745223 47.03692799999999 9.7481005 47.03845849999996 9.783335499999998 47.03169199999999 9.7919115 47.02909299999999 9.8014225 47.0217385 9.812349 47.0225495 9.815469499999999 47.019623499999994 9.824151999999998 47.014332000000024 9.8307265 47.01253700000001 9.836141 47.01512500000001 9.841029999999998 47.016418999999985 9.85275 47.02331449999997 9.8606815 47.021330500000005 9.867207 47.021232999999995 9.8762675 47.018024 9.8803515 47.013063999999986 9.871172000000001 47.00964449999998 9.870725 47.0065285 9.8729565 47.0007358 9.8887649 46.990365499999996 9.892325 46.98328000000001 9.883027 46.98085449999999 9.88457 46.9736595 9.875722 46.967501999999996 9.8756045 46.963100999999995 9.871269 46.95707350000001 9.878741 46.95039700000004 9.8748995 46.94071300000002 9.876591999999999 46.94011849999998 9.880727499999999 46.934635499999985 9.8761485 46.935024 9.8807465 46.931651999999985 9.894506499999999 46.925308 9.906342000000002 46.9260625 9.912331 46.91883100000001 9.9215515 46.913249500000006 9.937601999999998 46.91235649999999 9.946142000000002 46.9160315 9.959091 46.91240450000001 9.963132 46.912229999999994 9.966587 46.91588999999999 9.977887 46.91337800000002 9.980803 46.906206 9.982453999999999 46.90241549999999 9.99013 46.90226799999999 9.9958355 46.89880700000003 10.005929 46.901622 10.0178385 46.895812999999976 10.026487500000002 46.88658749999999 10.034674 46.88581400000001 10.039329 46.880446999999975 10.0424575 46.875754 10.052619500000002 46.86394949999999 10.0512175 46.860782 10.059581 46.86118999999999 10.087351499999999 46.8581805 10.092616 46.851706500000006 10.092319 46.84879050000001 10.096797 46.8409092 10.105171000000002 46.844177 10.119142999999998 46.847384500000004 10.119945000000001 46.848483499999986 10.1231145 46.847385 10.13943 46.851410499999986 10.147293000000001 46.85032749999999 10.154601499999998 46.84786700000001 10.1574305 46.85099649999998 10.1627105 46.85066649999999 10.169082 46.85367099999999 10.171776 46.85497699999996 10.1810105 46.86644949999999 10.1936785 46.866634000000005 10.1990325 46.864621 10.2038435 46.86729100000002 10.219248 46.86630549999998 10.232689 46.86944349999999 10.2308575 46.871613499999995 10.2328275 46.88468900000001 10.2348505 46.89021300000002 10.2276225 46.895946500000036 10.2257375 46.901647499999996 10.2333175 46.91570800000002 10.237051 46.918835 10.242031 46.931257500000015 10.2405795 46.929778500000026 10.257510499999999 46.92181199999999 10.293611999999998 46.91995650000001 10.2968845 46.924660500000016 10.300806 46.925184 10.316069 46.930958000000004 10.3171775 46.94014800000002 10.3061795 46.95020600000001 10.309367 46.9539805 10.3278315 46.96393549999996 10.329621 46.978380000000016 10.340722 46.981311000000005 10.339996999999999 46.982714999999956 10.344552 46.989592000000016 10.3465225 46.99236400000001 10.3549985 46.990673500000014 10.3720565 46.99927600000001 10.3833845 47.00052449999998 10.389318 46.9968825 10.398715999999999 46.990859 10.402183999999998 46.98264899999998 10.412506 46.97568650000002 10.426589 46.972702 10.4275045 46.965505500000006 10.4229745 46.959952499999986 10.4223805 46.9561535 10.428640500000002 46.9562765 10.432948 46.95231949999999 10.449156 46.95288450000004 10.4554815 46.947100500000005 10.468824 46.9410785 10.476588500000002 46.937790500000006 10.489350499999999 46.931449500000014 10.485296 46.926285500000006 10.4883075 46.91546149999999 10.4862185 46.910596500000025 10.4785425 46.894293000000005 10.475092 46.884281499999986 10.464697 46.88110600000002 10.4692315 46.872963500000026 10.471266 46.86211399999996 10.468009 46.84877349999999 10.471811 46.84142750000001 10.4639585 46.835894999999994 10.4665325 46.83408499999999 10.463073500000002 46.834686000000005 10.4601305 46.830247499999984 10.456666 46.82454050000001 10.4603565 46.822040000000015 10.455957 46.81647000000001 10.4577825 46.8042605 10.450775 46.7976395 10.4389925 46.79678050000001 10.429557 46.79423650000001 10.4267385 46.789406499999984 10.4266435 46.788242999999994 10.4227195 46.781878499999976 10.4338075 46.777613 10.4351105 46.77192600000001 10.4416585 46.75729100000004 10.443800999999999 46.752107000000024 10.4417075 46.75260750000001 10.435468 46.732820000000004 10.400201000000001 46.72847100000001 10.408970000000002 46.7238375 10.410960500000002 46.719054 10.4187305 46.709003499999994 10.416007 46.705465000000004 10.40999 46.705501500000025 10.4033275 46.68920750000001 10.393321500000003 46.68728249999998 10.3835695 46.68430649999999 10.381822 46.67137149999999 10.3924155 46.658861 10.3910135 46.65463750000001 10.3940885 46.64598699999996 10.4002825 46.640567000000004 10.401711 46.63858400000001 10.399859 46.63681199999999 10.402288 46.635058500000014 10.409127500000002 46.63831099999999 10.420209499999999 46.63937899999996 10.443446 46.64127149999999 10.446075499999997 46.633050500000024 10.462565 46.61742050000001 10.484266 46.6153415 10.4920355 46.611053999999996 10.491134000000002 46.6050285 10.4844785 46.59798749999999 10.487394500000002 46.59208449999997 10.483887999999999 46.589471 10.487898999999999 46.580902500000036 10.4835605 46.57719799999998 10.4848455 46.56646649999999 10.474751 46.56257949999994 10.474093 46.55710399999998 10.477748500000002 46.54833049999999 10.471074000000002 46.54350500000001 10.472213499999999 46.541266500000035 10.465685499999998 46.54131899999999 10.459112 46.53654949999995 10.4585785 46.53068300000001 10.452801 46.537391000000014 10.436687999999998 46.551320000000004 10.4181315 46.5439355 10.3973255 46.55004549999998 10.3842675 46.549972499999996 10.3792665 46.55393599999999 10.370484 46.55568599999998 10.352083 46.549454499999996 10.350209499999998 46.542688 10.3384775 46.55166700000001 10.324802 46.546626499999974 10.31066 46.54942299999999 10.3073725 46.549893499999996 10.295437000000002 46.551754500000044 10.293766999999999 46.55510699999999 10.296605000000001 46.55871849999997 10.2952105 46.56459799999999 10.288592 46.57025300000001 10.2866415 46.573953000000046 10.271122 46.5775185 10.268708999999998 46.576956999999965 10.263027 46.57124349999998 10.2535785 46.5745895 10.245915 46.57780149999999 10.243598 46.591571000000016 10.2415625 46.610442500000005 10.2588905 46.62210110000001 10.2448826 46.63533050000001 10.239202999999998 46.628994000000006 10.2239705 46.61694000000003 10.21532 46.620766 10.2063705 46.62313549999999 10.1934005 46.625934 10.1927655 46.62396949999999 10.183067 46.61570849999998 10.162274 46.610761999999994 10.137400000000001 46.607755999999995 10.136514 46.60550699999999 10.128460000000002 46.60710549999996 10.1132595 46.610652000000016 10.1067345 46.61072000000004 10.102353799999998 46.605433500000004 10.098879 46.60097649999997 10.1013495 46.59319850000003 10.0970915 46.58899349999999 10.1011545 46.582847500000014 10.100215 46.57734399999998 10.0953665 46.57514549999996 10.078619 46.571368500000005 10.0796715 46.56715650000004 10.085295 46.56071600000001 10.077671 46.55864199999996 10.071155000000001 46.550325499999985 10.0677165 46.54584999999997 10.061517 46.544044499999984 10.046766999999997 46.53753100000003 10.043919500000001 46.53183999999999 10.053245 46.528711499999986 10.0505365 46.522670000000005 10.0539345 46.513341 10.051483999999999 46.51006050000001 10.0423825 46.50189350000002 10.0450405 46.49984349999997 10.049049499999999 46.49368700000002 10.0449335 46.49039100000002 10.0451295 46.487814000000014 10.048532 46.48306650000001 10.0439165 46.476962499999985 10.045188 46.47177549999995 10.051756 46.46382849999998 10.053769 46.460406999999975 10.052492 46.45241849999999 10.0419855 46.44884400000004 10.0423705 46.446842000000004 10.039349499999998 46.44261850000004 10.0419729 46.43969899999999 10.052583 46.44086849999999 10.056279 46.42838900000001 10.060247999999998 46.425871 10.064393500000001 46.428057499999994 10.077308 46.42594 10.080132499999998 46.421036000000015 10.080472 46.422668999999985 10.092485499999999 46.421358999999995 10.100514500000001 46.4283015 10.1080895 46.42599050000001 10.1172095 46.42909499999996 10.119180499999999 46.4317365 10.129236499999998 46.429081 10.1329865 46.42827750000001 10.1431985 46.42297400000004 10.147088499999999 46.41422449999999 10.14767 46.41282050000001 10.1493865 46.415842999999995 10.157123 46.415445000000005 10.161034000000003 46.407647999999995 10.1666815 46.40346550000001 10.162032 46.390626 10.163860500000002 46.38766749999999 10.162031500000001 46.385009 10.156046 46.3868885 10.147427 46.38622299999997 10.142626 46.37768249999999 10.1273735 46.37427450000001 10.128527499999999 46.36989150000002 10.126140999999999 46.360990000000015 10.1292005 46.3573365 10.119382000000002 46.35267049999999 10.11361 46.35319599999997 10.110085499999999 46.35082200000002 10.108009499999998 46.34631300000001 10.1094305 46.34224450000002 10.1060915 46.33366749999999 10.1042735 46.323493499999984 10.1127215 46.31411249999999 10.116387 46.30461650000001 10.138353499999997 46.3010865 10.137526 46.29559149999997 10.1455545 46.292721 10.1542675 46.289255 10.156594500000002 46.28479800000002 10.154819 46.282354 10.162424 46.27718450000003 10.161245 46.27142599999999 10.1633465 46.266613500000005 10.171935999999999 46.25827650000002 10.1765245 46.25461250000001 10.1749335 46.239642 10.150873500000001 46.230482499999994 10.145949 46.22487699999999 10.132324 46.225594 10.128616 46.223787499999986 10.1232815 46.2257195 10.1091725 46.22856999999999 10.103486 46.228192000000035 10.091609500000002 46.22475299999999 10.0801875 46.2171185 10.0705935 46.22019450000002 10.0630825 46.224974 10.058612500000002 46.22974449999998 10.04367 46.23521099999999 10.052921 46.24151500000002 10.053437000000002 46.244080499999995 10.056963499999998 46.247152 10.0573545 46.24822899999998 10.060568500000002 46.26705750000002 10.053717 46.277417000000014 10.029061999999998 46.28066000000001 10.0092285 46.28476549999999 9.996015 46.29613500000002 9.991741 46.301444000000004 10.00061 46.30354 10.0009425 46.307491 9.996341 46.31307400000003 10.0001955 46.31403599999996 9.994912 46.32314650000001 9.9802195 46.33428549999999 9.985631 46.342343 9.9961245 46.34836100000001 9.9949785 46.350934499999994 9.996764 46.35240750000003 9.993776 46.351787 9.9852395 46.3638 9.9645725 46.37346450000001 9.9560175 46.37812450000001 9.959241 46.379155999999995 9.953191500000003 46.374870999999985 9.934299 46.371533 9.929784999999999 46.367841 9.9306265 46.36591150000001 9.9247885 46.37062700000004 9.9225675 46.37053999999998 9.916729499999999 46.38066210000002 9.9079115 46.37342849999999 9.884071000000002 46.3684475 9.880631999999999 46.362412000000006 9.8682245 46.36464699999999 9.865182 46.36279050000002 9.856281000000001 46.364611999999966 9.8495165 46.36184850000001 9.8461805 46.36098799999999 9.832073500000002 46.35812100000001 9.8309345 46.350685 9.8199985 46.34854949999999 9.809403999999999 46.34420299999999 9.802398 46.34099470000001 9.7845034 46.33546100000001 9.778579499999998 46.335913500000004 9.769648 46.344415 9.7576285 46.34789249999997 9.747367 46.35182000000003 9.7435325 46.35031299999997 9.7358385 46.344268 9.726695 46.34074000000001 9.7231505 46.332697499999995 9.727061499999998 46.331259999999986 9.7233375 46.323980500000005 9.7173255 46.321668999999986 9.7182685 46.319694 9.726010999999998 46.3132755 9.7258225 46.31001499999999 9.7244755 46.30628150000001 9.718219 46.29291839999999 9.7144511 46.29173500000002 9.710146 46.29081049999999 9.7027055 46.293959 9.6940995 46.293835 9.6886605 46.297094500000014 9.681814 46.299980500000004 9.6812475 46.30304850000002 9.6765125 46.29989950000001 9.670003000000001 46.29631199999997 9.669252500000002 46.296052 9.659976 46.29254700000001 9.651024 46.28981350000001 9.6497065 46.28615400000001 9.639238 46.28843050000003 9.624501000000002 46.287364499999995 9.618829 46.294648000000024 9.6104395 46.295710000000014 9.599309500000002 46.29350549999998 9.592726 46.29492450000001 9.589966500000001 46.294904 9.579259 46.29905600000001 9.5730955 46.3027075 9.562162 46.30629299999998 9.55982 46.30597 9.5543925 46.302379099999996 9.5495294 46.3080995 9.5391325 46.326842500000026 9.5186675 46.33260250000001 9.516721 46.33234200000001 9.5142325 46.35148050000001 9.5084725 46.3561665 9.5005305 46.36410299999997 9.496424 46.367335 9.483018999999999 46.37123750000001 9.479331 46.370653000000004 9.476028500000002 46.375970499999994 9.4608135 46.379039000000006 9.462817 46.38349149999999 9.461739 46.38426199999998 9.465143 46.38894049999999 9.4686535 46.412181000000004 9.461561 46.41591600000004 9.4563035 46.420777499999986 9.4542615 46.43670850000001 9.4570765 46.44253549999999 9.4606775 46.463333999999975 9.4590355 46.46964750000001 9.465402 46.48047199999999 9.462247499999998 46.47998049999998 9.449702499999999 46.484376999999995 9.449096 46.48484450000004 9.461036499999999 46.49764299999998 9.4628085 46.505487500000015 9.461066 46.50778249999999 9.464343 46.508351000000005 9.458546 46.50532150000001 9.455071 46.497975999999994 9.4341325 46.48860049999999 9.424823500000002 46.485938000000004 9.4264305 46.476665499999996 9.424429 46.46721250000002 9.413625 46.466791 9.4107885 46.47308850000002 9.3897835 46.48214300000001 9.3851645 46.483948 9.377788 46.489419 9.371252 46.49446649999999 9.3683745 46.49977150000001 9.37333 46.503551000000044 9.3734335 46.50950500000002 9.3623465 46.50426399999998 9.355109 46.505368000000004 9.351115 46.503804 9.3390805 46.50597549999998 9.3375045 46.50413800000001 9.311049 46.497075499999994 9.290703 46.49669499999999 9.2827395 46.48746299999999 9.278994 46.483698000000004 9.274375 46.479103500000036 9.2775535 46.466132500000015 9.2736405 46.4610055 9.277897 46.45153299999998 9.266221 46.44947749999997 9.252794 46.44679450000004 9.2470025 46.43101250000001 9.249851 46.425004 9.260832 46.420585500000044 9.263527 46.418180999999976 9.2696465 46.4188455 9.274534 46.4130615 9.280476 46.40509700000001 9.2821175 46.403434499999975 9.278612 46.401535499999994 9.2816925 46.39495149999999 9.2754055 46.38907649999999 9.27849 46.38629499999999 9.2835185 46.383651499999985 9.283506 46.37346400000001 9.27519 46.37142549999999 9.2771495 46.36781100000002 9.2760725 46.366607999999985 9.278838 46.3578435 9.28253 46.35565249999999 9.2965085 46.35146099999997 9.297838 46.34911249999999 9.2961445 46.343647000000004 9.2999765 46.33588750000004 9.292313 46.331871500000005 9.2935145 46.326456500000035 9.3001415 46.32325 9.295892 46.317239 9.294728 46.31438850000001 9.2852885 46.30922100000001 9.281611 46.29691249999999 9.285065 46.28954250000001 9.2719655 46.28216599999999 9.2677635 46.27856299999999 9.259212 46.26943850000001 9.2570475 46.26739199999997 9.2521175 46.262388999999985 9.2531475 46.25617350000002 9.2490965 46.2514085 9.2513415 46.2475335 9.248358 46.23970350000002 9.249802 46.23203750000002 9.2464385 46.233416500000004 9.2355305 46.2288935 9.2209065 46.223839999999996 9.2229975 46.2142705 9.2188305 46.210748499999994 9.2144015 46.20830599999999 9.202173 46.193625 9.1948445 46.187010499999985 9.198089 46.184056 9.194925 46.178438 9.1940385 46.1691725 9.1810995 46.17094350000002 9.1727465 46.17174299999999 9.1704465 46.17136299999996 9.1686665 46.169601 9.1593775 46.16216349999999 9.156579 46.1533225 9.1345095 46.134817999999996 9.1214755 46.13540649999996 9.117079 46.131970499999994 9.10471 46.12671850000001 9.0997915 46.125782000000044 9.089215 46.1212415 9.078689 46.11810299999999 9.0725175 46.090069 9.089146 46.08569349999999 9.0894325 46.07874100000001 9.0841955 46.075916000000035 9.0790725 46.06520169999999 9.0783211 46.062513499999994 9.073897 46.060667499999994 9.060423 46.06236400000003 9.0502305 46.058971499999984 9.044785 46.05894249999997 9.039377 46.05303200000003 9.028804 46.052694 9.022682 46.04973099999998 9.017218 46.043188499999985 9.0169695 46.03728799999999 9.009525 46.029799000000025 9.007594 46.015908800000005 9.0226588 46.00092749999996 9.0244898 45.993626000000006 9.028461 45.992751999999996 9.02289 45.98953899999998 9.022502 45.98765 9.0180785 45.98790249999999 9.0113585 45.9831815 9.0111415 45.980297500000006 9.0073435 45.98051100000001 8.995348 45.97281200000003 8.995821 45.971641500000004 8.99107 45.972932000000014 8.9885445 45.96655150000001 8.9940255 45.96054800000002 9.013964 45.94917649999999 9.017267 45.943843199999975 9.0122889 45.94151099999999 9.013568 45.93714800000001 9.0224785 45.928442099999984 9.0191952 45.928747499999986 9.0261575 45.926429799999994 9.0298123 45.9274935 9.0427355 45.92208099999996 9.049433 45.920428500000014 9.0490875 45.92094800000001 9.059905 45.916484 9.0590625 45.91279340000003 9.0684974 45.910634500000015 9.0678085 45.912833000000006 9.072649 45.911417 9.076576 45.90338550000001 9.0763465 45.899299499999984 9.0769315 45.90220500000001 9.086842 45.9006622 9.089026 45.89689699999997 9.0888035 45.895962999999966 9.085173 45.891796 9.0816435 45.89202800000001 9.0779545 45.8884645 9.079459 45.8850807 9.0778376 45.88175849999999 9.07146 45.87539050000004 9.0663865 45.8751575 9.0572345 45.873565499999984 9.054807 45.86800100000002 9.053696 45.8626175 9.0491785 45.85552150000001 9.051365 45.85318300000006 9.048236 45.85221250000001 9.0507745 45.849594499999995 9.0453995 45.84659149999999 9.0438115 45.84649250000001 9.0406285 45.842029999999994 9.038652 45.839658499999985 9.0354315 45.83552399999999 9.0378315 45.8246905 9.0309525 45.82301699999999 9.034462 45.82083349999999 9.0313895 45.8219225 9.022372 45.820693500000004 9.0213315 45.81797000000003 9.016526 45.82291649999999 8.998435 45.82197049999999 8.9939145 45.82620850000001 8.994115 45.834944500000006 8.9974875 45.83533700000001 8.9898905 45.838618499999995 8.9867485 45.8357115 8.981385 45.8366345 8.9761725 45.83304050000001 8.9742075 45.83235350000001 8.969984 45.836374000000006 8.9614595 45.83912749999996 8.9619675 45.84290899999999 8.9557735 45.84277799999998 8.946799 45.83890499999998 8.9328775 45.83337549999999 8.9290345 45.83419649999999 8.920476 45.830445 8.912147 45.842229 8.914226 45.860962 8.9325365 45.8637143 8.9393655 45.866978500000016 8.9453015 45.87034299999999 8.9420595 45.867305999999985 8.937027 45.870576700000015 8.9341441 45.885099999999966 8.9319025 45.895763999999986 8.9215375 45.90370249999995 8.924843 45.908998 8.9202431 45.914422599999995 8.9161879 45.91777250000001 8.914312 45.91774000000001 8.907148 45.93301450000001 8.892732 45.947788 8.898775 45.959014999999994 8.893755 45.9568515 8.881602 45.9628352 8.8665315 45.965405000000004 8.864875 45.96623249999999 8.8599296 45.97038649999999 8.8537154 45.97617500000001 8.8468215 45.97734650000004 8.8435515 45.981471 8.842698 45.98165949999998 8.8401025 45.98413249999999 8.8393015 45.985194500000006 8.834186 45.98795999999999 8.831639 45.98766699999999 8.8235925 45.987296000000015 8.8218605 45.99037799999999 8.813912 45.99205950000001 8.795799 45.99188549999997 8.792432 45.988609499999995 8.790857 45.98907550000001 8.785907 46.00810849999996 8.7930945 46.0121905 8.797105 46.02193349999999 8.805911 46.025497 8.819678 46.034227999999985 8.8281665 46.04161099999999 8.8300335 46.040569500000004 8.8327085 46.04377499999998 8.835439 46.046469 8.828817 46.05136949999999 8.8345335 46.04851400000001 8.8441915 46.06159149999996 8.8545945 46.07564150000002 8.852114 46.07575299999996 8.8475165 46.080498500000004 8.8414395 46.08286100000001 8.833761 46.09728499999997 8.8153575 46.101283499999994 8.806036 46.09471099999999 8.7997835 46.094183500000014 8.783036 46.10071450000004 8.7683025 46.1014175 8.7602275 46.10515179999999 8.7556759 46.12222249999999 8.7423305 46.110326999999984 8.724405 46.097272000000004 8.713936 46.101609499999995 8.698031 46.10210249999997 8.6858525 46.110379999999964 8.6792735 46.108826499999964 8.6700255 46.11269149999998 8.657714 46.1225345 8.6478995 46.12332649999999 8.648031 46.122331 8.6288925 46.121669499999996 8.6118585 46.1245275 8.611172 46.13287500000001 8.6097165 46.14277849999999 8.595678 46.14296999999999 8.592897 46.146004000000005 8.593127 46.149557500000014 8.599627 46.15312 8.5999015 46.153539999999964 8.6033675 46.15536900000001 8.603007 46.15668149999999 8.5879885 46.16159700000003 8.5873235 46.16264150000001 8.576414 46.166930500000035 8.572122 46.17705849999999 8.569695 46.1837975 8.5637275 46.186147000000005 8.55405 46.192027999999965 8.553586 46.19737649999999 8.542448 46.20426599999999 8.536403 46.21828249999999 8.532443 46.221850500000016 8.521686 46.2201585 8.515136 46.22910200000001 8.492382 46.23037150000002 8.477527 46.23289500000001 8.4686835 46.24455050000003 8.4641065 46.24789899999999 8.4472735 46.250625000000014 8.4431735 46.254151500000006 8.4422765 46.25801949999999 8.4478905 46.26139499999999 8.4484915 46.2637555 8.4558805 46.27432400000001 8.449771 46.28566599999999 8.4363045 46.291818000000006 8.433995 46.29830050000001 8.4277395 46.302209000000005 8.4330205 46.304119000000014 8.4405335 46.30805000000001 8.43912 46.310137 8.441792 46.31949449999999 8.4437215 46.32126199999996 8.453846 46.32725049999999 8.455656 46.32840899999999 8.4604155 46.333762500000006 8.465357 46.33681300000001 8.463289 46.34465399999999 8.464363 46.353256499999986 8.4615615 46.362551499999995 8.4702345 46.36831749999999 8.466813 46.3800555 8.466513 46.38667649999999 8.4608375 46.39592300000001 8.471172 46.40486799999999 8.4630535 46.41174399999997 8.4683155 46.4231795 8.45687 46.42839950000001 8.4607595 46.43476049999998 8.4575325 46.442679 8.4662415 46.44623899999999 8.4615545 46.450645699999995 8.4619988 46.45535100000001 8.452797 46.461844499999984 8.4500125 46.46371600000003 8.445719 46.46266650000001 8.4386375 46.46429549999999 8.4385285 46.458763000000005 8.4170995 46.458736999999985 8.408417 46.45474200000001 8.402231 46.454560000000015 8.3959535 46.45157549999999 8.392958 46.45215849999997 8.384717 46.45080300000001 8.379003 46.453126499999996 8.3752945 46.45192249999997 8.366936 46.44696299999998 8.355762 46.441643 8.352464 46.42571400000003 8.325441 46.42363149999997 8.3149635 46.425850999999994 8.3074915 46.417438000000004 8.2988965 46.41424600000002 8.298948 46.408109499999995 8.288934 46.40245049999996 8.3035475 46.402026000000006 8.3066035 46.40402450000002 8.3096725 46.3989655 8.3157325 46.394000000000005 8.317292 46.389825 8.3141565 46.386444599999976 8.3186947 46.383949 8.3149465 46.37706600000001 8.3128995 46.374074500000006 8.3000135 46.36913849999999 8.2897935 46.3636305 8.2842825 46.366862 8.273075 46.36402300000003 8.2637725 46.360849 8.260755 46.35710900000001 8.265034 46.3518435 8.2658795 46.34866249999999 8.2599275 46.3459665 8.2628835 46.3464415 8.2529435 46.340757999999994 8.2500425 46.340363999999965 8.235424 46.33444800000001 8.2239955 46.33286050000001 8.225024 46.33024649999999 8.221613 46.32641050000001 8.22507 46.319661999999994 8.214654 46.316227999999995 8.2149275 46.312589 8.2112405 46.30927700000001 8.212012 46.30602249999998 8.2053895 46.302250499999985 8.1987505 46.30423300000001 8.192956 46.29738950000001 8.178897 46.295884 8.1614215 46.301537499999995 8.1470015 46.301929 8.141117 46.301766999999984 8.1375635 46.29475350000001 8.1288565 46.29187350000001 8.120857 46.281143499999985 8.113563 46.27964700000004 8.105455 46.27370100000002 8.1004975 46.266617499999995 8.085928 46.2621135 8.0860575 46.260628999999994 8.080412 46.25428299999999 8.086245 46.25241250000002 8.1013505 46.249468500000035 8.1016175 46.24950449999997 8.1101545 46.23873800000004 8.113034 46.23600299999998 8.1153275 46.236031499999996 8.120479 46.229622000000006 8.1242735 46.226147999999995 8.1388775 46.21159549999999 8.1435255 46.202821 8.1513925 46.1911035 8.153295 46.18222750000004 8.1655095 46.17689060000001 8.1651559 46.17406399999996 8.1585815 46.162503000000015 8.1498785 46.1569375 8.1497415 46.14763099999999 8.1553445 46.13682300000002 8.1443895 46.135271999999986 8.125187 46.130346 8.1154155 46.11743949999999 8.113807 46.111628499999995 8.108233 46.11098999999999 8.099867 46.1084075 8.0971445 46.10545000000002 8.081798 46.10599549999998 8.069219 46.10129549999999 8.0543095 46.10227549999999 8.0491265 46.09992549999998 8.0430585 46.1008406 8.0343476 46.09525099999999 8.0339015 46.08960050000002 8.029584 46.08092149999996 8.029099 46.074708499999986 8.022531 46.06936600000003 8.021662 46.067544500000025 8.024564 46.062984 8.0238735 46.04404499999998 8.0354145 46.03896550000002 8.0220525 46.03120999999999 8.0118915 46.024704499999984 8.017501 46.018853500000006 8.0107585 46.01586350000002 8.0132475 46.01196999999999 8.012413 46.01221100000001 8.001084 45.99987350000001 7.993937 45.99593350000001 7.989094500000001 45.99945349999999 7.977114 45.996072999999996 7.957335 45.99760650000002 7.949491500000001 45.99597850000001 7.9326335 45.996967299999994 7.9086896 45.978635 7.893849000000001 45.97386 7.877425 45.964009000000004 7.8818114999999995 45.95793199999997 7.874891500000001 45.954369499999984 7.878907 45.94911350000001 7.877206500000001 45.947363499999994 7.8703745000000005 45.9363415 7.868500000000001 45.927091700000005 7.8770243 45.920466000000005 7.873073499999999 45.91957249999999 7.8663385 45.91669950000002 7.863576300000001 45.92086950000001 7.858500500000001 45.92172450000001 7.8367205 45.92496399999996 7.831447000000001 45.92696000000001 7.820390500000001 45.91739089999999 7.799501900000001 45.920000500000015 7.793984000000001 45.924949 7.790812999999999 45.93106649999996 7.7765605 45.93711749999997 7.769268 45.94100849999998 7.747751499999999 45.934878 7.745828999999999 45.92829900000001 7.736870999999999 45.9239905 7.7350975 45.923790000000025 7.7204805 45.927734499999985 7.7163335 45.92822799999999 7.712673500000001 45.932908999999995 7.711274 45.93477549999997 7.7073705 45.948155499999984 7.709769999999999 45.9540255 7.6996915 45.95490749999999 7.6876185 45.957772000000034 7.67963 45.96504749999997 7.676995 45.9739855 7.6681735 45.976631999999995 7.657467 45.9701115 7.6395005 45.972368500000016 7.619635 45.96939090000001 7.610003299999999 45.9705165 7.588791 45.974389 7.581727500000001 45.986012500000015 7.5786074999999995 45.987573999999995 7.574703 45.98568750000001 7.561997000000001 45.986556500000006 7.550134 45.9837665 7.545698500000001 45.97617700000001 7.541536999999999 45.96313950000001 7.546722000000001 45.9569425 7.542764 45.95494600000001 7.538433999999999 45.9568615 7.535464499999999 45.95649349999999 7.527978500000001 45.96232450000002 7.5176275 45.957967999999994 7.5075315 45.96241850000004 7.499186 45.95568850000001 7.4934395 45.955809999999985 7.487446 45.952406999999994 7.477937 45.947190000000006 7.471459499999999 45.93662749999996 7.4749315 45.93405949999999 7.471644000000001 45.93555700000002 7.458733999999999 45.932147999999984 7.4558995 45.9317465 7.444620500000001 45.920225000000016 7.434416999999999 45.915402 7.427056500000001 45.90871150000001 7.410806 45.909088499999996 7.405508 45.911474999999996 7.401733 45.908473000000015 7.397882999999999 45.90486099999998 7.3971965 45.897155500000025 7.386337499999999 45.89650449999999 7.382384500000001 45.90413799999999 7.3660675 45.90332749999999 7.3612165 45.907242000000025 7.356449499999999 45.910642499999994 7.3564625 45.91158950000002 7.350535999999999 45.91524050000001 7.344303 45.9105165 7.3307235 45.910229500000014 7.323765 45.91167200000001 7.318111999999999 45.91657950000001 7.3161745 45.91722149999998 7.301557 45.921795900000006 7.294512299999999 45.9157505 7.285315 45.900667999999996 7.2767715 45.89985150000001 7.271476 45.888217999999995 7.256877500000001 45.888465499999995 7.2531435 45.893134 7.2494865 45.890063999999995 7.24054 45.89202 7.228292 45.88976800000003 7.225684000000001 45.8887795 7.2164395 45.883872 7.215700499999999 45.88018099999999 7.206093000000001 45.87647749999999 7.203609 45.87551350000004 7.200118000000001 45.87034299999999 7.197700500000001 45.86308249999999 7.200823499999999 45.8602745 7.196588500000001 45.85867950000002 7.1906025 45.863512000000014 7.1789075 45.86285499999997 7.175214500000001 45.87149950000003 7.161742 45.87668450000001 7.164098999999999 45.879249500000014 7.153543499999999 45.872709499999985 7.1352765 45.866735000000006 7.131419 45.859192500000006 7.117904 45.85927050000004 7.101174999999999 45.87206599999996 7.092142999999999 45.8758335 7.095292 45.88529299999999 7.0799395 45.89017899999999 7.076461500000001 45.895182000000005 7.0766055 45.89992799999999 7.064193 45.909366000000006 7.064455499999999 45.91338300000001 7.060583500000001 45.915546000000006 7.053107000000001 45.922413000000006 7.044886 45.930950499999994 7.041839 45.9384115 7.035671999999999 45.944796999999994 7.038539 45.95427299999997 7.0376 45.960174499999994 7.018369 45.969391 7.009050000000001 45.973304499999955 7.010733 45.976249499999966 7.020972 45.98054100000002 7.022241499999999 45.98670950000002 7.015547 45.98735450000004 7.012056 45.9972765 7.010530999999999 46.001209500000016 7.005619 45.999138000000016 6.999714 46.005127000000044 6.984753000000001 46.02024850000004 6.980931000000001 46.025795000000016 6.971083 46.03118899999998 6.966569 46.03053649999998 6.962905999999999 46.05173099999999 6.949742 46.050956499999984 6.943008 46.05513400000001 6.935878 46.06403749999998 6.937628 46.06672299999997 6.933152999999999 46.06417099999999 6.928431 46.06472400000001 6.923767 46.050640499999986 6.908989000000001 46.04809149999997 6.894678 46.04246150000003 6.890639000000001 46.044479499999994 6.882988999999999 46.047695000000004 6.875638500000001 46.05556849999999 6.873080999999999 46.06945399999998 6.880819000000001 46.07388320000001 6.8914787 46.078670500000015 6.888369 46.08504500000001 6.891781000000001 46.095207000000016 6.8829555 46.10822300000001 6.895308 46.11293799999996 6.893258 46.124055099999964 6.8994739 46.1253815 6.890419 46.1229285 6.882292 46.125782000000044 6.876219 46.1265525 6.851372 46.128963500000026 6.843121999999999 46.13202989999999 6.8415572 46.13106899999997 6.819328 46.129323400000004 6.8152311999999995 46.136101 6.807956 46.13538349999999 6.8009390000000005 46.136798999999996 6.797889 46.154315999999994 6.790425000000001 46.16319649999997 6.792314000000001 46.17280199999999 6.805625000000001 46.17784900000001 6.807331 46.181419500000004 6.812422 46.19646850000001 6.8069749999999996 46.2031365 6.803564 46.2138865 6.810092 46.223460999999986 6.821667 46.22996899999998 6.820745 46.232177500000006 6.821311 46.234245499999986 6.830511 46.240696000000014 6.837019000000001 46.24830650000001 6.840119 46.25465 6.855108500000001 46.25889600000002 6.854517 46.26587299999997 6.859961 46.273799999999994 6.859064 46.28059400000001 6.864807999999999 46.29043200000001 6.858923500000001 46.292381500000005 6.854228 46.28998200000004 6.847147 46.299792999999994 6.834328 46.29984300000001 6.830533000000001 46.30277649999999 6.828208 46.30605299999999 6.830028000000001 46.315338 6.819344000000001 46.320651999999995 6.806631 46.319851 6.8006585 46.332802000000015 6.796461 46.3329315 6.784402999999999 46.34440599999999 6.779319499999999 46.34728770000001 6.774688499999999 46.35520550000001 6.770442 46.36118299999998 6.771636 46.36647049999999 6.780803 46.367142 6.791786 46.37670149999997 6.803819 46.3831175 6.805885999999999 46.38694000000001 6.8017935000000005 46.394070699999986 6.8052021 46.42715450000003 6.821064 46.454334500000016 6.681858 46.4563675 6.519104 46.415806 6.425619 46.403717 6.3351895 46.36042000000003 6.252957 46.3435825 6.24136 46.3294295 6.231694 46.31187800000001 6.219547 46.304564399999975 6.2413903 46.301552000000015 6.248842 46.3002625 6.247178000000001 46.294456499999995 6.248481 46.29167949999999 6.251883 46.2878915 6.251224999999999 46.285083499999985 6.244290000000001 46.28179549999999 6.237864 46.27661899999998 6.237747 46.26229500000002 6.250052 46.25487500000003 6.260860999999999 46.251705000000044 6.260172 46.24769950000001 6.266508000000001 46.25452050000001 6.284622 46.25623700000003 6.284043999999999 46.264599000000004 6.294877999999999 46.263679999999994 6.296544 46.25595450000003 6.295236 46.2548635 6.300889 46.25618000000003 6.310281 46.25502399999999 6.308533 46.251243500000015 6.306055499999999 46.2499655 6.309328 46.2440455 6.310210999999999 46.22493 6.2944640000000005 46.223464999999976 6.2917275 46.215248 6.276372 46.213390499999974 6.265539000000001 46.20499050000001 6.24875 46.20655450000004 6.2450079999999994 46.204822500000006 6.243419 46.20636350000001 6.234133 46.2035635 6.230119 46.201415999999966 6.223854000000001 46.193794499999996 6.214244 46.192184499999996 6.206817 46.18377749999999 6.198424999999999 46.18142299999997 6.189075 46.178226499999994 6.186103 46.16619450000002 6.188839 46.158142 6.175417 46.151527500000014 6.152244 46.14591999999999 6.146694 46.14481749999999 6.1449 46.147007 6.141611 46.14115899999999 6.135542 46.1404685 6.126619 46.1426735 6.121164 46.143966500000005 6.099131 46.1516685 6.091844 46.14930749999996 6.0745585 46.151268000000044 6.051922 46.147414999999995 6.048703 46.14094549999999 6.047811 46.14106749999999 6.042919 46.134765000000016 6.035725 46.139365999999995 6.031981000000001 46.14070400000003 6.0243864 46.14294449999997 6.015263999999999 46.14194500000002 6.003766999999999 46.144428500000004 5.993983 46.1421349 5.9827235 46.13587949999999 5.980358 46.13262950000001 5.976353 46.12958549999999 5.965283 46.130302 5.960917000000001 46.12794809999997 5.957313200000001 46.1320887 5.9560876 46.13718399999999 5.965939 46.14469550000001 5.964661 46.15617510000001 5.973363000000001 46.16032400000003 5.9762293 46.172680000000014 5.981867 46.173564999999996 5.984863999999999 46.1707375 5.988297 46.17686119999999 5.9923112 46.179328999999996 5.99165 46.18289549999997 5.995222 46.1874315 5.991342 46.196968200000015 5.9637 46.19802770000001 5.9642155 46.202526000000006 5.972953 46.2066385 5.969278 46.214751999999976 5.974414 46.21690750000002 5.978375 46.21550350000001 5.993136000000001 46.22239300000001 5.9914325 46.22240049999999 5.996338999999999 46.220115899999996 6.0000851 46.223468999999994 6.006867 46.22915649999999 6.010006 46.228992500000004 6.013508 46.2305825 6.012864 46.2318305 6.016677999999999 46.233238 6.0251925 46.238426000000004 6.033722 46.233104499999996 6.042397 46.2314375 6.046336 46.24517800000001 6.061139 46.24561649999998 6.0634575 46.24107749999999 6.069625000000001 46.24704349999999 6.088136 46.2375375 6.101817 46.240688499999976 6.106342 46.23966200000001 6.109014 46.250572000000034 6.12358 46.261150499999985 6.120089999999999 46.26358400000001 6.1182 46.264759 6.120130999999999 46.26566300000002 6.116042 46.27021400000001 6.110389 46.27246099999999 6.113458 46.278385000000014 6.103639 46.2839735 6.10455 46.28485499999999 6.102367 46.294182000000006 6.1132555 46.29430399999998 6.118958 46.2971685 6.121142 46.3077165 6.119092000000001 46.312404500000014 6.119808000000001 46.31726850000001 6.124369 46.317509099999995 6.1257606000000004 46.32118600000001 6.126711000000001 46.32466010000002 6.1314595 46.3331263 6.1377108 46.33463710000001 6.1392202000000005 46.33558249999999 6.137258 46.3393135 6.138619 46.342712500000005 6.149157999999999 46.34727849999999 6.151547 46.35096500000003 6.1580323 46.35758200000001 6.15935 46.36643219999999 6.170156500000001 46.37953949999999 6.158578000000001 46.37761699999999 6.156664 46.377395500000006 6.149839 46.387817499999954 6.135853 46.399925499999995 6.113564 46.396698000000015 6.114083 46.39971550000001 6.105511 46.408607500000016 6.098221499999999 46.416223900000006 6.064025899999999 46.431843000000015 6.074907999999999 46.43956399999999 6.084172 46.44314600000001 6.086244 46.44737650000002 6.084431 46.4533275 6.074894 46.457325 6.076842 46.459934000000004 6.073467 46.46575150000001 6.0728275 46.481587899999994 6.0971403 46.50990349999998 6.112961 46.53057499999997 6.137494 46.52801149999999 6.144202999999999 46.536617500000006 6.153417 46.53935599999997 6.148575000000001 46.545252000000005 6.1564804 46.57665650000001 6.1109610000000005 46.584014999999965 6.121743999999999 46.5894735 6.126113999999999 46.59711849999999 6.138842 46.603759999999994 6.153778 46.60990150000001 6.161225 46.616161500000004 6.179136 46.620205 6.180358000000001 46.62818149999998 6.196011 46.634254500000026 6.19985 46.6360665 6.208083 46.644899699999996 6.2194419 46.64811700000001 6.227711 46.6549455 6.233578 46.67647199999999 6.267544 46.67923350000001 6.270553 46.68272000000002 6.269439000000001 46.69045650000001 6.2831085 46.698581700000034 6.3074067 46.706039499999974 6.324135999999999 46.710376999999966 6.342011 46.71514500000001 6.352424499999999 46.72308749999999 6.360242 46.72191650000002 6.364485999999999 46.724357499999996 6.371761 46.728816999999964 6.371478 46.729255499999994 6.368117 46.730365999999975 6.370067000000001 46.73210900000001 6.3854845 46.738151000000016 6.391610999999999 46.743209999999976 6.388475 46.7478715 6.394511 46.75069450000001 6.400689 46.75001550000002 6.404272 46.75276550000001 6.417144000000001 46.75708800000001 6.430822 46.762573 6.439425 46.76637249999999 6.438902 46.773987000000005 6.4516915 46.778572499999996 6.451786 46.78831099999999 6.458442499999999 46.802040000000005 6.43463 46.81232850000001 6.430997 46.81626499999999 6.440680999999999 46.824123499999985 6.439606 46.831878500000045 6.442506 46.8515515 6.460010999999999 46.8755415 6.462804 46.89041499999996 6.464458 46.900982 6.4578 46.92165 6.435789 46.928455499999956 6.432750000000001 46.933410699999996 6.444752199999999 46.9430735 6.459481 46.95561810000001 6.471642 46.9671635 6.486020300000001 46.974178600000045 6.4966990000000004 46.966140499999995 6.5059640000000005 46.97080600000001 6.518606 46.979416000000015 6.563492 46.99078750000004 6.5919305 46.992526999999995 6.596142 46.991626499999995 6.616914 46.99840950000001 6.6337105 47.006561500000004 6.643747 47.0263405 6.658475000000001 47.035229000000015 6.677939 47.038803 6.698958499999999 47.0523225 6.7197439999999995 47.053458500000005 6.7124925 47.057998500000025 6.708872 47.05888749999997 6.700968999999999 47.06640999999999 6.691792 47.073868000000004 6.705781000000001 47.079155000000014 6.707525000000001 47.081501 6.702785999999999 47.08847800000001 6.715808 47.091792999999996 6.725930999999999 47.08961099999999 6.731325 47.090482399999985 6.7390397 47.09238449999998 6.743385999999999 47.09645450000002 6.746044 47.1086425 6.739968999999999 47.109610299999986 6.7441387 47.12033450000001 6.765146999999999 47.1210595 6.775303000000001 47.127027999999996 6.792348 47.130206999999984 6.804992000000001 47.13538349999996 6.808631 47.135479000000004 6.815083 47.14635099999998 6.8285860000000005 47.15034850000001 6.839611 47.154289000000006 6.841661000000001 47.15646000000001 6.849975 47.16528890000001 6.8589121 47.1664045 6.845239 47.17139799999998 6.841327999999999 47.180000500000006 6.8637809999999995 47.185287500000015 6.867591999999999 47.18533350000004 6.873894 47.18956749999998 6.873714 47.200031499999994 6.879939 47.205070500000005 6.889444500000001 47.218192999999985 6.9103140000000005 47.222133499999984 6.923847000000001 47.228488999999996 6.927531 47.23088450000003 6.932999999999999 47.23106000000004 6.939418999999999 47.234526999999986 6.9427387000000005 47.238178500000004 6.943239 47.24297470000002 6.9554785 47.2534675 6.946507999999999 47.25967800000001 6.951108 47.26903949999999 6.951943999999999 47.2865065 6.940742000000001 47.292392500000005 6.953224999999999 47.29275100000004 6.9685109999999995 47.291424000000006 6.973294 47.296367499999974 6.976575000000001 47.29612749999998 6.996572 47.30140699999998 7.003336000000001 47.30129609999997 7.007402700000001 47.313984000000005 7.016214 47.31991199999999 7.013608 47.3208315 7.009719 47.324367499999994 7.009739 47.3284075 7.034439 47.32672099999999 7.045719000000001 47.33439250000001 7.056631000000001 47.33689900000002 7.052925 47.339878 7.059147 47.34373449999998 7.061636 47.34722149999999 7.0499245 47.351661500000006 7.052586 47.36184299999999 7.048925 47.364029000000016 7.043322000000001 47.36358949999999 7.0344750000000005 47.36787749999999 7.0336515 47.3695185 7.033335999999999 47.370311499999985 7.020406 47.372883 7.017908 47.37149449999998 7.013417 47.372794999999996 7.012343999999999 47.367558 7.006125 47.363449 6.995997 47.3635065 6.983092 47.35985949999997 6.974433 47.359768 6.951407999999999 47.35755549999999 6.941756 47.3584065 6.932978000000001 47.3553125 6.921100000000001 47.35940550000001 6.901847 47.35770400000001 6.899225 47.358611999999994 6.895747 47.35639549999999 6.894472 47.352810000000005 6.8847689999999995 47.35244 6.879806000000001 47.35743350000004 6.878969 47.36701199999996 6.884849999999999 47.37315749999999 6.883669 47.379940000000005 6.895586 47.38166799999999 6.894963999999999 47.382942000000014 6.905180499999999 47.38618450000001 6.9119395 47.38945749999999 6.913669 47.39618300000001 6.909542 47.39736199999999 6.915439 47.40323999999998 6.917817 47.40465950000001 6.9136169999999995 47.40650199999999 6.919436 47.405204999999995 6.920874999999999 47.40647899999999 6.9385995 47.416027000000014 6.941681000000001 47.433704500000005 6.939186000000001 47.435077500000034 6.954618999999999 47.4337275 6.957753000000001 47.4356995 6.96365 47.44705999999999 6.970293999999999 47.44899000000001 6.981431 47.447895000000045 6.990261 47.4537435 7.00155 47.456028 7.000947 47.45663450000001 6.997528000000001 47.46007900000001 6.9980530000000005 47.461761499999994 7.001092 47.46687750000001 7.000361 47.46642700000001 6.991778000000001 47.4712485 6.992925 47.476211500000005 6.986539 47.487262499999986 6.988467 47.4942705 6.982913999999999 47.49358000000001 6.986303 47.49995050000001 7.000853 47.504222999999996 7.024406 47.50133149999999 7.0272395 47.4975015 7.036975000000001 47.49817300000001 7.044802999999999 47.49519350000003 7.051317000000001 47.49521200000001 7.060406 47.4922675 7.071342 47.488167000000004 7.074877999999999 47.494834999999995 7.091671999999999 47.495105499999994 7.111858 47.503589500000004 7.128017 47.5020945 7.138075 47.497116000000005 7.1504829999999995 47.49077199999999 7.159363500000001 47.48934550000001 7.169347 47.49388099999999 7.201083 47.49170699999999 7.202327999999999 47.488201000000004 7.190864 47.46813950000001 7.177603 47.4641762 7.178829400000001 47.45813990000002 7.178262199999999 47.4434545 7.170422 47.438755000000015 7.192267 47.43542099999999 7.196180499999999 47.434894499999956 7.206239 47.43977749999999 7.225569 47.43688950000001 7.235908 47.43383800000001 7.238603 47.42879499999998 7.2385744999999995 47.42684550000001 7.245017000000001 47.4202995 7.245588999999999 47.423992 7.254164 47.427043999999995 7.270469 47.434627499999976 7.282563999999999 47.43312049999997 7.292203 47.43873199999999 7.302975 47.438961000000035 7.324572 47.4398535 7.326465999999999 47.44143300000002 7.329825 47.4409105 7.338706 47.43535600000001 7.347222 47.43189250000003 7.380894 47.43539799999999 7.400356000000001 47.43551249999999 7.402983000000001 47.437862499999994 7.402847 47.440201 7.406581000000001 47.442039499999964 7.413942 47.44638800000001 7.421139500000001 47.4508285 7.423344000000001 47.453521499999994 7.428478 47.459282 7.430072 47.461723500000005 7.445019 47.47036 7.4552475 47.47279 7.455797 47.475307999999984 7.450483000000001 47.4742205 7.447819 47.478473500000035 7.443783 47.48246 7.4293689999999994 47.48018250000001 7.421236 47.488387999999986 7.4255439999999995 47.49797049999998 7.434775 47.48943700000001 7.454636000000001 47.489093999999994 7.462125 47.48044949999999 7.470896999999999 47.48230749999999 7.487628 47.48925400000002 7.497505999999999 47.490440500000034 7.502 47.49351899999999 7.501919 47.496826 7.510972 47.501945500000005 7.508725 47.50258250000002 7.5109055 47.50958249999999 7.509197 47.515987499999994 7.499164 47.521233000000024 7.497817 47.51462150000003 7.503519 47.517044 7.516753 47.515067999999985 7.518808 47.515232 7.523900000000001 47.51867300000001 7.523786 47.527717499999994 7.531475000000001 47.532306500000004 7.527814 47.53195199999999 7.524439000000001 47.534534500000035 7.519208 47.53260800000004 7.5161964999999995 47.5285265 7.509817 47.52848449999999 7.502432999999999 47.535240499999986 7.499042 47.53983299999999 7.499239 47.54297249999999 7.504519000000001 47.54476149999999 7.507889 47.546131 7.519233 47.55164350000001 7.525233 47.56339250000002 7.551786 47.56456399999996 7.5551595 47.56939299999999 7.558861000000001 47.57120499999996 7.556386 47.57261649999998 7.557483 47.57740849999999 7.566267 47.576145 7.574818999999999 47.575657000000035 7.584828 47.589878 7.589039 47.58482650000002 7.6049385 47.57779199999999 7.6045105 47.57683 7.619065 47.57944599999999 7.624522999999999 47.59131550000001 7.643203 47.59422250000003 7.6419325 47.5969685 7.645815999999999 47.59621799999999 7.64904 47.592044500000014 7.667261 47.592040499999996 7.675051 47.59849199999999 7.682847 47.600644999999986 7.693370000000001 47.58735999999999 7.6717545000000005 47.5850925 7.6720429999999995 47.58269250000001 7.680725 47.58092049999996 7.681114 47.57398549999999 7.6837435 47.57150050000001 7.6895305 47.5656175 7.6859705 47.571181000000024 7.6834375 47.565447000000006 7.675219499999999 47.56384800000001 7.677368999999999 47.563770999999974 7.6723384999999995 47.56588099999999 7.6701595 47.56242900000001 7.654705999999999 47.559883499999984 7.648155999999999 47.56401149999999 7.6362285 47.561113500000005 7.634097 47.552615 7.6453055 47.546996500000006 7.6515245 47.54484500000001 7.6613955 47.53661500000001 7.666803999999999 47.53355450000001 7.67529 47.532498000000004 7.6862235 47.5329035 7.6969815 47.539405000000016 7.713784499999999 47.54222900000002 7.72405 47.545027000000005 7.7526765 47.54837650000002 7.757851999999999 47.553296999999986 7.783334000000001 47.5574455 7.795672500000001 47.562637499999965 7.799482 47.5707525 7.8119955 47.587106000000006 7.8188200000000005 47.58656100000002 7.832744 47.58263649999998 7.837581000000001 47.582381 7.8472075 47.58735250000001 7.860485 47.588516 7.868769999999999 47.588872500000036 7.885044999999999 47.586371499999984 7.8940966 47.584053900000015 7.8979583 47.576923599999986 7.906522699999999 47.569016500000004 7.911530000000001 47.560816999999986 7.9073875 47.55542249999999 7.908518 47.54772650000001 7.917205500000001 47.54691650000001 7.932319 47.54448099999999 7.9404995000000005 47.54396500000004 7.9455505 47.545548 7.948642999999999 47.557116000000036 7.955421 47.558276000000035 7.960036499999999 47.557180500000015 7.964700999999999 47.555215000000004 7.977975999999999 47.556397499999974 7.999166 47.55497350000002 8.0072325 47.55454950000001 8.0082015 47.5504545 8.0195435 47.55529999999999 8.0460355 47.56342000000001 8.0592765 47.564490500000005 8.067313 47.56411299999999 8.071343 47.557436499999994 8.083569 47.557901999999984 8.090359 47.56102899999999 8.0971805 47.566363499999966 8.101439 47.57609900000003 8.102989 47.580723000000006 8.107204 47.583541 8.1127155 47.583286499999986 8.1261005 47.58404999999999 8.1364095 47.59078149999999 8.1383625 47.59498450000004 8.1472935 47.594154 8.159201 47.59430850000001 8.1655465 47.60195199999998 8.174452 47.60480949999999 8.184461 47.6162745 8.193912 47.62035850000001 8.201661 47.6199805 8.214005 47.6155119 8.2212491 47.60684979999999 8.2240473 47.605135500000046 8.225893 47.605396499999955 8.2293505 47.6127285 8.2382285 47.615223499999985 8.258417 47.613464300000004 8.2611483 47.609419 8.2651135 47.611617499999966 8.279824 47.6103195 8.2884835 47.60548 8.297631 47.594603500000034 8.2950295 47.58874500000002 8.298266 47.58364850000001 8.31029 47.578940999999986 8.3163515 47.572606500000006 8.324458 47.57039800000001 8.337175 47.569488500000006 8.3621045 47.565495 8.3835395 47.575016000000005 8.392099 47.577068 8.3995065 47.570742499999994 8.416288 47.567548999999985 8.4264345 47.567102000000006 8.437169 47.572355000000016 8.4558925 47.572212500000006 8.4641205 47.57786149999998 8.476828 47.577242600000034 8.4837482 47.577717699999994 8.4869211 47.5812014 8.4945405 47.587851 8.488619 47.587354000000005 8.4870125 47.583950000000016 8.468808 47.588036999999986 8.4648145 47.58830549999999 8.460419 47.59257199999999 8.461227 47.59728500000003 8.457047 47.60235549999999 8.4565995 47.603658499999995 8.468109 47.606893000000014 8.4713795 47.60847250000003 8.4702785 47.60769749999997 8.474989 47.61073099999999 8.4778125 47.615163499999994 8.4791385 47.613639500000005 8.483242 47.614475 8.493896 47.61750749999999 8.5082515 47.623845500000016 8.507306 47.62336500000001 8.514944 47.625587499999966 8.512608 47.63195000000002 8.5164495 47.63391999999999 8.515533 47.63447450000001 8.520817 47.63176849999999 8.5257255 47.63113849999999 8.538118 47.626094499999994 8.5385565 47.6269575 8.5430435 47.6252245 8.5441355 47.624562 8.557338 47.61676750000004 8.562801 47.61726949999999 8.5692955 47.612491500000004 8.5710365 47.611931 8.574408 47.60987399999999 8.566406 47.60537399999998 8.5660625 47.601382 8.561473 47.599432500000006 8.562841 47.59710300000003 8.5664905 47.598161000000005 8.5714195 47.59552149999999 8.574658 47.596823 8.577079 47.596134500000005 8.582355 47.6017765 8.587799 47.602226 8.5913965 47.60615899999999 8.592694 47.6055389 8.595596 47.611261799999994 8.6034488 47.6159825 8.6049595 47.628964999999994 8.5973905 47.64262750000003 8.595324 47.65242599999996 8.6077065 47.6493485 8.6126925 47.644137 8.613848 47.64209499999998 8.611146 47.641547 8.6044635 47.639467999999994 8.602787 47.637061500000044 8.606523 47.63801200000003 8.616754 47.641021499999994 8.623423 47.64872359999998 8.6282974 47.653306999999984 8.6279875 47.66152840000001 8.6144855 47.66075749999999 8.612818 47.66342349999999 8.608964 47.669003799999984 8.6063557 47.67212950000001 8.6066495 47.672807000000006 8.598066 47.66706049999999 8.593828 47.66640800000002 8.5873725 47.6616085 8.577711 47.66470699999999 8.570951 47.66533200000001 8.5646325 47.66994399999996 8.563654 47.66705999999999 8.5471585 47.66507200000001 8.540051 47.65706 8.5414315 47.65992399999999 8.533774 47.6632075 8.533378 47.660394999999994 8.5270095 47.65061399999996 8.533424 47.64578850000001 8.531527 47.6449815 8.522713 47.64749849999998 8.5133275 47.647055499999965 8.4931125 47.642104500000045 8.4942035 47.64206999999999 8.4923425 47.64509699999999 8.4873385 47.64420200000001 8.482706 47.649231499999985 8.4805195 47.64982499999999 8.4737635 47.64794899999998 8.4729355 47.644675000000035 8.477685 47.642341500000015 8.471116 47.639707999999985 8.477887 47.638307 8.473507 47.641293500000046 8.4674745 47.648559999999975 8.4637715 47.656075500000014 8.4671755 47.657044499999984 8.4656325 47.65269200000003 8.4573885 47.654843 8.453655 47.654739500000005 8.449051 47.65378200000001 8.4450905 47.65739049999999 8.4367715 47.666814999999986 8.423684 47.66627449999996 8.412355 47.67451349999999 8.405566 47.67872349999999 8.408517 47.679632 8.4160395 47.683865 8.420668 47.694255999999996 8.4121365 47.69546700000001 8.4063995 47.69806350000002 8.404426 47.709968299999986 8.4167944 47.71113199999999 8.4258785 47.718233 8.436732 47.717668499999974 8.4415515 47.71975599999999 8.440226 47.722961 8.4452355 47.722635 8.4552019 47.72721999999999 8.4546655 47.72915810000001 8.4569668 47.73043150000001 8.4528545 47.73816600000001 8.4496835 47.74277699999999 8.4558505 47.74944000000002 8.456882 47.753784499999995 8.466608 47.764588 8.473712 47.7732685 8.4890275 47.77069149999997 8.4960265 47.773608499999995 8.502137 47.77431500000003 8.509297 47.776186199999984 8.5101076 47.770490499999994 8.520118 47.778133499999996 8.5264825 47.7779845 8.532663 47.784636500000005 8.5526745 47.780495 8.562975 47.77785399999999 8.5625445 47.777976800000005 8.5661975 47.781540300000046 8.5770821 47.789526499999994 8.5749215 47.792771500000015 8.5616945 47.8053185 8.5635385 47.80848800000001 8.5678585 47.80598999999998 8.573027</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </Polygon>
+                  </gml:surfaceMember>
+                </MultiSurface>
+              </gmd:polygon>
+            </gmd:EX_BoundingPolygon>
+          </gmd:geographicElement>
+        </gmd:EX_Extent>
+      </srv:extent>
+      <srv:coupledResource>
+        <srv:SV_CoupledResource>
+          <srv:operationName>
+            <gco:CharacterString>GetCapabilities</gco:CharacterString>
+          </srv:operationName>
+          <srv:identifier>
+            <gco:CharacterString>7d60efcf-5997-4124-9340-a6c5178a6dee</gco:CharacterString>
+          </srv:identifier>
+          <gco:ScopedName />
+        </srv:SV_CoupledResource>
+      </srv:coupledResource>
+      <srv:coupledResource>
+        <srv:SV_CoupledResource>
+          <srv:operationName>
+            <gco:CharacterString>GetCapabilities</gco:CharacterString>
+          </srv:operationName>
+          <srv:identifier>
+            <gco:CharacterString>3373ea93-ed63-4ff6-a43a-e15a7bf1f24b</gco:CharacterString>
+          </srv:identifier>
+          <gco:ScopedName />
+        </srv:SV_CoupledResource>
+      </srv:coupledResource>
+      <srv:coupledResource>
+        <srv:SV_CoupledResource>
+          <srv:operationName>
+            <gco:CharacterString>GetCapabilities</gco:CharacterString>
+          </srv:operationName>
+          <srv:identifier>
+            <gco:CharacterString>b4c3f648-6778-4701-a5c7-31e764d12127</gco:CharacterString>
+          </srv:identifier>
+          <gco:ScopedName />
+        </srv:SV_CoupledResource>
+      </srv:coupledResource>
+      <srv:couplingType>
+        <srv:SV_CouplingType codeList="http://www.isotc211.org/2005/iso19119/resources/Codelist/gmxCodelists.xml#SV_CouplingType" codeListValue="tight" />
+      </srv:couplingType>
+      <srv:containsOperations>
+        <srv:SV_OperationMetadata>
+          <srv:operationName>
+            <gco:CharacterString>GetCapabilities</gco:CharacterString>
+          </srv:operationName>
+          <srv:DCP>
+            <srv:DCPList codeList="http://www.isotc211.org/2005/iso19119/resources/Codelist/gmxCodelists.xml#DCPList" codeListValue="WebServices" />
+          </srv:DCP>
+          <srv:connectPoint>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <gmd:URL>http://wms.ga.admin.ch/LG_DE_Geologie_und_Tektonik/wms?service=wms&amp;request=getcapabilities</gmd:URL>
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://wms.ga.admin.ch/LG_DE_Geologie_und_Tektonik/wms?service=wms&amp;request=getcapabilities</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://wms.ga.admin.ch/SGN_FR_Geologie_et_Tectonique/wms?service=wms&amp;request=getcapabilities</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>OGC:WMS</gco:CharacterString>
+              </gmd:protocol>
+            </gmd:CI_OnlineResource>
+          </srv:connectPoint>
+        </srv:SV_OperationMetadata>
+      </srv:containsOperations>
+      <srv:containsOperations>
+        <srv:SV_OperationMetadata>
+          <srv:operationName>
+            <gco:CharacterString>GetMap</gco:CharacterString>
+          </srv:operationName>
+          <srv:DCP>
+            <srv:DCPList codeList="http://www.isotc211.org/2005/iso19119/resources/Codelist/gmxCodelists.xml#DCPList" codeListValue="WebServices" />
+          </srv:DCP>
+          <srv:connectPoint>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <gmd:URL>http://wms.ga.admin.ch/LG_DE_Geologie_und_Tektonik/wms</gmd:URL>
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://wms.ga.admin.ch/LG_DE_Geologie_und_Tektonik/wms</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#FR">http://wms.ga.admin.ch/SGN_FR_Geologie_et_Tectonique/wms</che:LocalisedURL>
+                  </che:URLGroup>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#EN">http://wms.ga.admin.ch/exows/?language=eng</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>OGC:WMS</gco:CharacterString>
+              </gmd:protocol>
+            </gmd:CI_OnlineResource>
+          </srv:connectPoint>
+        </srv:SV_OperationMetadata>
+      </srv:containsOperations>
+      <srv:containsOperations>
+        <srv:SV_OperationMetadata>
+          <srv:operationName>
+            <gco:CharacterString>GetFeatureInfo</gco:CharacterString>
+          </srv:operationName>
+          <srv:DCP>
+            <srv:DCPList codeList="http://www.isotc211.org/2005/iso19119/resources/Codelist/gmxCodelists.xml#DCPList" codeListValue="WebServices" />
+          </srv:DCP>
+          <srv:connectPoint>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage xsi:type="che:PT_FreeURL_PropertyType">
+                <gmd:URL>http://wms.ga.admin.ch/LG_DE_Geologie_und_Tektonik/wms</gmd:URL>
+                <che:PT_FreeURL>
+                  <che:URLGroup>
+                    <che:LocalisedURL locale="#DE">http://wms.ga.admin.ch/LG_DE_Geologie_und_Tektonik/wms</che:LocalisedURL>
+                  </che:URLGroup>
+                </che:PT_FreeURL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>OGC:WMS</gco:CharacterString>
+              </gmd:protocol>
+            </gmd:CI_OnlineResource>
+          </srv:connectPoint>
+        </srv:SV_OperationMetadata>
+      </srv:containsOperations>
+      <srv:operatesOn uuidref="7d60efcf-5997-4124-9340-a6c5178a6dee" xlink:href="http://www.geocat.ch/geonetwork/srv/eng/csw?service=CSW&amp;request=GetRecordById&amp;version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=7d60efcf-5997-4124-9340-a6c5178a6dee" />
+      <srv:operatesOn uuidref="3373ea93-ed63-4ff6-a43a-e15a7bf1f24b" xlink:href="http://www.geocat.ch/geonetwork/srv/eng/csw?service=CSW&amp;request=GetRecordById&amp;version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=3373ea93-ed63-4ff6-a43a-e15a7bf1f24b" />
+      <srv:operatesOn uuidref="b4c3f648-6778-4701-a5c7-31e764d12127" xlink:href="http://www.geocat.ch/geonetwork/srv/eng/csw?service=CSW&amp;request=GetRecordById&amp;version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id=b4c3f648-6778-4701-a5c7-31e764d12127" />
+    </srv:SV_ServiceIdentification>
+  </gmd:identificationInfo>
+</che:CHE_MD_Metadata>
+


### PR DESCRIPTION
Fix errors during the migration with the conversion from iso19139.che to iso19115-3.20§8.che

https://swissgeoplatform.atlassian.net/browse/MGEO_SB-1122?focusedCommentId=36277

Errors:

1. "A sequence of more than one item is not allowed as the first argument of normalize-space() (\\"Forfaits \xc3\xa0 l\'ha des subvention...\\", \\"Monitoring des for\xc3\xaats protectr...\\"

gmd:featureCatalogueCitation/gmd:CI_Citation/gmd:title

- gco:CharacterString
- gmd:textGroup/gmdLocalisedCharacterString

Accept only one value for element featureCatalogueCitation

2. "A sequence of more than one item is not allowed as the first argument of normalize-space() (\\"1.1.1\\", \\"1.3.0\\"

\\"1.0.0\\", \\"\\"
\\"1.0.0\\", \\"1.3.0\\"

srv:serviceTypeVersion accept only one version in iso19115-3.2018.che