### PR TITLE
Update DCAT-AP-CH formatter and regenerate test snapshots

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,18 @@
       </exclusions>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-shacl</artifactId>
+      <version>4.10.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.17.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
+++ b/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
@@ -50,7 +50,7 @@
   
   <xsl:template match="che:CHE_MD_Metadata" mode="iso19115-3-to-dcat">
     <xsl:variable name="uuid" select="mdb:metadataIdentifier/*/mcc:code/*/text()"/>
-    <xsl:variable name="resourceUri" select="concat($geonetworkBaseUrl, 'api/records/', $uuid, '/formatters/dcat-ap-ch')"/>
+    <xsl:variable name="resourceUri" select="concat($geonetworkBaseUrl, 'srv/api/records/', $uuid, '/formatters/dcat-ap-ch')"/>
     
     <dcat:Dataset rdf:about="{$resourceUri}">
       <!-- 1. TYPE -->
@@ -232,7 +232,7 @@
         starts-with($protocol, 'MAP:Preview')
       ">
         <xsl:variable name="datasetUuid" select="ancestor::che:CHE_MD_Metadata/mdb:metadataIdentifier/*/mcc:code/*/text()"/>
-        <xsl:variable name="distributionUri" select="concat($geonetworkBaseUrl, 'api/records/', $datasetUuid, '/distributions/', position())"/>
+        <xsl:variable name="distributionUri" select="concat($geonetworkBaseUrl, 'srv/api/records/', $datasetUuid, '/distributions/', position())"/>
         <dcat:distribution>
           <dcat:Distribution rdf:about="{$distributionUri}">
             <!-- Access URL -->

--- a/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
+++ b/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
@@ -30,6 +30,7 @@
                 xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
                 xmlns:skos="http://www.w3.org/2004/02/skos/core#"
                 xmlns:local="http://local-functions"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
                 exclude-result-prefixes="#all">
 
   <!-- ================================================ -->
@@ -38,13 +39,18 @@
   <!-- https://handbook.opendata.swiss/de/content/glossar/bibliothek/dcat-ap-ch.html -->
   <!-- ================================================ -->
 
+  <!-- Base URL of the GeoNetwork instance (no trailing slash); resolved at runtime via GeoNetwork setting 'nodeUrl' -->
+  <xsl:param name="geonetworkBaseUrl" select="util:getSettingValue('nodeUrl')"/>
+  <!-- Base URL of the opendata datahub (geocat.ch-specific, no trailing slash) -->
+  <xsl:param name="datahubBaseUrl" select="'https://www.geocat.ch/datahub'"/>
+
   <!-- ================================================ -->
   <!-- MAIN TEMPLATE: CHE_MD_Metadata to dcat:Dataset  -->
   <!-- ================================================ -->
   
   <xsl:template match="che:CHE_MD_Metadata" mode="iso19115-3-to-dcat">
     <xsl:variable name="uuid" select="mdb:metadataIdentifier/*/mcc:code/*/text()"/>
-    <xsl:variable name="resourceUri" select="concat('https://www.geocat.ch/geonetwork/srv/api/records/', $uuid, '/formatters/dcat-ap-ch')"/>
+    <xsl:variable name="resourceUri" select="concat($geonetworkBaseUrl, 'api/records/', $uuid, '/formatters/dcat-ap-ch')"/>
     
     <dcat:Dataset rdf:about="{$resourceUri}">
       <!-- 1. TYPE -->
@@ -226,7 +232,7 @@
         starts-with($protocol, 'MAP:Preview')
       ">
         <xsl:variable name="datasetUuid" select="ancestor::che:CHE_MD_Metadata/mdb:metadataIdentifier/*/mcc:code/*/text()"/>
-        <xsl:variable name="distributionUri" select="concat('https://www.geocat.ch/geonetwork/srv/api/records/', $datasetUuid, '/distributions/', position())"/>
+        <xsl:variable name="distributionUri" select="concat($geonetworkBaseUrl, 'api/records/', $datasetUuid, '/distributions/', position())"/>
         <dcat:distribution>
           <dcat:Distribution rdf:about="{$distributionUri}">
             <!-- Access URL -->
@@ -401,7 +407,7 @@
   <!-- 9. ADD GEOCAT RELATION -->
   <xsl:template name="add-geocat-relation">
     <xsl:variable name="uuid" select="mdb:metadataIdentifier/*/mcc:code/*/text()"/>
-    <xsl:variable name="geocatUrl" select="concat('https://www.geocat.ch/datahub/dataset/', $uuid)"/>
+    <xsl:variable name="geocatUrl" select="concat($datahubBaseUrl, '/dataset/', $uuid)"/>
     
     <dct:relation>
       <rdf:Description rdf:about="{$geocatUrl}">

--- a/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
+++ b/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
@@ -596,6 +596,9 @@
     <xsl:param name="protocol"/>
     <xsl:param name="url"/>
     
+    <!-- Strip URL fragment (#...) and query string (?...) before extension detection -->
+    <xsl:variable name="urlBase" select="lower-case(tokenize($url, '[#?]')[1])"/>
+    
     <xsl:variable name="formatUri">
       <xsl:choose>
         <!-- Service protocols (full URIs) -->
@@ -616,17 +619,17 @@
         </xsl:when>
         
         <!-- File formats by extension (code only) -->
-        <xsl:when test="ends-with(lower-case($url), '.shp')">http://publications.europa.eu/resource/authority/file-type/SHP</xsl:when>
-        <xsl:when test="ends-with(lower-case($url), '.gpkg')">http://publications.europa.eu/resource/authority/file-type/GPKG</xsl:when>
-        <xsl:when test="ends-with(lower-case($url), '.geojson')">http://publications.europa.eu/resource/authority/file-type/GEOJSON</xsl:when>
-        <xsl:when test="ends-with(lower-case($url), '.json')">http://publications.europa.eu/resource/authority/file-type/JSON</xsl:when>
-        <xsl:when test="ends-with(lower-case($url), '.gml')">http://publications.europa.eu/resource/authority/file-type/GML</xsl:when>
-        <xsl:when test="ends-with(lower-case($url), '.kml')">http://publications.europa.eu/resource/authority/file-type/KML</xsl:when>
-        <xsl:when test="ends-with(lower-case($url), '.csv')">http://publications.europa.eu/resource/authority/file-type/CSV</xsl:when>
-        <xsl:when test="ends-with(lower-case($url), '.xml')">http://publications.europa.eu/resource/authority/file-type/XML</xsl:when>
-        <xsl:when test="ends-with(lower-case($url), '.zip')">http://publications.europa.eu/resource/authority/file-type/ZIP</xsl:when>
-        <xsl:when test="ends-with(lower-case($url), '.pdf')">http://publications.europa.eu/resource/authority/file-type/PDF</xsl:when>
-        <xsl:when test="ends-with(lower-case($url), '.html') or ends-with(lower-case($url), '.htm')">http://publications.europa.eu/resource/authority/file-type/HTML</xsl:when>
+        <xsl:when test="ends-with($urlBase, '.shp')">http://publications.europa.eu/resource/authority/file-type/SHP</xsl:when>
+        <xsl:when test="ends-with($urlBase, '.gpkg')">http://publications.europa.eu/resource/authority/file-type/GPKG</xsl:when>
+        <xsl:when test="ends-with($urlBase, '.geojson')">http://publications.europa.eu/resource/authority/file-type/GEOJSON</xsl:when>
+        <xsl:when test="ends-with($urlBase, '.json')">http://publications.europa.eu/resource/authority/file-type/JSON</xsl:when>
+        <xsl:when test="ends-with($urlBase, '.gml')">http://publications.europa.eu/resource/authority/file-type/GML</xsl:when>
+        <xsl:when test="ends-with($urlBase, '.kml')">http://publications.europa.eu/resource/authority/file-type/KML</xsl:when>
+        <xsl:when test="ends-with($urlBase, '.csv')">http://publications.europa.eu/resource/authority/file-type/CSV</xsl:when>
+        <xsl:when test="ends-with($urlBase, '.xml')">http://publications.europa.eu/resource/authority/file-type/XML</xsl:when>
+        <xsl:when test="ends-with($urlBase, '.zip')">http://publications.europa.eu/resource/authority/file-type/ZIP</xsl:when>
+        <xsl:when test="ends-with($urlBase, '.pdf')">http://publications.europa.eu/resource/authority/file-type/PDF</xsl:when>
+        <xsl:when test="ends-with($urlBase, '.html') or ends-with($urlBase, '.htm')">http://publications.europa.eu/resource/authority/file-type/HTML</xsl:when>
         
         <!-- Default -->
         <xsl:otherwise>http://publications.europa.eu/resource/authority/file-type/UNSPECIFIED</xsl:otherwise>

--- a/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
+++ b/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
@@ -225,8 +225,10 @@
         starts-with($protocol, 'LINKED:DATA') or
         starts-with($protocol, 'MAP:Preview')
       ">
+        <xsl:variable name="datasetUuid" select="ancestor::che:CHE_MD_Metadata/mdb:metadataIdentifier/*/mcc:code/*/text()"/>
+        <xsl:variable name="distributionUri" select="concat('https://www.geocat.ch/geonetwork/srv/api/records/', $datasetUuid, '/distributions/', position())"/>
         <dcat:distribution>
-          <dcat:Distribution>
+          <dcat:Distribution rdf:about="{$distributionUri}">
             <!-- Access URL -->
             <dcat:accessURL rdf:resource="{$url}"/>
             <!-- Download URL for download protocols -->
@@ -557,14 +559,28 @@
 
   <!-- 16. ADD DOCUMENTATION -->
   <xsl:template name="add-documentation">
-    <!-- Additional documentation resources -->
+    <!-- foaf:page: WWW:LINK with function 'information' -->
+    <xsl:for-each select="
+      mdb:distributionInfo//mrd:onLine[
+        starts-with((*/cit:protocol/*/text())[1], 'WWW:LINK') and
+        */cit:function/*/@codeListValue = 'information'
+      ]
+    ">
+      <xsl:variable name="url" select="normalize-space((*/cit:linkage/gco:CharacterString/text())[1])"/>
+      <xsl:if test="$url != ''">
+        <foaf:page>
+          <foaf:Document rdf:about="{$url}"/>
+        </foaf:page>
+      </xsl:if>
+    </xsl:for-each>
+    <!-- foaf:documentation: function 'documentation' or in additionalDocumentation -->
     <xsl:for-each select="
       mdb:distributionInfo//mrd:onLine[
         */cit:function/*/@codeListValue = 'documentation' or
         ancestor::mrl:additionalDocumentation
       ]
     ">
-  <xsl:variable name="url" select="normalize-space((*/cit:linkage/*/text())[1])"/>
+      <xsl:variable name="url" select="normalize-space((*/cit:linkage/*/text())[1])"/>
       <xsl:if test="$url != ''">
         <foaf:documentation>
           <foaf:Document rdf:about="{$url}">

--- a/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
+++ b/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
@@ -186,9 +186,9 @@
   <!-- 4. ADD CONTACT POINT -->
   <xsl:template name="add-contact-point">
     <xsl:variable name="contacts" select="
-      mdb:identificationInfo/*/mri:pointOfContact[*/cit:role/*/@codeListValue = 'pointOfContact'] |
-      mdb:identificationInfo/*/mri:pointOfContact[*/cit:role/*/@codeListValue = 'owner'] |
-      mdb:contact
+      mdb:identificationInfo/*/mri:pointOfContact[cit:CI_Responsibility/cit:role/*/@codeListValue = 'pointOfContact'] |
+      mdb:identificationInfo/*/mri:pointOfContact[cit:CI_Responsibility/cit:role/*/@codeListValue = 'owner'] |
+      mdb:contact[cit:CI_Responsibility]
     "/>
     
     <xsl:for-each select="$contacts[1]">
@@ -262,7 +262,9 @@
               ($dates[*/cit:dateType/*/@codeListValue = 'publication']/*/cit:date/gco:Date/text())[1] |
               ($dates[*/cit:dateType/*/@codeListValue = 'publication']/*/cit:date/gco:DateTime/text())[1] |
               ($dates[*/cit:dateType/*/@codeListValue = 'creation']/*/cit:date/gco:Date/text())[1] |
-              ($dates[*/cit:dateType/*/@codeListValue = 'creation']/*/cit:date/gco:DateTime/text())[1]
+              ($dates[*/cit:dateType/*/@codeListValue = 'creation']/*/cit:date/gco:DateTime/text())[1] |
+              ($dates[*/cit:dateType/*/@codeListValue = 'revision']/*/cit:date/gco:Date/text())[1] |
+              ($dates[*/cit:dateType/*/@codeListValue = 'revision']/*/cit:date/gco:DateTime/text())[1]
             "/>
             <xsl:if test="$issued[1] != ''">
               <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
@@ -307,14 +309,7 @@
     "/>
     <xsl:if test="$issued[1] != ''">
       <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-        <xsl:choose>
-          <xsl:when test="contains($issued[1], 'T')">
-            <xsl:value-of select="$issued[1]"/>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:value-of select="concat($issued[1], 'T00:00:00')"/>
-          </xsl:otherwise>
-        </xsl:choose>
+        <xsl:value-of select="local:format-datetime($issued[1])"/>
       </dct:issued>
     </xsl:if>
     
@@ -325,14 +320,7 @@
     "/>
     <xsl:if test="$modified[1] != ''">
       <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">
-        <xsl:choose>
-          <xsl:when test="contains($modified[1], 'T')">
-            <xsl:value-of select="$modified[1]"/>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:value-of select="concat($modified[1], 'T00:00:00')"/>
-          </xsl:otherwise>
-        </xsl:choose>
+        <xsl:value-of select="local:format-datetime($modified[1])"/>
       </dct:modified>
     </xsl:if>
   </xsl:template>
@@ -809,8 +797,21 @@
         </xsl:choose>
       </xsl:when>
       <xsl:otherwise>
-        <!-- Date only, add time and timezone -->
-        <xsl:value-of select="concat($dateValue, 'T00:00:00+00:00')"/>
+        <!-- Date only, add time and timezone, completing partial dates (yyyy-MM → yyyy-MM-01, yyyy → yyyy-01-01) -->
+        <xsl:variable name="paddedDate">
+          <xsl:choose>
+            <xsl:when test="string-length($dateValue) = 4">
+              <xsl:value-of select="concat($dateValue, '-01-01')"/>
+            </xsl:when>
+            <xsl:when test="string-length($dateValue) = 7">
+              <xsl:value-of select="concat($dateValue, '-01')"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:value-of select="$dateValue"/>
+            </xsl:otherwise>
+          </xsl:choose>
+        </xsl:variable>
+        <xsl:value-of select="concat($paddedDate, 'T00:00:00+00:00')"/>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:function>

--- a/src/main/plugin/iso19115-3.2018.che/present/csw/dcat-ap-ch-brief.xsl
+++ b/src/main/plugin/iso19115-3.2018.che/present/csw/dcat-ap-ch-brief.xsl
@@ -2,7 +2,8 @@
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:che="http://geocat.ch/che"
-                xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0">
+                xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 
   <!-- Import the DCAT-AP-CH formatter -->
   <xsl:import href="../../formatter/dcat-ap-ch/dcat-ap-ch-core.xsl"/>
@@ -13,7 +14,10 @@
 
   <!-- Main template to apply DCAT-AP-CH transformation -->
   <xsl:template match="/" priority="99">
-    <xsl:apply-templates select="$metadata" mode="iso19115-3-to-dcat"/>
+    <rdf:RDF>
+      <xsl:call-template name="create-namespaces-dcat-ap-ch"/>
+      <xsl:apply-templates select="$metadata" mode="iso19115-3-to-dcat"/>
+    </rdf:RDF>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugin/iso19115-3.2018.che/present/csw/dcat-ap-ch-full.xsl
+++ b/src/main/plugin/iso19115-3.2018.che/present/csw/dcat-ap-ch-full.xsl
@@ -2,7 +2,8 @@
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:che="http://geocat.ch/che"
-                xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0">
+                xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 
   <!-- Import the DCAT-AP-CH formatter -->
   <xsl:import href="../../formatter/dcat-ap-ch/dcat-ap-ch-core.xsl"/>
@@ -13,7 +14,10 @@
 
   <!-- Main template to apply DCAT-AP-CH transformation -->
   <xsl:template match="/" priority="99">
-    <xsl:apply-templates select="$metadata" mode="iso19115-3-to-dcat"/>
+    <rdf:RDF>
+      <xsl:call-template name="create-namespaces-dcat-ap-ch"/>
+      <xsl:apply-templates select="$metadata" mode="iso19115-3-to-dcat"/>
+    </rdf:RDF>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/src/main/plugin/iso19115-3.2018.che/present/csw/dcat-ap-ch-summary.xsl
+++ b/src/main/plugin/iso19115-3.2018.che/present/csw/dcat-ap-ch-summary.xsl
@@ -2,7 +2,8 @@
 <xsl:stylesheet version="2.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:che="http://geocat.ch/che"
-                xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0">
+                xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
 
   <!-- Import the DCAT-AP-CH formatter -->
   <xsl:import href="../../formatter/dcat-ap-ch/dcat-ap-ch-core.xsl"/>
@@ -13,7 +14,10 @@
 
   <!-- Main template to apply DCAT-AP-CH transformation -->
   <xsl:template match="/" priority="99">
-    <xsl:apply-templates select="$metadata" mode="iso19115-3-to-dcat"/>
+    <rdf:RDF>
+      <xsl:call-template name="create-namespaces-dcat-ap-ch"/>
+      <xsl:apply-templates select="$metadata" mode="iso19115-3-to-dcat"/>
+    </rdf:RDF>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/src/test/java/org/fao/geonet/schema/DCatFormatterTest.java
+++ b/src/test/java/org/fao/geonet/schema/DCatFormatterTest.java
@@ -17,7 +17,7 @@ import static org.fao.geonet.schema.TestSupport.getResourceInsideSchema;
 
 public class DCatFormatterTest {
 
-	private static final boolean GENERATE_EXPECTED_FILE = false;
+private static final boolean GENERATE_EXPECTED_FILE = false;
 
 	@BeforeClass
 	public static void initSaxon() {

--- a/src/test/java/org/fao/geonet/schema/DCatFormatterTest.java
+++ b/src/test/java/org/fao/geonet/schema/DCatFormatterTest.java
@@ -17,7 +17,7 @@ import static org.fao.geonet.schema.TestSupport.getResourceInsideSchema;
 
 public class DCatFormatterTest {
 
-private static final boolean GENERATE_EXPECTED_FILE = false;
+	private static final boolean GENERATE_EXPECTED_FILE = false;
 
 	@BeforeClass
 	public static void initSaxon() {

--- a/src/test/java/org/fao/geonet/schema/ShaclDcatApChTest.java
+++ b/src/test/java/org/fao/geonet/schema/ShaclDcatApChTest.java
@@ -1,0 +1,176 @@
+package org.fao.geonet.schema;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.shacl.ShaclValidator;
+import org.apache.jena.shacl.Shapes;
+import org.apache.jena.shacl.ValidationReport;
+import org.fao.geonet.utils.TransformerFactoryFactory;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+import org.jdom.output.Format;
+import org.jdom.output.XMLOutputter;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+
+import static org.fao.geonet.schema.TestSupport.getResource;
+import static org.fao.geonet.schema.TestSupport.getResourceInsideSchema;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Validates DCAT-AP-CH formatter output against SHACL shapes.
+ *
+ * Two shape files are combined:
+ *  - shacl/dcat-ap-2.1.1-base-SHACL.ttl : official DCAT-AP 2.1.1 shapes (from itb.ec.europa.eu)
+ *  - shacl/dcat-ap-ch-shapes.ttl         : Swiss-specific constraints (opendata.swiss)
+ *
+ * Reference: https://handbook.opendata.swiss/de/content/glossar/bibliothek/dcat-ap-ch.html
+ */
+public class ShaclDcatApChTest {
+
+    @BeforeClass
+    public static void initSaxon() {
+        TransformerFactoryFactory.init("net.sf.saxon.TransformerFactoryImpl");
+    }
+
+    @Test
+    public void validateAmphibians() throws Exception {
+        assertConformsToShacl("amphibians");
+    }
+
+    @Test
+    public void validateVeterinarians() throws Exception {
+        assertConformsToShacl("veterinarians");
+    }
+
+    @Test
+    public void validateGrundwasservorkommen() throws Exception {
+        assertConformsToShacl("grundwasservorkommen");
+    }
+
+    @Test
+    public void validateConventionDesAlpes() throws Exception {
+        assertConformsToShacl("conventionDesAlpesTousLesChamps");
+    }
+
+    @Test
+    public void validateTrees() throws Exception {
+        assertConformsToShacl("trees");
+    }
+
+    @Test
+    public void validateGrundWasserSchutzZonen() throws Exception {
+        assertConformsToShacl("grundwasserschutzzonen");
+    }
+
+    @Test
+    public void validateZonesDeTranquillite() throws Exception {
+        assertConformsToShacl("zonesDeTranquillite");
+    }
+
+    @Test
+    public void validateSwissTLM3D() throws Exception {
+        assertConformsToShacl("swissTLM3D");
+    }
+
+    @Test
+    public void validateModellDokumentationSwissTLM3D() throws Exception {
+        assertConformsToShacl("modellDokumentationSwissTLM3D");
+    }
+
+    @Test
+    public void validateVALTRALOC() throws Exception {
+        assertConformsToShacl("VALTRALOC");
+    }
+
+    @Test
+    public void validateOrganischenBodenInDerSchweiz() throws Exception {
+        assertConformsToShacl("organischenBodenInDerSchweiz");
+    }
+
+    @Test
+    public void validateSchuetzenswerte() throws Exception {
+        assertConformsToShacl("schuetzenswerte");
+    }
+
+    @Test
+    public void validateWeatherStations() throws Exception {
+        assertConformsToShacl("weatherStations");
+    }
+
+    @Test
+    public void validateHoheitsgrenzpunkteLV() throws Exception {
+        assertConformsToShacl("hoheitsgrenzpunkteLV");
+    }
+
+    @Test
+    public void validateFiktiverDarstellungskatalogMitURL() throws Exception {
+        assertConformsToShacl("fiktiverDarstellungskatalogMitURL");
+    }
+
+    @Test
+    public void validateWanderWege() throws Exception {
+        assertConformsToShacl("wanderWege");
+    }
+
+    // ---------------------------------------------------------------
+    // Core validation logic
+    // ---------------------------------------------------------------
+
+    /**
+     * Transforms a metadata file with the DCAT-AP-CH XSL, then validates
+     * the resulting RDF/XML against the SHACL shapes.
+     */
+    private void assertConformsToShacl(String mdNameRoot) throws Exception {
+        // 1. Transform ISO 19115-3 CHE → DCAT-AP-CH RDF/XML
+        Path xslFile = getResourceInsideSchema("formatter/dcat-ap-ch/view.xsl");
+        Path xmlFile = getResource(mdNameRoot + "-19115-3.che.xml");
+        Element md = Xml.loadFile(xmlFile);
+        Element result = Xml.transform(md, xslFile);
+
+        XMLOutputter xmlOutputter = new XMLOutputter(Format.getPrettyFormat().setLineSeparator("\n"));
+        String rdfXml = xmlOutputter.outputString(result);
+
+        // 2. Load RDF into Jena model
+        Model dataModel = ModelFactory.createDefaultModel();
+        RDFDataMgr.read(dataModel,
+            new ByteArrayInputStream(rdfXml.getBytes(StandardCharsets.UTF_8)),
+            null,
+            Lang.RDFXML
+        );
+
+        // 3. Load and merge SHACL shapes: DCAT-AP 2.1.1 base + CH-specific rules
+        Path dcatApBasePath = getResource("shacl/dcat-ap-2.1.1-base-SHACL.ttl");
+        Path dcatApChPath = getResource("shacl/dcat-ap-ch-shapes.ttl");
+        Model shapesModel = ModelFactory.createDefaultModel();
+        RDFDataMgr.read(shapesModel, dcatApBasePath.toString(), Lang.TURTLE);
+        RDFDataMgr.read(shapesModel, dcatApChPath.toString(), Lang.TURTLE);
+        Shapes shapes = Shapes.parse(shapesModel);
+
+        // 4. Validate
+        ValidationReport report = ShaclValidator.get().validate(shapes, dataModel.getGraph());
+
+        // 5. Build violation message
+        String violations = "";
+        if (!report.conforms()) {
+            violations = report.getEntries().stream()
+                .map(e -> String.format(
+                    "\n  [%s] path=%s value=%s message=%s",
+                    e.severity(),
+                    e.resultPath(),
+                    e.value(),
+                    e.message()
+                ))
+                .collect(Collectors.joining());
+        }
+
+        assertTrue("SHACL violations in '" + mdNameRoot + "':" + violations, report.conforms());
+    }
+}

--- a/src/test/java/org/fao/geonet/schema/ShaclDcatApChTest.java
+++ b/src/test/java/org/fao/geonet/schema/ShaclDcatApChTest.java
@@ -157,19 +157,17 @@ public class ShaclDcatApChTest {
         // 4. Validate
         ValidationReport report = ShaclValidator.get().validate(shapes, dataModel.getGraph());
 
-        // 5. Build violation message
-        String violations = "";
-        if (!report.conforms()) {
-            violations = report.getEntries().stream()
-                .map(e -> String.format(
-                    "\n  [%s] path=%s value=%s message=%s",
-                    e.severity(),
-                    e.resultPath(),
-                    e.value(),
-                    e.message()
-                ))
-                .collect(Collectors.joining());
-        }
+        // 5. Build violation message (always collect entries: conforms() may be true
+        //    even when warning-level entries are present)
+        String violations = report.getEntries().stream()
+            .map(e -> String.format(
+                "\n  [%s] path=%s value=%s message=%s",
+                e.severity(),
+                e.resultPath(),
+                e.value(),
+                e.message()
+            ))
+            .collect(Collectors.joining());
 
         assertTrue("SHACL violations in '" + mdNameRoot + "':" + violations, report.conforms());
     }

--- a/src/test/java/org/fao/geonet/util/XslUtil.java
+++ b/src/test/java/org/fao/geonet/util/XslUtil.java
@@ -64,6 +64,8 @@ public class XslUtil {
                 return "false";
             case "system/inspire/enable":
                 return IS_INSPIRE_ENABLED.toString();
+            case "nodeUrl":
+                return "https://www.geocat.ch/geonetwork/";
             default:
                 return "true";
         }

--- a/src/test/resources/dcat/VALTRALOC-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/VALTRALOC-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/f01959c2-b48f-4f0c-ae81-3f6c68357267/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f01959c2-b48f-4f0c-ae81-3f6c68357267/formatters/dcat-ap-ch">
     <dct:identifier>f01959c2-b48f-4f0c-ae81-3f6c68357267</dct:identifier>
     <dct:title xml:lang="fr">Projets VALTRALOC</dct:title>
     <dct:title xml:lang="de">VALTRALOC-Projekte</dct:title>

--- a/src/test/resources/dcat/VALTRALOC-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/VALTRALOC-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f01959c2-b48f-4f0c-ae81-3f6c68357267/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/f01959c2-b48f-4f0c-ae81-3f6c68357267/formatters/dcat-ap-ch">
     <dct:identifier>f01959c2-b48f-4f0c-ae81-3f6c68357267</dct:identifier>
     <dct:title xml:lang="fr">Projets VALTRALOC</dct:title>
     <dct:title xml:lang="de">VALTRALOC-Projekte</dct:title>

--- a/src/test/resources/dcat/VALTRALOC-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/VALTRALOC-dcat-ap-ch.xml
@@ -18,7 +18,7 @@
         <vcard:hasEmail rdf:resource="mailto:christophe.emery@fr.ch" />
       </vcard:Organization>
     </dcat:contactPoint>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-06-01T00:00:00</dct:modified>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2019-06-01T00:00:00+00:00</dct:modified>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/TRAN" />
     <dcat:landingPage rdf:resource="https://map.geo.fr.ch/?dataTheme=Routes%20cantonales" />
     <dct:relation>

--- a/src/test/resources/dcat/amphibians-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/amphibians-dcat-ap-ch.xml
@@ -24,7 +24,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/distributions/1">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dct:title xml:lang="de">Datenbeschreibung_AmphibienAckerland.pdf</dct:title>
@@ -43,7 +43,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/distributions/2">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/DescriptionDonnees_BatrachiensAgricole.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/DescriptionDonnees_BatrachiensAgricole.pdf" />
         <dct:title xml:lang="de">DescriptionDonnees_BatrachiensAgricole.pdf</dct:title>

--- a/src/test/resources/dcat/amphibians-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/amphibians-dcat-ap-ch.xml
@@ -61,7 +61,7 @@
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ROH" />
       </dcat:Distribution>
     </dcat:distribution>
-    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-02-23T00:00:00</dct:issued>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-02-23T00:00:00+00:00</dct:issued>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/AGRI" />

--- a/src/test/resources/dcat/amphibians-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/amphibians-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/formatters/dcat-ap-ch">
     <dct:identifier>9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce</dct:identifier>
     <dct:title xml:lang="de">Amphibien Ausbreitungskarten - Ichthyosaura alpestris</dct:title>
     <dct:title xml:lang="fr">Cartes de dispersion des amphibiens - Ichthyosaura alpestris</dct:title>
@@ -24,7 +24,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/distributions/1">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/distributions/1">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dct:title xml:lang="de">Datenbeschreibung_AmphibienAckerland.pdf</dct:title>
@@ -43,7 +43,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/distributions/2">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/DescriptionDonnees_BatrachiensAgricole.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/DescriptionDonnees_BatrachiensAgricole.pdf" />
         <dct:title xml:lang="de">DescriptionDonnees_BatrachiensAgricole.pdf</dct:title>

--- a/src/test/resources/dcat/amphibians-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/amphibians-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/formatters/dcat-ap-ch">
     <dct:identifier>9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce</dct:identifier>
     <dct:title xml:lang="de">Amphibien Ausbreitungskarten - Ichthyosaura alpestris</dct:title>
     <dct:title xml:lang="fr">Cartes de dispersion des amphibiens - Ichthyosaura alpestris</dct:title>
@@ -24,7 +24,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/distributions/1">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/distributions/1">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dct:title xml:lang="de">Datenbeschreibung_AmphibienAckerland.pdf</dct:title>
@@ -43,7 +43,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/distributions/2">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/DescriptionDonnees_BatrachiensAgricole.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/DescriptionDonnees_BatrachiensAgricole.pdf" />
         <dct:title xml:lang="de">DescriptionDonnees_BatrachiensAgricole.pdf</dct:title>

--- a/src/test/resources/dcat/amphibians-dcat.xml
+++ b/src/test/resources/dcat/amphibians-dcat.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-  <rdf:Description rdf:about="trueapi/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource">
+  <rdf:Description rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource">
     <rdf:type rdf:resource="http://www.w3.org/ns/dcat#Dataset" />
     <dct:type>
       <skos:Concept rdf:about="http://purl.org/dc/dcmitype/Dataset">
@@ -13,7 +13,7 @@
       </skos:Concept>
     </dct:type>
     <foaf:isPrimaryTopicOf>
-      <rdf:Description rdf:about="trueapi/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce">
+      <rdf:Description rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce">
         <rdf:type rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord" />
         <dct:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string">9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce</dct:identifier>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-17T16:04:56.559Z</dct:modified>
@@ -35,7 +35,7 @@ These maps should be thought of as heatmaps for dispersal activity of existing p
 Areas with many populations in close proximity appear a darker red, reflecting the higher probability of dispersal as multiple dispersal routes between populations intersect. This feature of the maps deserves special attention. Lighter shades at the edges of the species' range do not necessarily indicate a weaker connection between populations, but rather a consequence of the lower density of breeding sites at the edges of the range. The color scale should be considered in the context of the immediate surroundings.
 The dispersal map was calculated using Circuitscape and is based on a landscape resistance matrix derived from the best-ranked dispersal model for each species.
 For details, see the attached data description.</dct:description>
-        <foaf:primaryTopic rdf:resource="trueapi/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource" />
+        <foaf:primaryTopic rdf:resource="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource" />
       </rdf:Description>
     </foaf:isPrimaryTopicOf>
     <dct:title xml:lang="de">Amphibien Ausbreitungskarten - Ichthyosaura alpestris</dct:title>

--- a/src/test/resources/dcat/amphibians-eu-dcat-ap-hvd.xml
+++ b/src/test/resources/dcat/amphibians-eu-dcat-ap-hvd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatap="http://data.europa.eu/r5r/" xmlns:eli="http://data.europa.eu/eli/ontology">
-  <rdf:Description rdf:about="trueapi/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource">
+  <rdf:Description rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource">
     <rdf:type rdf:resource="http://www.w3.org/ns/dcat#Dataset" />
     <dct:type>
       <skos:Concept rdf:about="http://purl.org/dc/dcmitype/Dataset">
@@ -8,7 +8,7 @@
       </skos:Concept>
     </dct:type>
     <foaf:isPrimaryTopicOf>
-      <rdf:Description rdf:about="trueapi/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce">
+      <rdf:Description rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce">
         <rdf:type rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord" />
         <dct:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string">9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce</dct:identifier>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-17T16:04:56.559Z</dct:modified>
@@ -48,7 +48,7 @@ For details, see the attached data description.</dct:description>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://www.w3.org/TR/vocab-dcat/" />
         </dct:conformsTo>
-        <foaf:primaryTopic rdf:resource="trueapi/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource" />
+        <foaf:primaryTopic rdf:resource="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource" />
       </rdf:Description>
     </foaf:isPrimaryTopicOf>
     <dct:title xml:lang="de">Amphibien Ausbreitungskarten - Ichthyosaura alpestris</dct:title>

--- a/src/test/resources/dcat/amphibians-eu-dcat-ap-mobility.xml
+++ b/src/test/resources/dcat/amphibians-eu-dcat-ap-mobility.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatap="http://data.europa.eu/r5r/" xmlns:eli="http://data.europa.eu/eli/ontology" xmlns:mobilitydcatap="https://w3id.org/mobilitydcat-ap">
-  <rdf:Description rdf:about="trueapi/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource">
+  <rdf:Description rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource">
     <rdf:type rdf:resource="http://www.w3.org/ns/dcat#Dataset" />
     <dct:type>
       <skos:Concept rdf:about="http://purl.org/dc/dcmitype/Dataset">
@@ -8,7 +8,7 @@
       </skos:Concept>
     </dct:type>
     <foaf:isPrimaryTopicOf>
-      <rdf:Description rdf:about="trueapi/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce">
+      <rdf:Description rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce">
         <rdf:type rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord" />
         <dct:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string">9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce</dct:identifier>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-17T16:04:56.559Z</dct:modified>
@@ -48,7 +48,7 @@ For details, see the attached data description.</dct:description>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://www.w3.org/TR/vocab-dcat/" />
         </dct:conformsTo>
-        <foaf:primaryTopic rdf:resource="trueapi/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource" />
+        <foaf:primaryTopic rdf:resource="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource" />
       </rdf:Description>
     </foaf:isPrimaryTopicOf>
     <dct:title xml:lang="de">Amphibien Ausbreitungskarten - Ichthyosaura alpestris</dct:title>

--- a/src/test/resources/dcat/amphibians-eu-dcat-ap.xml
+++ b/src/test/resources/dcat/amphibians-eu-dcat-ap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatap="http://data.europa.eu/r5r/" xmlns:eli="http://data.europa.eu/eli/ontology">
-  <rdf:Description rdf:about="trueapi/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource">
+  <rdf:Description rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource">
     <rdf:type rdf:resource="http://www.w3.org/ns/dcat#Dataset" />
     <dct:type>
       <skos:Concept rdf:about="http://purl.org/dc/dcmitype/Dataset">
@@ -8,7 +8,7 @@
       </skos:Concept>
     </dct:type>
     <foaf:isPrimaryTopicOf>
-      <rdf:Description rdf:about="trueapi/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce">
+      <rdf:Description rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce">
         <rdf:type rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord" />
         <dct:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string">9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce</dct:identifier>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-17T16:04:56.559Z</dct:modified>
@@ -48,7 +48,7 @@ For details, see the attached data description.</dct:description>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://www.w3.org/TR/vocab-dcat/" />
         </dct:conformsTo>
-        <foaf:primaryTopic rdf:resource="trueapi/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource" />
+        <foaf:primaryTopic rdf:resource="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource" />
       </rdf:Description>
     </foaf:isPrimaryTopicOf>
     <dct:title xml:lang="de">Amphibien Ausbreitungskarten - Ichthyosaura alpestris</dct:title>

--- a/src/test/resources/dcat/amphibians-eu-geodcat-ap.xml
+++ b/src/test/resources/dcat/amphibians-eu-geodcat-ap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatap="http://data.europa.eu/r5r/" xmlns:geodcatap="http://data.europa.eu/930/" xmlns:cnt="http://www.w3.org/2011/content#" xmlns:eli="http://data.europa.eu/eli/ontology">
-  <rdf:Description rdf:about="trueapi/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource">
+  <rdf:Description rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource">
     <rdf:type rdf:resource="http://www.w3.org/ns/dcat#Dataset" />
     <dct:type>
       <skos:Concept rdf:about="http://purl.org/dc/dcmitype/Dataset">
@@ -9,7 +9,7 @@
     </dct:type>
     <geodcatap:resourceType rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/ResourceType/dataset" />
     <foaf:isPrimaryTopicOf>
-      <rdf:Description rdf:about="trueapi/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce">
+      <rdf:Description rdf:about="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce">
         <rdf:type rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord" />
         <dct:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string">9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce</dct:identifier>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-17T16:04:56.559Z</dct:modified>
@@ -66,7 +66,7 @@ For details, see the attached data description.</dct:description>
         <dct:conformsTo>
           <dct:Standard rdf:about="https://www.w3.org/TR/vocab-dcat/" />
         </dct:conformsTo>
-        <foaf:primaryTopic rdf:resource="trueapi/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource" />
+        <foaf:primaryTopic rdf:resource="https://www.geocat.ch/geonetwork/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce#resource" />
       </rdf:Description>
     </foaf:isPrimaryTopicOf>
     <dct:title xml:lang="de">Amphibien Ausbreitungskarten - Ichthyosaura alpestris</dct:title>

--- a/src/test/resources/dcat/asiatischeHornisse-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/asiatischeHornisse-dcat-ap-ch.xml
@@ -16,7 +16,7 @@
         <vcard:hasEmail rdf:resource="mailto:support.gis@bl.ch" />
       </vcard:Organization>
     </dcat:contactPoint>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-07T00:00:00</dct:modified>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-07T00:00:00+00:00</dct:modified>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dct:relation>
       <rdf:Description rdf:about="https://www.geocat.ch/datahub/dataset/786606bc-2b81-4426-8ccd-e3a2c76cdb14">

--- a/src/test/resources/dcat/asiatischeHornisse-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/asiatischeHornisse-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/786606bc-2b81-4426-8ccd-e3a2c76cdb14/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/786606bc-2b81-4426-8ccd-e3a2c76cdb14/formatters/dcat-ap-ch">
     <dct:identifier>786606bc-2b81-4426-8ccd-e3a2c76cdb14</dct:identifier>
     <dct:title xml:lang="de">Asiatische Hornisse</dct:title>
     <dct:description xml:lang="de">Die Asiatische Hornisse wurde im Kanton Basel-Landschaft erstmals im Jahr 2022 nachgewiesen. Diese Art gilt als invasiv, da sie zur Ernährung ihrer Brut einheimische Wildbienen und Honigbienen in grossen Mengen jagt und diese Bestände so dezimiert. Die Bestandesdichte der Asiatischen Hornisse ist seit dem ersten Nachweis stark am Ansteigen. Mit dem Vernichten gefundener Nester wird versucht, deren Ausbreitung zu verlangsamen und die Populationsdichte zu senken.</dct:description>

--- a/src/test/resources/dcat/asiatischeHornisse-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/asiatischeHornisse-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/786606bc-2b81-4426-8ccd-e3a2c76cdb14/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/786606bc-2b81-4426-8ccd-e3a2c76cdb14/formatters/dcat-ap-ch">
     <dct:identifier>786606bc-2b81-4426-8ccd-e3a2c76cdb14</dct:identifier>
     <dct:title xml:lang="de">Asiatische Hornisse</dct:title>
     <dct:description xml:lang="de">Die Asiatische Hornisse wurde im Kanton Basel-Landschaft erstmals im Jahr 2022 nachgewiesen. Diese Art gilt als invasiv, da sie zur Ernährung ihrer Brut einheimische Wildbienen und Honigbienen in grossen Mengen jagt und diese Bestände so dezimiert. Die Bestandesdichte der Asiatischen Hornisse ist seit dem ersten Nachweis stark am Ansteigen. Mit dem Vernichten gefundener Nester wird versucht, deren Ausbreitung zu verlangsamen und die Populationsdichte zu senken.</dct:description>

--- a/src/test/resources/dcat/conventionDesAlpesTousLesChamps-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/conventionDesAlpesTousLesChamps-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/formatters/dcat-ap-ch">
     <dct:identifier>fbafbbd4-4622-445f-8e07-1ad4f6a61c55</dct:identifier>
     <dct:title xml:lang="de">Alpenkonvention créée le 2020.03.18-Avec tous les champs</dct:title>
     <dct:title xml:lang="fr">Convention des Alpes créée le 2020.03.18-Avec tous les champs</dct:title>
@@ -28,7 +28,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/2">
         <dcat:accessURL rdf:resource="http://data.geo.admin.ch/ch.are.alpenkonvention/data.zip" />
         <dcat:downloadURL rdf:resource="http://data.geo.admin.ch/ch.are.alpenkonvention/data.zip" />
         <dct:description xml:lang="de">Download von data.geo.admin.ch</dct:description>
@@ -51,7 +51,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/3">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/3">
         <dcat:accessURL rdf:resource="http://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.are.alpenkonvention</dct:title>
         <dct:description xml:lang="de">WMS Dienst von geo.admin.ch</dct:description>
@@ -74,7 +74,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/4">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/4">
         <dcat:accessURL rdf:resource="https://www.are.admin.ch/are/de/home/raumentwicklung-und-raumplanung/grundlagen-und-daten/minimale-geodatenmodelle/alpenkonvention.html" />
         <dcat:downloadURL rdf:resource="https://www.are.admin.ch/are/de/home/raumentwicklung-und-raumplanung/grundlagen-und-daten/minimale-geodatenmodelle/alpenkonvention.html" />
         <dct:description xml:lang="de">Minimales Geodatenmodell in INTERLIS 2.3</dct:description>
@@ -95,7 +95,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/6">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/6">
         <dcat:accessURL rdf:resource="http://wmts.geo.admin.ch" />
         <dct:title xml:lang="de">ch.are.alpenkonvention</dct:title>
         <dct:description xml:lang="de">WMTS für das Nationale Geoportal</dct:description>

--- a/src/test/resources/dcat/conventionDesAlpesTousLesChamps-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/conventionDesAlpesTousLesChamps-dcat-ap-ch.xml
@@ -21,6 +21,12 @@
         <foaf:name xml:lang="rm">Uffizi federal da topografia swisstopo</foaf:name>
       </foaf:Agent>
     </dct:publisher>
+    <dcat:contactPoint>
+      <vcard:Organization>
+        <vcard:fn>Bundesamt für Landestopografie swisstopo</vcard:fn>
+        <vcard:hasEmail rdf:resource="mailto:geocat@swisstopo.ch" />
+      </vcard:Organization>
+    </dcat:contactPoint>
     <dcat:distribution>
       <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/2">
         <dcat:accessURL rdf:resource="http://data.geo.admin.ch/ch.are.alpenkonvention/data.zip" />
@@ -35,7 +41,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
-        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1999-01-01T00:00:00+00:00</dct:issued>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-01-01T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-01-01T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
@@ -58,7 +64,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
-        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1999-01-01T00:00:00+00:00</dct:issued>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-01-01T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-01-01T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
@@ -79,7 +85,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
-        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1999-01-01T00:00:00+00:00</dct:issued>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-01-01T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-01-01T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
@@ -101,7 +107,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
-        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1999-01-01T00:00:00+00:00</dct:issued>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-01-01T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-01-01T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
@@ -110,8 +116,8 @@
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ROH" />
       </dcat:Distribution>
     </dcat:distribution>
-    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1999-01-01T00:00:00</dct:issued>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-01-01T00:00:00</dct:modified>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1999-01-01T00:00:00+00:00</dct:issued>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-01-01T00:00:00+00:00</dct:modified>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/REGI" />
     <dcat:landingPage rdf:resource="https://www.are.admin.ch/are/de/home/laendliche-raeume-und-berggebiete/internationale-zusammenarbeit/alpenkonvention.html" />
     <dct:relation>

--- a/src/test/resources/dcat/conventionDesAlpesTousLesChamps-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/conventionDesAlpesTousLesChamps-dcat-ap-ch.xml
@@ -22,7 +22,7 @@
       </foaf:Agent>
     </dct:publisher>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/2">
         <dcat:accessURL rdf:resource="http://data.geo.admin.ch/ch.are.alpenkonvention/data.zip" />
         <dcat:downloadURL rdf:resource="http://data.geo.admin.ch/ch.are.alpenkonvention/data.zip" />
         <dct:description xml:lang="de">Download von data.geo.admin.ch</dct:description>
@@ -45,7 +45,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/3">
         <dcat:accessURL rdf:resource="http://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.are.alpenkonvention</dct:title>
         <dct:description xml:lang="de">WMS Dienst von geo.admin.ch</dct:description>
@@ -68,7 +68,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/4">
         <dcat:accessURL rdf:resource="https://www.are.admin.ch/are/de/home/raumentwicklung-und-raumplanung/grundlagen-und-daten/minimale-geodatenmodelle/alpenkonvention.html" />
         <dcat:downloadURL rdf:resource="https://www.are.admin.ch/are/de/home/raumentwicklung-und-raumplanung/grundlagen-und-daten/minimale-geodatenmodelle/alpenkonvention.html" />
         <dct:description xml:lang="de">Minimales Geodatenmodell in INTERLIS 2.3</dct:description>
@@ -89,7 +89,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/6">
         <dcat:accessURL rdf:resource="http://wmts.geo.admin.ch" />
         <dct:title xml:lang="de">ch.are.alpenkonvention</dct:title>
         <dct:description xml:lang="de">WMTS für das Nationale Geoportal</dct:description>
@@ -158,6 +158,15 @@
       </dct:PeriodOfTime>
     </dct:temporal>
     <dct:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/IRREG" />
+    <foaf:page>
+      <foaf:Document rdf:about="http://www.alpconv.org" />
+    </foaf:page>
+    <foaf:page>
+      <foaf:Document rdf:about="http://map.geo.admin.ch/?selectedNode=LT1_1&amp;Y=660000&amp;X=190000&amp;zoom=1&amp;bgLayer=ch.swisstopo.pixelkarte-farbe&amp;layers=ch.are.alpenkonvention&amp;layers_opacity=0.6&amp;layers_visibility=true&amp;lang=de" />
+    </foaf:page>
+    <foaf:page>
+      <foaf:Document rdf:about="http://www.admin.ch/ch/d/sr/0_700_1/app1.html" />
+    </foaf:page>
   </dcat:Dataset>
 </rdf:RDF>
 

--- a/src/test/resources/dcat/conventionDesAlpesTousLesChamps-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/conventionDesAlpesTousLesChamps-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/formatters/dcat-ap-ch">
     <dct:identifier>fbafbbd4-4622-445f-8e07-1ad4f6a61c55</dct:identifier>
     <dct:title xml:lang="de">Alpenkonvention créée le 2020.03.18-Avec tous les champs</dct:title>
     <dct:title xml:lang="fr">Convention des Alpes créée le 2020.03.18-Avec tous les champs</dct:title>
@@ -28,7 +28,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/2">
         <dcat:accessURL rdf:resource="http://data.geo.admin.ch/ch.are.alpenkonvention/data.zip" />
         <dcat:downloadURL rdf:resource="http://data.geo.admin.ch/ch.are.alpenkonvention/data.zip" />
         <dct:description xml:lang="de">Download von data.geo.admin.ch</dct:description>
@@ -51,7 +51,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/3">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/3">
         <dcat:accessURL rdf:resource="http://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.are.alpenkonvention</dct:title>
         <dct:description xml:lang="de">WMS Dienst von geo.admin.ch</dct:description>
@@ -74,7 +74,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/4">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/4">
         <dcat:accessURL rdf:resource="https://www.are.admin.ch/are/de/home/raumentwicklung-und-raumplanung/grundlagen-und-daten/minimale-geodatenmodelle/alpenkonvention.html" />
         <dcat:downloadURL rdf:resource="https://www.are.admin.ch/are/de/home/raumentwicklung-und-raumplanung/grundlagen-und-daten/minimale-geodatenmodelle/alpenkonvention.html" />
         <dct:description xml:lang="de">Minimales Geodatenmodell in INTERLIS 2.3</dct:description>
@@ -95,7 +95,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/6">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/6">
         <dcat:accessURL rdf:resource="http://wmts.geo.admin.ch" />
         <dct:title xml:lang="de">ch.are.alpenkonvention</dct:title>
         <dct:description xml:lang="de">WMTS für das Nationale Geoportal</dct:description>

--- a/src/test/resources/dcat/fiktiverDarstellungskatalogMitURL-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/fiktiverDarstellungskatalogMitURL-dcat-ap-ch.xml
@@ -41,7 +41,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_by" />
         </dct:rights>
-        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1996-01-01T00:00:00+00:00</dct:issued>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
@@ -64,7 +64,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_by" />
         </dct:rights>
-        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1996-01-01T00:00:00+00:00</dct:issued>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
@@ -88,7 +88,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_by" />
         </dct:rights>
-        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1996-01-01T00:00:00+00:00</dct:issued>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
@@ -110,7 +110,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_by" />
         </dct:rights>
-        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1996-01-01T00:00:00+00:00</dct:issued>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
@@ -138,7 +138,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_by" />
         </dct:rights>
-        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1996-01-01T00:00:00+00:00</dct:issued>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
@@ -147,8 +147,8 @@
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ROH" />
       </dcat:Distribution>
     </dcat:distribution>
-    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1996-01-01T00:00:00</dct:issued>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T00:00:00</dct:modified>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1996-01-01T00:00:00+00:00</dct:issued>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T00:00:00+00:00</dct:modified>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dcat:landingPage rdf:resource="https://www.bafu.admin.ch/bafu/de/home/themen/biodiversitaet/zustand/karten.html" />
     <dct:relation>

--- a/src/test/resources/dcat/fiktiverDarstellungskatalogMitURL-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/fiktiverDarstellungskatalogMitURL-dcat-ap-ch.xml
@@ -27,7 +27,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/3">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.bafu.fauna-steinbockkolonien/data.zip" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.bafu.fauna-steinbockkolonien/data.zip" />
         <dct:title xml:lang="de">Download-Server von geo.admin.ch</dct:title>
@@ -51,7 +51,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/4">
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.bafu.fauna-steinbockkolonien</dct:title>
         <dct:description xml:lang="de">WMS-BGDI Dienst, Layer "Steinbockkolonien"</dct:description>
@@ -74,7 +74,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/5">
         <dcat:accessURL rdf:resource="http://www.bafu.admin.ch/geodaten" />
         <dcat:downloadURL rdf:resource="http://www.bafu.admin.ch/geodaten" />
         <dct:title xml:lang="de">Download ESRI Shapefile</dct:title>
@@ -98,7 +98,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/6">
         <dcat:accessURL rdf:resource="http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml" />
         <dct:title xml:lang="de">ch.bafu.fauna-steinbockkolonien</dct:title>
         <dct:description xml:lang="de">WMTS für das Nationale Geoportal</dct:description>
@@ -120,7 +120,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/7">
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.bafu.fauna-steinbockkolonien" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>
@@ -199,6 +199,9 @@
     <dcat:keyword xml:lang="en">Species distribution</dcat:keyword>
     <dct:spatial>Schweiz</dct:spatial>
     <dct:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/IRREG" />
+    <foaf:page>
+      <foaf:Document rdf:about="https://www.bafu.admin.ch/bafu/de/home/themen/biodiversitaet/zustand/karten.html" />
+    </foaf:page>
   </dcat:Dataset>
   <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_by">
     <rdf:type rdf:resource="http://purl.org/dc/terms/LicenseDocument" />

--- a/src/test/resources/dcat/fiktiverDarstellungskatalogMitURL-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/fiktiverDarstellungskatalogMitURL-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/formatters/dcat-ap-ch">
     <dct:identifier>0e5a8467-bf17-4d4d-aab4-3ba49417cedc</dct:identifier>
     <dct:title xml:lang="de">Beispiel II "Verbreitung der Steinbockkolonien"</dct:title>
     <dct:title xml:lang="fr">Example II "Colonies de bouquetins"</dct:title>
@@ -27,7 +27,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/3">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/3">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.bafu.fauna-steinbockkolonien/data.zip" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.bafu.fauna-steinbockkolonien/data.zip" />
         <dct:title xml:lang="de">Download-Server von geo.admin.ch</dct:title>
@@ -51,7 +51,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/4">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/4">
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.bafu.fauna-steinbockkolonien</dct:title>
         <dct:description xml:lang="de">WMS-BGDI Dienst, Layer "Steinbockkolonien"</dct:description>
@@ -74,7 +74,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/5">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/5">
         <dcat:accessURL rdf:resource="http://www.bafu.admin.ch/geodaten" />
         <dcat:downloadURL rdf:resource="http://www.bafu.admin.ch/geodaten" />
         <dct:title xml:lang="de">Download ESRI Shapefile</dct:title>
@@ -98,7 +98,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/6">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/6">
         <dcat:accessURL rdf:resource="http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml" />
         <dct:title xml:lang="de">ch.bafu.fauna-steinbockkolonien</dct:title>
         <dct:description xml:lang="de">WMTS für das Nationale Geoportal</dct:description>
@@ -120,7 +120,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/7">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/7">
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.bafu.fauna-steinbockkolonien" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/dcat/fiktiverDarstellungskatalogMitURL-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/fiktiverDarstellungskatalogMitURL-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/formatters/dcat-ap-ch">
     <dct:identifier>0e5a8467-bf17-4d4d-aab4-3ba49417cedc</dct:identifier>
     <dct:title xml:lang="de">Beispiel II "Verbreitung der Steinbockkolonien"</dct:title>
     <dct:title xml:lang="fr">Example II "Colonies de bouquetins"</dct:title>
@@ -27,7 +27,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/3">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/3">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.bafu.fauna-steinbockkolonien/data.zip" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.bafu.fauna-steinbockkolonien/data.zip" />
         <dct:title xml:lang="de">Download-Server von geo.admin.ch</dct:title>
@@ -51,7 +51,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/4">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/4">
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.bafu.fauna-steinbockkolonien</dct:title>
         <dct:description xml:lang="de">WMS-BGDI Dienst, Layer "Steinbockkolonien"</dct:description>
@@ -74,7 +74,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/5">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/5">
         <dcat:accessURL rdf:resource="http://www.bafu.admin.ch/geodaten" />
         <dcat:downloadURL rdf:resource="http://www.bafu.admin.ch/geodaten" />
         <dct:title xml:lang="de">Download ESRI Shapefile</dct:title>
@@ -98,7 +98,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/6">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/6">
         <dcat:accessURL rdf:resource="http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml" />
         <dct:title xml:lang="de">ch.bafu.fauna-steinbockkolonien</dct:title>
         <dct:description xml:lang="de">WMTS für das Nationale Geoportal</dct:description>
@@ -120,7 +120,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/7">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/7">
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.bafu.fauna-steinbockkolonien" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/dcat/grundwasserschutzzonen-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/grundwasserschutzzonen-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/formatters/dcat-ap-ch">
     <dct:identifier>f494da66-8860-48d5-9cc7-ec38b885afd1</dct:identifier>
     <dct:title xml:lang="de">Grundwasserschutzzonen</dct:title>
     <dct:description xml:lang="de">Der Geobasisdatensatz beinhaltet Grundwasserschutzzonen gemäss Gewässerschutzgesetzgebung. Schutzzonen dienen dazu, Trinkwassergewinnungsanlagen und Grundwasseranreicherungen sowie das Grundwasser unmittelbar vor seiner Nutzung als Trinkwasser vor qualitativer und quantitativer Beeinträchtigungen zu schützen. Innerhalb der Schutzzonen gelten Nutzungsbeschränken. Schutzzonen sind ein Element des planerischen Grundwasserschutzes, Bestandteilt der Gewässerschutzkarte und überlagern die Gewässerschutzbereiche.</dct:description>
@@ -18,7 +18,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/4">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/4">
         <dcat:accessURL rdf:resource="https://ows.geo.tg.ch/geofy_access_proxy/gewaesserschutzkarte?Service=WMS&amp;Version=1.3.0&amp;Request=GetCapabilities" />
         <dct:title xml:lang="de">Grundwasserschutzzonen</dct:title>
         <dct:description xml:lang="de">Grundwasserschutzzonen</dct:description>
@@ -37,7 +37,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/5">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/5">
         <dcat:accessURL rdf:resource="https://ows.geo.tg.ch/geofy_access_proxy/gewaesserschutzkarte?Service=WFS&amp;Version=2.0.0&amp;Request=GetCapabilities" />
         <dct:description xml:lang="de">Grundwasserschutzzonen</dct:description>
         <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/WFS_SRVC" />
@@ -55,7 +55,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/7">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/7">
         <dcat:accessURL rdf:resource="https://shop.geo.tg.ch/products/gewaesserschutzkarte" />
         <dcat:downloadURL rdf:resource="https://shop.geo.tg.ch/products/gewaesserschutzkarte" />
         <dct:title xml:lang="de">shop.geo.tg.ch</dct:title>

--- a/src/test/resources/dcat/grundwasserschutzzonen-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/grundwasserschutzzonen-dcat-ap-ch.xml
@@ -74,8 +74,8 @@
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG" />
       </dcat:Distribution>
     </dcat:distribution>
-    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2000-01-01T00:00:00</dct:issued>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-16T00:00:00</dct:modified>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2000-01-01T00:00:00+00:00</dct:issued>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-04-16T00:00:00+00:00</dct:modified>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dcat:landingPage rdf:resource="https://map.geo.tg.ch" />
     <dct:relation>

--- a/src/test/resources/dcat/grundwasserschutzzonen-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/grundwasserschutzzonen-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/formatters/dcat-ap-ch">
     <dct:identifier>f494da66-8860-48d5-9cc7-ec38b885afd1</dct:identifier>
     <dct:title xml:lang="de">Grundwasserschutzzonen</dct:title>
     <dct:description xml:lang="de">Der Geobasisdatensatz beinhaltet Grundwasserschutzzonen gemäss Gewässerschutzgesetzgebung. Schutzzonen dienen dazu, Trinkwassergewinnungsanlagen und Grundwasseranreicherungen sowie das Grundwasser unmittelbar vor seiner Nutzung als Trinkwasser vor qualitativer und quantitativer Beeinträchtigungen zu schützen. Innerhalb der Schutzzonen gelten Nutzungsbeschränken. Schutzzonen sind ein Element des planerischen Grundwasserschutzes, Bestandteilt der Gewässerschutzkarte und überlagern die Gewässerschutzbereiche.</dct:description>
@@ -18,7 +18,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/4">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/4">
         <dcat:accessURL rdf:resource="https://ows.geo.tg.ch/geofy_access_proxy/gewaesserschutzkarte?Service=WMS&amp;Version=1.3.0&amp;Request=GetCapabilities" />
         <dct:title xml:lang="de">Grundwasserschutzzonen</dct:title>
         <dct:description xml:lang="de">Grundwasserschutzzonen</dct:description>
@@ -37,7 +37,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/5">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/5">
         <dcat:accessURL rdf:resource="https://ows.geo.tg.ch/geofy_access_proxy/gewaesserschutzkarte?Service=WFS&amp;Version=2.0.0&amp;Request=GetCapabilities" />
         <dct:description xml:lang="de">Grundwasserschutzzonen</dct:description>
         <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/WFS_SRVC" />
@@ -55,7 +55,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/7">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/7">
         <dcat:accessURL rdf:resource="https://shop.geo.tg.ch/products/gewaesserschutzkarte" />
         <dcat:downloadURL rdf:resource="https://shop.geo.tg.ch/products/gewaesserschutzkarte" />
         <dct:title xml:lang="de">shop.geo.tg.ch</dct:title>

--- a/src/test/resources/dcat/grundwasserschutzzonen-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/grundwasserschutzzonen-dcat-ap-ch.xml
@@ -18,7 +18,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/4">
         <dcat:accessURL rdf:resource="https://ows.geo.tg.ch/geofy_access_proxy/gewaesserschutzkarte?Service=WMS&amp;Version=1.3.0&amp;Request=GetCapabilities" />
         <dct:title xml:lang="de">Grundwasserschutzzonen</dct:title>
         <dct:description xml:lang="de">Grundwasserschutzzonen</dct:description>
@@ -37,7 +37,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/5">
         <dcat:accessURL rdf:resource="https://ows.geo.tg.ch/geofy_access_proxy/gewaesserschutzkarte?Service=WFS&amp;Version=2.0.0&amp;Request=GetCapabilities" />
         <dct:description xml:lang="de">Grundwasserschutzzonen</dct:description>
         <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/WFS_SRVC" />
@@ -55,7 +55,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/7">
         <dcat:accessURL rdf:resource="https://shop.geo.tg.ch/products/gewaesserschutzkarte" />
         <dcat:downloadURL rdf:resource="https://shop.geo.tg.ch/products/gewaesserschutzkarte" />
         <dct:title xml:lang="de">shop.geo.tg.ch</dct:title>

--- a/src/test/resources/dcat/grundwasservorkommen-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/grundwasservorkommen-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f8ca237a-882b-4e72-8b81-81378fb9e85c/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/f8ca237a-882b-4e72-8b81-81378fb9e85c/formatters/dcat-ap-ch">
     <dct:identifier>f8ca237a-882b-4e72-8b81-81378fb9e85c</dct:identifier>
     <dct:title xml:lang="de">geodienste.ch WMS Grundwasservorkommen</dct:title>
     <dct:title xml:lang="fr">geodienste.ch WMS Nappes souterraines</dct:title>

--- a/src/test/resources/dcat/grundwasservorkommen-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/grundwasservorkommen-dcat-ap-ch.xml
@@ -22,7 +22,7 @@
         <vcard:hasEmail rdf:resource="mailto:geodienste@kgk-cgc.ch" />
       </vcard:Organization>
     </dcat:contactPoint>
-    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-11-27T00:00:00</dct:issued>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-11-27T00:00:00+00:00</dct:issued>
     <dct:relation>
       <rdf:Description rdf:about="https://www.geocat.ch/datahub/dataset/f8ca237a-882b-4e72-8b81-81378fb9e85c">
         <rdfs:label xml:lang="de">geocat.ch Permalink</rdfs:label>

--- a/src/test/resources/dcat/grundwasservorkommen-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/grundwasservorkommen-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/f8ca237a-882b-4e72-8b81-81378fb9e85c/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f8ca237a-882b-4e72-8b81-81378fb9e85c/formatters/dcat-ap-ch">
     <dct:identifier>f8ca237a-882b-4e72-8b81-81378fb9e85c</dct:identifier>
     <dct:title xml:lang="de">geodienste.ch WMS Grundwasservorkommen</dct:title>
     <dct:title xml:lang="fr">geodienste.ch WMS Nappes souterraines</dct:title>

--- a/src/test/resources/dcat/grundwasservorkommen-eu-dcat-ap.xml
+++ b/src/test/resources/dcat/grundwasservorkommen-eu-dcat-ap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatap="http://data.europa.eu/r5r/" xmlns:eli="http://data.europa.eu/eli/ontology">
-  <rdf:Description rdf:about="trueapi/records/f8ca237a-882b-4e72-8b81-81378fb9e85c#resource">
+  <rdf:Description rdf:about="https://www.geocat.ch/geonetwork/api/records/f8ca237a-882b-4e72-8b81-81378fb9e85c#resource">
     <rdf:type rdf:resource="http://www.w3.org/ns/dcat#DataService" />
     <dct:type>
       <skos:Concept rdf:about="http://purl.org/dc/dcmitype/Service">
@@ -8,7 +8,7 @@
       </skos:Concept>
     </dct:type>
     <foaf:isPrimaryTopicOf>
-      <rdf:Description rdf:about="trueapi/records/f8ca237a-882b-4e72-8b81-81378fb9e85c">
+      <rdf:Description rdf:about="https://www.geocat.ch/geonetwork/api/records/f8ca237a-882b-4e72-8b81-81378fb9e85c">
         <rdf:type rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord" />
         <dct:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string">f8ca237a-882b-4e72-8b81-81378fb9e85c</dct:identifier>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-12-12T12:56:53.929Z</dct:modified>
@@ -35,7 +35,7 @@ I dati si basano sul modello di geodati minimo (MGDM) «Inventario dei prelievi 
         <dct:conformsTo>
           <dct:Standard rdf:about="https://www.w3.org/TR/vocab-dcat/" />
         </dct:conformsTo>
-        <foaf:primaryTopic rdf:resource="trueapi/records/f8ca237a-882b-4e72-8b81-81378fb9e85c#resource" />
+        <foaf:primaryTopic rdf:resource="https://www.geocat.ch/geonetwork/api/records/f8ca237a-882b-4e72-8b81-81378fb9e85c#resource" />
       </rdf:Description>
     </foaf:isPrimaryTopicOf>
     <dct:title xml:lang="de">geodienste.ch WMS Grundwasservorkommen</dct:title>

--- a/src/test/resources/dcat/hoheitsgrenzpunkteLV-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/hoheitsgrenzpunkteLV-dcat-ap-ch.xml
@@ -28,7 +28,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/1">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.swisstopo.swisstlm3d-uebrigerverkehr" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -54,7 +54,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/2">
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-uebrigerverkehr</dct:title>
         <dct:title xml:lang="fr">ch.swisstopo.swisstlm3d-uebrigerverkehr</dct:title>
@@ -82,7 +82,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/4">
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-uebrigerverkehr</dct:title>
         <dct:description xml:lang="de">Seilbahnen swissTLM3D</dct:description>
@@ -102,7 +102,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/5">
         <dcat:accessURL rdf:resource="https://www.swisstopo.admin.ch/de/landschaftsmodell-swisstlm3d" />
         <dcat:downloadURL rdf:resource="https://www.swisstopo.admin.ch/de/landschaftsmodell-swisstlm3d" />
         <dct:description xml:lang="de">Shop</dct:description>
@@ -125,7 +125,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/7">
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.swisstopo.swisstlm3d-uebrigerverkehr" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/dcat/hoheitsgrenzpunkteLV-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/hoheitsgrenzpunkteLV-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/formatters/dcat-ap-ch">
     <dct:identifier>ffc0267e-aca8-49ac-8f3e-86c9beca51f2</dct:identifier>
     <dct:title xml:lang="de">swissTLM3D Übrige Bahn</dct:title>
     <dct:title xml:lang="fr">swissTLM3D Autres transports</dct:title>
@@ -28,7 +28,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/1">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/1">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.swisstopo.swisstlm3d-uebrigerverkehr" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -54,7 +54,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/2">
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-uebrigerverkehr</dct:title>
         <dct:title xml:lang="fr">ch.swisstopo.swisstlm3d-uebrigerverkehr</dct:title>
@@ -82,7 +82,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/4">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/4">
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-uebrigerverkehr</dct:title>
         <dct:description xml:lang="de">Seilbahnen swissTLM3D</dct:description>
@@ -102,7 +102,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/5">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/5">
         <dcat:accessURL rdf:resource="https://www.swisstopo.admin.ch/de/landschaftsmodell-swisstlm3d" />
         <dcat:downloadURL rdf:resource="https://www.swisstopo.admin.ch/de/landschaftsmodell-swisstlm3d" />
         <dct:description xml:lang="de">Shop</dct:description>
@@ -125,7 +125,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/7">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/7">
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.swisstopo.swisstlm3d-uebrigerverkehr" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/dcat/hoheitsgrenzpunkteLV-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/hoheitsgrenzpunkteLV-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/formatters/dcat-ap-ch">
     <dct:identifier>ffc0267e-aca8-49ac-8f3e-86c9beca51f2</dct:identifier>
     <dct:title xml:lang="de">swissTLM3D Übrige Bahn</dct:title>
     <dct:title xml:lang="fr">swissTLM3D Autres transports</dct:title>
@@ -28,7 +28,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/1">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/1">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.swisstopo.swisstlm3d-uebrigerverkehr" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -54,7 +54,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/2">
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-uebrigerverkehr</dct:title>
         <dct:title xml:lang="fr">ch.swisstopo.swisstlm3d-uebrigerverkehr</dct:title>
@@ -82,7 +82,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/4">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/4">
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-uebrigerverkehr</dct:title>
         <dct:description xml:lang="de">Seilbahnen swissTLM3D</dct:description>
@@ -102,7 +102,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/5">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/5">
         <dcat:accessURL rdf:resource="https://www.swisstopo.admin.ch/de/landschaftsmodell-swisstlm3d" />
         <dcat:downloadURL rdf:resource="https://www.swisstopo.admin.ch/de/landschaftsmodell-swisstlm3d" />
         <dct:description xml:lang="de">Shop</dct:description>
@@ -125,7 +125,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/7">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/7">
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.swisstopo.swisstlm3d-uebrigerverkehr" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/dcat/hoheitsgrenzpunkteLV-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/hoheitsgrenzpunkteLV-dcat-ap-ch.xml
@@ -152,8 +152,8 @@
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ROH" />
       </dcat:Distribution>
     </dcat:distribution>
-    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2011-04-01T00:00:00</dct:issued>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-05T00:00:00</dct:modified>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2011-04-01T00:00:00+00:00</dct:issued>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-05T00:00:00+00:00</dct:modified>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/REGI" />
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/TRAN" />
     <dcat:landingPage rdf:resource="https://www.swisstopo.admin.ch/de/landschaftsmodell-swisstlm3d" />

--- a/src/test/resources/dcat/hoheitsgrenzpunkteLV-eu-dcat-ap-hvd.xml
+++ b/src/test/resources/dcat/hoheitsgrenzpunkteLV-eu-dcat-ap-hvd.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatap="http://data.europa.eu/r5r/" xmlns:eli="http://data.europa.eu/eli/ontology">
-  <rdf:Description rdf:about="trueapi/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2#resource">
+  <rdf:Description rdf:about="https://www.geocat.ch/geonetwork/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2#resource">
     <rdf:type rdf:resource="http://www.w3.org/ns/dcat#Dataset" />
     <dct:type>
       <skos:Concept rdf:about="http://purl.org/dc/dcmitype/Dataset">
@@ -8,7 +8,7 @@
       </skos:Concept>
     </dct:type>
     <foaf:isPrimaryTopicOf>
-      <rdf:Description rdf:about="trueapi/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2">
+      <rdf:Description rdf:about="https://www.geocat.ch/geonetwork/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2">
         <rdf:type rdf:resource="http://www.w3.org/ns/dcat#CatalogRecord" />
         <dct:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#string">ffc0267e-aca8-49ac-8f3e-86c9beca51f2</dct:identifier>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-04T14:56:05.532Z</dct:modified>
@@ -40,7 +40,7 @@
         <dct:conformsTo>
           <dct:Standard rdf:about="https://www.w3.org/TR/vocab-dcat/" />
         </dct:conformsTo>
-        <foaf:primaryTopic rdf:resource="trueapi/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2#resource" />
+        <foaf:primaryTopic rdf:resource="https://www.geocat.ch/geonetwork/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2#resource" />
       </rdf:Description>
     </foaf:isPrimaryTopicOf>
     <dct:title xml:lang="de">swissTLM3D Übrige Bahn</dct:title>

--- a/src/test/resources/dcat/modellDokumentationSwissTLM3D-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/modellDokumentationSwissTLM3D-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/formatters/dcat-ap-ch">
     <dct:identifier>6e2efe8b-7153-4f5c-81a5-c154e69727ba</dct:identifier>
     <dct:title xml:lang="de">Modelldokumentation "swissTLM3D 2.3"</dct:title>
     <dct:title xml:lang="fr">Documentation de modèle "swissTLM3D 2.3"</dct:title>
@@ -21,7 +21,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/distributions/2">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/attachments/be4129e9-d1d6-4856-b465-8ca2803e1376.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/attachments/be4129e9-d1d6-4856-b465-8ca2803e1376.pdf" />
         <dct:description xml:lang="de">Deutsche Version</dct:description>

--- a/src/test/resources/dcat/modellDokumentationSwissTLM3D-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/modellDokumentationSwissTLM3D-dcat-ap-ch.xml
@@ -39,7 +39,7 @@
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG" />
       </dcat:Distribution>
     </dcat:distribution>
-    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-05T00:00:00</dct:issued>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-05T00:00:00+00:00</dct:issued>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/REGI" />
     <dcat:landingPage rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/attachments/b6444b4c-50ea-4982-8bd1-bcf7541a5b0d.pdf" />
     <dct:relation>

--- a/src/test/resources/dcat/modellDokumentationSwissTLM3D-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/modellDokumentationSwissTLM3D-dcat-ap-ch.xml
@@ -21,7 +21,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/distributions/2">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/attachments/be4129e9-d1d6-4856-b465-8ca2803e1376.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/attachments/be4129e9-d1d6-4856-b465-8ca2803e1376.pdf" />
         <dct:description xml:lang="de">Deutsche Version</dct:description>

--- a/src/test/resources/dcat/modellDokumentationSwissTLM3D-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/modellDokumentationSwissTLM3D-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/formatters/dcat-ap-ch">
     <dct:identifier>6e2efe8b-7153-4f5c-81a5-c154e69727ba</dct:identifier>
     <dct:title xml:lang="de">Modelldokumentation "swissTLM3D 2.3"</dct:title>
     <dct:title xml:lang="fr">Documentation de modèle "swissTLM3D 2.3"</dct:title>
@@ -21,7 +21,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/distributions/2">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/attachments/be4129e9-d1d6-4856-b465-8ca2803e1376.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/attachments/be4129e9-d1d6-4856-b465-8ca2803e1376.pdf" />
         <dct:description xml:lang="de">Deutsche Version</dct:description>

--- a/src/test/resources/dcat/organischenBodenInDerSchweiz-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/organischenBodenInDerSchweiz-dcat-ap-ch.xml
@@ -23,7 +23,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/2">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.agroscope.LAYERNAME" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.agroscope.LAYERNAME" />
         <dct:title xml:lang="de">STAC Browser</dct:title>
@@ -47,7 +47,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/3">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?topic=aviation&amp;lang=de&amp;bgLayer=ch.swisstopo.pixelkarte-grau&amp;layers=ch.bazl.wohngebiete-aulav&amp;catalogNodes=2863&amp;layers_opacity=0.6&amp;E=2642942.51&amp;N=1189717.47&amp;zoom=2" />
         <dct:title xml:lang="de">Vorschau der Karte</dct:title>
         <dct:title xml:lang="fr">Prévie da la carte</dct:title>
@@ -67,7 +67,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/6">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/W%C3%BCst-Galley%20Leifeld%202025%20org%20soils%20map%20SI.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/W%C3%BCst-Galley%20Leifeld%202025%20org%20soils%20map%20SI.pdf" />
         <dct:title xml:lang="de">Wüst-Galley Leifeld 2025 org soils map SI.pdf</dct:title>
@@ -93,7 +93,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/8">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/Abstract_de_engl_fr_def.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/Abstract_de_engl_fr_def.pdf" />
         <dct:title xml:lang="de">Abstract_de_engl_fr_def.pdf</dct:title>

--- a/src/test/resources/dcat/organischenBodenInDerSchweiz-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/organischenBodenInDerSchweiz-dcat-ap-ch.xml
@@ -32,7 +32,7 @@
         <dct:description xml:lang="fr">Lien vers la distribution des données</dct:description>
         <dct:description xml:lang="it">Link per le fonti dei dati</dct:description>
         <dct:description xml:lang="en">Link for data download</dct:description>
-        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/UNSPECIFIED" />
+        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/HTML" />
         <dcat:mediaType rdf:resource="http://www.iana.org/assignments/media-types/application/octet-stream" />
         <dct:license rdf:resource="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         <dct:rights>

--- a/src/test/resources/dcat/organischenBodenInDerSchweiz-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/organischenBodenInDerSchweiz-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/formatters/dcat-ap-ch">
     <dct:identifier>0572e842-7e34-409a-90d9-526d012a1c2d</dct:identifier>
     <dct:title xml:lang="de">Abschätzung der organischen Böden in der Schweiz 2024</dct:title>
     <dct:title xml:lang="fr">Estimation des sols organiques en Suisse 2024</dct:title>
@@ -23,7 +23,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/2">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.agroscope.LAYERNAME" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.agroscope.LAYERNAME" />
         <dct:title xml:lang="de">STAC Browser</dct:title>
@@ -47,7 +47,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/3">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/3">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?topic=aviation&amp;lang=de&amp;bgLayer=ch.swisstopo.pixelkarte-grau&amp;layers=ch.bazl.wohngebiete-aulav&amp;catalogNodes=2863&amp;layers_opacity=0.6&amp;E=2642942.51&amp;N=1189717.47&amp;zoom=2" />
         <dct:title xml:lang="de">Vorschau der Karte</dct:title>
         <dct:title xml:lang="fr">Prévie da la carte</dct:title>
@@ -67,7 +67,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/6">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/6">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/W%C3%BCst-Galley%20Leifeld%202025%20org%20soils%20map%20SI.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/W%C3%BCst-Galley%20Leifeld%202025%20org%20soils%20map%20SI.pdf" />
         <dct:title xml:lang="de">Wüst-Galley Leifeld 2025 org soils map SI.pdf</dct:title>
@@ -93,7 +93,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/8">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/8">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/Abstract_de_engl_fr_def.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/Abstract_de_engl_fr_def.pdf" />
         <dct:title xml:lang="de">Abstract_de_engl_fr_def.pdf</dct:title>

--- a/src/test/resources/dcat/organischenBodenInDerSchweiz-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/organischenBodenInDerSchweiz-dcat-ap-ch.xml
@@ -38,7 +38,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
-        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-08T00:00:00+00:00</dct:issued>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-08-01T00:00:00+00:00</dct:issued>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ITA" />
@@ -58,7 +58,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
-        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-08T00:00:00+00:00</dct:issued>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-08-01T00:00:00+00:00</dct:issued>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ITA" />
@@ -84,7 +84,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
-        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-08T00:00:00+00:00</dct:issued>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-08-01T00:00:00+00:00</dct:issued>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ITA" />
@@ -110,7 +110,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
-        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-08T00:00:00+00:00</dct:issued>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-08-01T00:00:00+00:00</dct:issued>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ITA" />
@@ -118,7 +118,7 @@
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ROH" />
       </dcat:Distribution>
     </dcat:distribution>
-    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-08T00:00:00</dct:issued>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-08-01T00:00:00+00:00</dct:issued>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/REGI" />
     <dcat:landingPage rdf:resource="https://www.agroscope.admin.ch/agroscope/de/home/themen/umwelt-ressourcen/klima-lufthygiene/co2-treibhausgase-landwirtschaftliche-boeden/organische-boeden/flaeche.html" />
     <dct:relation>

--- a/src/test/resources/dcat/organischenBodenInDerSchweiz-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/organischenBodenInDerSchweiz-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/formatters/dcat-ap-ch">
     <dct:identifier>0572e842-7e34-409a-90d9-526d012a1c2d</dct:identifier>
     <dct:title xml:lang="de">Abschätzung der organischen Böden in der Schweiz 2024</dct:title>
     <dct:title xml:lang="fr">Estimation des sols organiques en Suisse 2024</dct:title>
@@ -23,7 +23,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/2">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.agroscope.LAYERNAME" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.agroscope.LAYERNAME" />
         <dct:title xml:lang="de">STAC Browser</dct:title>
@@ -47,7 +47,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/3">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/3">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?topic=aviation&amp;lang=de&amp;bgLayer=ch.swisstopo.pixelkarte-grau&amp;layers=ch.bazl.wohngebiete-aulav&amp;catalogNodes=2863&amp;layers_opacity=0.6&amp;E=2642942.51&amp;N=1189717.47&amp;zoom=2" />
         <dct:title xml:lang="de">Vorschau der Karte</dct:title>
         <dct:title xml:lang="fr">Prévie da la carte</dct:title>
@@ -67,7 +67,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/6">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/6">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/W%C3%BCst-Galley%20Leifeld%202025%20org%20soils%20map%20SI.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/W%C3%BCst-Galley%20Leifeld%202025%20org%20soils%20map%20SI.pdf" />
         <dct:title xml:lang="de">Wüst-Galley Leifeld 2025 org soils map SI.pdf</dct:title>
@@ -93,7 +93,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/8">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/8">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/Abstract_de_engl_fr_def.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/Abstract_de_engl_fr_def.pdf" />
         <dct:title xml:lang="de">Abstract_de_engl_fr_def.pdf</dct:title>

--- a/src/test/resources/dcat/schuetzenswerte-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/schuetzenswerte-dcat-ap-ch.xml
@@ -150,7 +150,7 @@
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ROH" />
       </dcat:Distribution>
     </dcat:distribution>
-    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-02-22T00:00:00</dct:issued>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-02-22T00:00:00+00:00</dct:issued>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/SOCI" />
     <dcat:landingPage rdf:resource="https://www.bak.admin.ch/bak/de/home/baukultur/isos-und-ortsbildschutz.html" />
     <dct:relation>

--- a/src/test/resources/dcat/schuetzenswerte-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/schuetzenswerte-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/formatters/dcat-ap-ch">
     <dct:identifier>b9c1d690-008f-494c-a47f-ec96d9a8d84f</dct:identifier>
     <dct:title xml:lang="de">ISOS - Bundesinventar der schützenswerten Ortsbilder der Schweiz von nationaler Bedeutung ab 2021 - Bilder</dct:title>
     <dct:title xml:lang="fr">ISOS - Inventaire fédéral des sites construits d'importance nationale à protéger en Suisse dès 2021 - Photos</dct:title>
@@ -28,7 +28,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/2">
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
         <dct:title xml:lang="fr">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
@@ -55,7 +55,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/3">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/3">
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
         <dct:title xml:lang="fr">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
@@ -82,7 +82,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/4">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/4">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -104,7 +104,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/5">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/5">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.bak.bundesinventar-schuetzenswerte-ortsbilder/items/bundesinventar-schuetzenswerte-ortsbilder" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.bak.bundesinventar-schuetzenswerte-ortsbilder/items/bundesinventar-schuetzenswerte-ortsbilder" />
         <dct:description xml:lang="de">Link zum Datenbezug</dct:description>
@@ -124,7 +124,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/7">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/7">
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/dcat/schuetzenswerte-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/schuetzenswerte-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/formatters/dcat-ap-ch">
     <dct:identifier>b9c1d690-008f-494c-a47f-ec96d9a8d84f</dct:identifier>
     <dct:title xml:lang="de">ISOS - Bundesinventar der schützenswerten Ortsbilder der Schweiz von nationaler Bedeutung ab 2021 - Bilder</dct:title>
     <dct:title xml:lang="fr">ISOS - Inventaire fédéral des sites construits d'importance nationale à protéger en Suisse dès 2021 - Photos</dct:title>
@@ -28,7 +28,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/2">
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
         <dct:title xml:lang="fr">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
@@ -55,7 +55,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/3">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/3">
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
         <dct:title xml:lang="fr">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
@@ -82,7 +82,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/4">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/4">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -104,7 +104,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/5">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/5">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.bak.bundesinventar-schuetzenswerte-ortsbilder/items/bundesinventar-schuetzenswerte-ortsbilder" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.bak.bundesinventar-schuetzenswerte-ortsbilder/items/bundesinventar-schuetzenswerte-ortsbilder" />
         <dct:description xml:lang="de">Link zum Datenbezug</dct:description>
@@ -124,7 +124,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/7">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/7">
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/dcat/schuetzenswerte-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/schuetzenswerte-dcat-ap-ch.xml
@@ -28,7 +28,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/2">
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
         <dct:title xml:lang="fr">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
@@ -55,7 +55,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/3">
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
         <dct:title xml:lang="fr">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
@@ -82,7 +82,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/4">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -104,7 +104,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/5">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.bak.bundesinventar-schuetzenswerte-ortsbilder/items/bundesinventar-schuetzenswerte-ortsbilder" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.bak.bundesinventar-schuetzenswerte-ortsbilder/items/bundesinventar-schuetzenswerte-ortsbilder" />
         <dct:description xml:lang="de">Link zum Datenbezug</dct:description>
@@ -124,7 +124,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/7">
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>
@@ -217,6 +217,9 @@
     <dcat:keyword xml:lang="en">Area management/restriction/regulation zones and reporting units</dcat:keyword>
     <dct:spatial>Schweiz</dct:spatial>
     <dct:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/ANNUAL" />
+    <foaf:page>
+      <foaf:Document rdf:about="https://www.bak.admin.ch/bak/de/home/baukultur/isos-und-ortsbildschutz.html" />
+    </foaf:page>
   </dcat:Dataset>
   <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_by">
     <rdf:type rdf:resource="http://purl.org/dc/terms/LicenseDocument" />

--- a/src/test/resources/dcat/schuetzenswerte-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/schuetzenswerte-dcat-ap-ch.xml
@@ -109,7 +109,7 @@
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.bak.bundesinventar-schuetzenswerte-ortsbilder/items/bundesinventar-schuetzenswerte-ortsbilder" />
         <dct:description xml:lang="de">Link zum Datenbezug</dct:description>
         <dct:description xml:lang="fr">Lien vers la distribution des données</dct:description>
-        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/UNSPECIFIED" />
+        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/HTML" />
         <dcat:mediaType rdf:resource="http://www.iana.org/assignments/media-types/application/octet-stream" />
         <dct:license rdf:resource="http://dcat-ap.ch/vocabulary/licenses/terms_by" />
         <dct:rights>

--- a/src/test/resources/dcat/swissTLM3D-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/swissTLM3D-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/eeab64f5-e878-4898-b80c-50440b89f525/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/eeab64f5-e878-4898-b80c-50440b89f525/formatters/dcat-ap-ch">
     <dct:identifier>eeab64f5-e878-4898-b80c-50440b89f525</dct:identifier>
     <dct:title xml:lang="de">Geodatenmodell "swissTLM3D_ili2_V2_3"</dct:title>
     <dct:title xml:lang="fr">Modèle de géodonnées "swissTLM3D_ili2_V2_3"</dct:title>
@@ -21,7 +21,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/eeab64f5-e878-4898-b80c-50440b89f525/distributions/1">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/eeab64f5-e878-4898-b80c-50440b89f525/distributions/1">
         <dcat:accessURL rdf:resource="https://models.geo.admin.ch/Swisstopo/swissTLM3D_ili2_V2_3.ili" />
         <dcat:downloadURL rdf:resource="https://models.geo.admin.ch/Swisstopo/swissTLM3D_ili2_V2_3.ili" />
         <dct:title xml:lang="de">swissTLM3D_ili2_V2_3.ili</dct:title>

--- a/src/test/resources/dcat/swissTLM3D-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/swissTLM3D-dcat-ap-ch.xml
@@ -21,7 +21,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/eeab64f5-e878-4898-b80c-50440b89f525/distributions/1">
         <dcat:accessURL rdf:resource="https://models.geo.admin.ch/Swisstopo/swissTLM3D_ili2_V2_3.ili" />
         <dcat:downloadURL rdf:resource="https://models.geo.admin.ch/Swisstopo/swissTLM3D_ili2_V2_3.ili" />
         <dct:title xml:lang="de">swissTLM3D_ili2_V2_3.ili</dct:title>

--- a/src/test/resources/dcat/swissTLM3D-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/swissTLM3D-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/eeab64f5-e878-4898-b80c-50440b89f525/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/eeab64f5-e878-4898-b80c-50440b89f525/formatters/dcat-ap-ch">
     <dct:identifier>eeab64f5-e878-4898-b80c-50440b89f525</dct:identifier>
     <dct:title xml:lang="de">Geodatenmodell "swissTLM3D_ili2_V2_3"</dct:title>
     <dct:title xml:lang="fr">Modèle de géodonnées "swissTLM3D_ili2_V2_3"</dct:title>
@@ -21,7 +21,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/eeab64f5-e878-4898-b80c-50440b89f525/distributions/1">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/eeab64f5-e878-4898-b80c-50440b89f525/distributions/1">
         <dcat:accessURL rdf:resource="https://models.geo.admin.ch/Swisstopo/swissTLM3D_ili2_V2_3.ili" />
         <dcat:downloadURL rdf:resource="https://models.geo.admin.ch/Swisstopo/swissTLM3D_ili2_V2_3.ili" />
         <dct:title xml:lang="de">swissTLM3D_ili2_V2_3.ili</dct:title>

--- a/src/test/resources/dcat/swissTLM3D-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/swissTLM3D-dcat-ap-ch.xml
@@ -41,7 +41,7 @@
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG" />
       </dcat:Distribution>
     </dcat:distribution>
-    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-01-01T00:00:00</dct:issued>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-01-01T00:00:00+00:00</dct:issued>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/REGI" />
     <dct:relation>
       <rdf:Description rdf:about="https://www.geocat.ch/datahub/dataset/eeab64f5-e878-4898-b80c-50440b89f525">

--- a/src/test/resources/dcat/trees-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/trees-dcat-ap-ch.xml
@@ -34,6 +34,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-11T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-11T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
@@ -55,6 +56,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-11T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-11T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
@@ -73,6 +75,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-11T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-11T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
@@ -97,6 +100,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-11T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-11T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
@@ -104,7 +108,7 @@
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ENG" />
       </dcat:Distribution>
     </dcat:distribution>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-11T00:00:00</dct:modified>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-11T00:00:00+00:00</dct:modified>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/REGI" />
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/AGRI" />
     <dcat:landingPage rdf:resource="https://map.geo.fr.ch/?dataTheme=Agriculture&amp;theme&amp;lang=fr" />

--- a/src/test/resources/dcat/trees-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/trees-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/formatters/dcat-ap-ch">
     <dct:identifier>1d177f9e-2446-428f-8740-0dbe11e4131c</dct:identifier>
     <dct:title xml:lang="fr">Localisation des arbres annoncés dans les exploitations agricoles</dct:title>
     <dct:title xml:lang="de">Bäume</dct:title>
@@ -21,7 +21,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/4">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/4">
         <dcat:accessURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportail/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dcat:downloadURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportail/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dct:description xml:lang="fr">Accès aux données (fr) : téléchargement et services web (Géoportail cantonal)</dct:description>
@@ -43,7 +43,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/5">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/5">
         <dcat:accessURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportal/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dcat:downloadURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportal/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dct:description xml:lang="fr">Datenzugriff (de): Download und Webservices (Kantonales Geoportal)</dct:description>
@@ -65,7 +65,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/6">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/6">
         <dcat:accessURL rdf:resource="https://geo.fr.ch/ags/services/OpenData/Arbres_culture/MapServer/WMSServer?request=GetCapabilities&amp;service=WMS" />
         <dct:title xml:lang="fr">0</dct:title>
         <dct:description xml:lang="fr">Arbres (culture)</dct:description>
@@ -84,7 +84,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/7">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/7">
         <dcat:accessURL rdf:resource="https://geo.fr.ch/CartoFR/?showLegend&amp;uniquelayer=https://geo.fr.ch/ags/rest/services/OpenData/Arbres_culture/MapServer/0" />
         <dct:title xml:lang="fr">Visualisation des données</dct:title>
         <dct:title xml:lang="de">Visualisierung der Daten</dct:title>

--- a/src/test/resources/dcat/trees-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/trees-dcat-ap-ch.xml
@@ -21,7 +21,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/4">
         <dcat:accessURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportail/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dcat:downloadURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportail/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dct:description xml:lang="fr">Accès aux données (fr) : téléchargement et services web (Géoportail cantonal)</dct:description>
@@ -42,7 +42,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/5">
         <dcat:accessURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportal/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dcat:downloadURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportal/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dct:description xml:lang="fr">Datenzugriff (de): Download und Webservices (Kantonales Geoportal)</dct:description>
@@ -63,7 +63,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/6">
         <dcat:accessURL rdf:resource="https://geo.fr.ch/ags/services/OpenData/Arbres_culture/MapServer/WMSServer?request=GetCapabilities&amp;service=WMS" />
         <dct:title xml:lang="fr">0</dct:title>
         <dct:description xml:lang="fr">Arbres (culture)</dct:description>
@@ -81,7 +81,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/7">
         <dcat:accessURL rdf:resource="https://geo.fr.ch/CartoFR/?showLegend&amp;uniquelayer=https://geo.fr.ch/ags/rest/services/OpenData/Arbres_culture/MapServer/0" />
         <dct:title xml:lang="fr">Visualisation des données</dct:title>
         <dct:title xml:lang="de">Visualisierung der Daten</dct:title>

--- a/src/test/resources/dcat/trees-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/trees-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/formatters/dcat-ap-ch">
     <dct:identifier>1d177f9e-2446-428f-8740-0dbe11e4131c</dct:identifier>
     <dct:title xml:lang="fr">Localisation des arbres annoncés dans les exploitations agricoles</dct:title>
     <dct:title xml:lang="de">Bäume</dct:title>
@@ -21,7 +21,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/4">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/4">
         <dcat:accessURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportail/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dcat:downloadURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportail/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dct:description xml:lang="fr">Accès aux données (fr) : téléchargement et services web (Géoportail cantonal)</dct:description>
@@ -43,7 +43,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/5">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/5">
         <dcat:accessURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportal/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dcat:downloadURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportal/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dct:description xml:lang="fr">Datenzugriff (de): Download und Webservices (Kantonales Geoportal)</dct:description>
@@ -65,7 +65,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/6">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/6">
         <dcat:accessURL rdf:resource="https://geo.fr.ch/ags/services/OpenData/Arbres_culture/MapServer/WMSServer?request=GetCapabilities&amp;service=WMS" />
         <dct:title xml:lang="fr">0</dct:title>
         <dct:description xml:lang="fr">Arbres (culture)</dct:description>
@@ -84,7 +84,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/7">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/7">
         <dcat:accessURL rdf:resource="https://geo.fr.ch/CartoFR/?showLegend&amp;uniquelayer=https://geo.fr.ch/ags/rest/services/OpenData/Arbres_culture/MapServer/0" />
         <dct:title xml:lang="fr">Visualisation des données</dct:title>
         <dct:title xml:lang="de">Visualisierung der Daten</dct:title>

--- a/src/test/resources/dcat/veterinarians-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/veterinarians-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/8b1185b2-b14b-45b3-9814-95247c4f3d09/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/8b1185b2-b14b-45b3-9814-95247c4f3d09/formatters/dcat-ap-ch">
     <dct:identifier>8b1185b2-b14b-45b3-9814-95247c4f3d09</dct:identifier>
     <dct:title xml:lang="fr">Vétérinaires (Canton de Fribourg) - EN TRAVAIL</dct:title>
     <dct:description xml:lang="fr">Cette donnée recense les adresses de cabinets vétérinaires. Elle sert actuellement de base à la création de la donnée "Vétérinaires de contact pour le piétin". À l'avenir, elle sera enrichie avec d'autres cabinets vétérinaires du canton.</dct:description>
@@ -17,7 +17,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/8b1185b2-b14b-45b3-9814-95247c4f3d09/distributions/1">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/8b1185b2-b14b-45b3-9814-95247c4f3d09/distributions/1">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dct:title xml:lang="fr">Datenbeschreibung_AmphibienAckerland.pdf</dct:title>

--- a/src/test/resources/dcat/veterinarians-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/veterinarians-dcat-ap-ch.xml
@@ -33,7 +33,7 @@
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
       </dcat:Distribution>
     </dcat:distribution>
-    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2023-05-26T00:00:00</dct:issued>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2023-05-26T00:00:00+00:00</dct:issued>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/AGRI" />
     <dcat:landingPage rdf:resource="https://www.fr.ch/diaf/saav" />
     <dct:relation>

--- a/src/test/resources/dcat/veterinarians-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/veterinarians-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/8b1185b2-b14b-45b3-9814-95247c4f3d09/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/8b1185b2-b14b-45b3-9814-95247c4f3d09/formatters/dcat-ap-ch">
     <dct:identifier>8b1185b2-b14b-45b3-9814-95247c4f3d09</dct:identifier>
     <dct:title xml:lang="fr">Vétérinaires (Canton de Fribourg) - EN TRAVAIL</dct:title>
     <dct:description xml:lang="fr">Cette donnée recense les adresses de cabinets vétérinaires. Elle sert actuellement de base à la création de la donnée "Vétérinaires de contact pour le piétin". À l'avenir, elle sera enrichie avec d'autres cabinets vétérinaires du canton.</dct:description>
@@ -17,7 +17,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/8b1185b2-b14b-45b3-9814-95247c4f3d09/distributions/1">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/8b1185b2-b14b-45b3-9814-95247c4f3d09/distributions/1">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dct:title xml:lang="fr">Datenbeschreibung_AmphibienAckerland.pdf</dct:title>

--- a/src/test/resources/dcat/veterinarians-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/veterinarians-dcat-ap-ch.xml
@@ -17,7 +17,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/8b1185b2-b14b-45b3-9814-95247c4f3d09/distributions/1">
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dct:title xml:lang="fr">Datenbeschreibung_AmphibienAckerland.pdf</dct:title>

--- a/src/test/resources/dcat/wanderWege-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/wanderWege-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/formatters/dcat-ap-ch">
     <dct:identifier>97df4dcd-364c-4649-9c11-c65b3b0e9ff2</dct:identifier>
     <dct:title xml:lang="de">Beispiel swissTLM3D Wanderwege</dct:title>
     <dct:title xml:lang="fr">Exemple swissTLM3D chemins de randonnée pédestre</dct:title>
@@ -27,7 +27,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/1">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/1">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.swisstopo.swisstlm3d-wanderwege" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -53,7 +53,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/2">
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
         <dct:title xml:lang="fr">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
@@ -81,7 +81,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/3">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/3">
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
         <dct:title xml:lang="fr">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
@@ -109,7 +109,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/5">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/5">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.swisstopo.swisstlm3d-wanderwege/swisstlm3d-wanderwege/swisstlm3d-wanderwege_2056_5728.gpkg.zip" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.swisstopo.swisstlm3d-wanderwege/swisstlm3d-wanderwege/swisstlm3d-wanderwege_2056_5728.gpkg.zip" />
         <dct:title xml:lang="de">swisstlm3d-wanderwege</dct:title>
@@ -133,7 +133,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/7">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/7">
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.swisstopo.swisstlm3d-wanderwege" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/dcat/wanderWege-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/wanderWege-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/formatters/dcat-ap-ch">
     <dct:identifier>97df4dcd-364c-4649-9c11-c65b3b0e9ff2</dct:identifier>
     <dct:title xml:lang="de">Beispiel swissTLM3D Wanderwege</dct:title>
     <dct:title xml:lang="fr">Exemple swissTLM3D chemins de randonnée pédestre</dct:title>
@@ -27,7 +27,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/1">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/1">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.swisstopo.swisstlm3d-wanderwege" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -53,7 +53,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/2">
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
         <dct:title xml:lang="fr">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
@@ -81,7 +81,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/3">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/3">
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
         <dct:title xml:lang="fr">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
@@ -109,7 +109,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/5">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/5">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.swisstopo.swisstlm3d-wanderwege/swisstlm3d-wanderwege/swisstlm3d-wanderwege_2056_5728.gpkg.zip" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.swisstopo.swisstlm3d-wanderwege/swisstlm3d-wanderwege/swisstlm3d-wanderwege_2056_5728.gpkg.zip" />
         <dct:title xml:lang="de">swisstlm3d-wanderwege</dct:title>
@@ -133,7 +133,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/7">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/7">
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.swisstopo.swisstlm3d-wanderwege" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/dcat/wanderWege-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/wanderWege-dcat-ap-ch.xml
@@ -27,7 +27,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/1">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.swisstopo.swisstlm3d-wanderwege" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -53,7 +53,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/2">
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
         <dct:title xml:lang="fr">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
@@ -81,7 +81,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/3">
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
         <dct:title xml:lang="fr">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
@@ -109,7 +109,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/5">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.swisstopo.swisstlm3d-wanderwege/swisstlm3d-wanderwege/swisstlm3d-wanderwege_2056_5728.gpkg.zip" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.swisstopo.swisstlm3d-wanderwege/swisstlm3d-wanderwege/swisstlm3d-wanderwege_2056_5728.gpkg.zip" />
         <dct:title xml:lang="de">swisstlm3d-wanderwege</dct:title>
@@ -133,7 +133,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/7">
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.swisstopo.swisstlm3d-wanderwege" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/dcat/wanderWege-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/wanderWege-dcat-ap-ch.xml
@@ -160,8 +160,8 @@
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ROH" />
       </dcat:Distribution>
     </dcat:distribution>
-    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2012-04-01T00:00:00</dct:issued>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-06-04T00:00:00</dct:modified>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2012-04-01T00:00:00+00:00</dct:issued>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-06-04T00:00:00+00:00</dct:modified>
     <dcat:landingPage rdf:resource="https://www.swisstopo.admin.ch/de/landschaftsmodell-swisstlm3d" />
     <dct:relation>
       <rdf:Description rdf:about="https://www.geocat.ch/datahub/dataset/97df4dcd-364c-4649-9c11-c65b3b0e9ff2">

--- a/src/test/resources/dcat/weatherStations-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/weatherStations-dcat-ap-ch.xml
@@ -19,7 +19,7 @@
       </foaf:Agent>
     </dct:publisher>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/1">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.messwerte-aktuell/VQHA80.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.messwerte-aktuell/VQHA80.csv" />
         <dct:title xml:lang="de">Hauptparameter aller Stationen – alle 10 Minuten, aktuellste Werte</dct:title>
@@ -45,7 +45,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/2">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_parameters.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_parameters.csv" />
         <dct:title xml:lang="de">Parameter-Metadaten</dct:title>
@@ -71,7 +71,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/3">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_stations.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_stations.csv" />
         <dct:title xml:lang="de">Stations-Metadaten</dct:title>
@@ -97,7 +97,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/4">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-smn" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-smn" />
         <dct:title xml:lang="de">Alle Parameter einer Station – alle Auflösungen und Zeiträume</dct:title>
@@ -123,7 +123,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/8">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_datainventory.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_datainventory.csv" />
         <dct:title xml:lang="de">Dateninventar-Metadaten</dct:title>
@@ -235,6 +235,12 @@
     <dcat:keyword xml:lang="en">OpenData</dcat:keyword>
     <dct:spatial>Schweiz</dct:spatial>
     <dct:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/CONT" />
+    <foaf:page>
+      <foaf:Document rdf:about="https://www.meteoschweiz.admin.ch/service-und-publikationen/service/open-data.html" />
+    </foaf:page>
+    <foaf:page>
+      <foaf:Document rdf:about="https://opendatadocs.meteoswiss.ch/de/a-data-groundbased/a1-automatic-weather-stations" />
+    </foaf:page>
   </dcat:Dataset>
   <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_by">
     <rdf:type rdf:resource="http://purl.org/dc/terms/LicenseDocument" />

--- a/src/test/resources/dcat/weatherStations-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/weatherStations-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/35323752-ed32-4cc1-8a75-898c749b777b/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/formatters/dcat-ap-ch">
     <dct:identifier>35323752-ed32-4cc1-8a75-898c749b777b</dct:identifier>
     <dct:title xml:lang="de">Automatische Wetterstationen – Messwerte</dct:title>
     <dct:title xml:lang="fr">Stations météorologiques automatiques – Valeurs mesurées</dct:title>
@@ -25,7 +25,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/1">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/1">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.messwerte-aktuell/VQHA80.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.messwerte-aktuell/VQHA80.csv" />
         <dct:title xml:lang="de">Hauptparameter aller Stationen – alle 10 Minuten, aktuellste Werte</dct:title>
@@ -51,7 +51,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/2">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_parameters.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_parameters.csv" />
         <dct:title xml:lang="de">Parameter-Metadaten</dct:title>
@@ -77,7 +77,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/3">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/3">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_stations.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_stations.csv" />
         <dct:title xml:lang="de">Stations-Metadaten</dct:title>
@@ -103,7 +103,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/4">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/4">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-smn" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-smn" />
         <dct:title xml:lang="de">Alle Parameter einer Station – alle Auflösungen und Zeiträume</dct:title>
@@ -129,7 +129,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/8">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/8">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_datainventory.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_datainventory.csv" />
         <dct:title xml:lang="de">Dateninventar-Metadaten</dct:title>

--- a/src/test/resources/dcat/weatherStations-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/weatherStations-dcat-ap-ch.xml
@@ -18,6 +18,12 @@
         <foaf:name xml:lang="en">Federal Office of Meterology and Climatology MeteoSwiss</foaf:name>
       </foaf:Agent>
     </dct:publisher>
+    <dcat:contactPoint>
+      <vcard:Organization>
+        <vcard:fn>Bundesamt für Meteorologie und Klimatologie MeteoSchweiz</vcard:fn>
+        <vcard:hasEmail rdf:resource="mailto:opendata.en@meteoschweiz.ch" />
+      </vcard:Organization>
+    </dcat:contactPoint>
     <dcat:distribution>
       <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/1">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.messwerte-aktuell/VQHA80.csv" />
@@ -148,7 +154,7 @@
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ROH" />
       </dcat:Distribution>
     </dcat:distribution>
-    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-05-20T00:00:00</dct:issued>
+    <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-05-20T00:00:00+00:00</dct:issued>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dcat:landingPage rdf:resource="https://www.meteoschweiz.admin.ch/service-und-publikationen/service/open-data.html" />
     <dct:relation>

--- a/src/test/resources/dcat/weatherStations-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/weatherStations-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/35323752-ed32-4cc1-8a75-898c749b777b/formatters/dcat-ap-ch">
     <dct:identifier>35323752-ed32-4cc1-8a75-898c749b777b</dct:identifier>
     <dct:title xml:lang="de">Automatische Wetterstationen – Messwerte</dct:title>
     <dct:title xml:lang="fr">Stations météorologiques automatiques – Valeurs mesurées</dct:title>
@@ -25,7 +25,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/1">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/1">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.messwerte-aktuell/VQHA80.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.messwerte-aktuell/VQHA80.csv" />
         <dct:title xml:lang="de">Hauptparameter aller Stationen – alle 10 Minuten, aktuellste Werte</dct:title>
@@ -51,7 +51,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/2">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_parameters.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_parameters.csv" />
         <dct:title xml:lang="de">Parameter-Metadaten</dct:title>
@@ -77,7 +77,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/3">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/3">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_stations.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_stations.csv" />
         <dct:title xml:lang="de">Stations-Metadaten</dct:title>
@@ -103,7 +103,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/4">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/4">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-smn" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-smn" />
         <dct:title xml:lang="de">Alle Parameter einer Station – alle Auflösungen und Zeiträume</dct:title>
@@ -129,7 +129,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/8">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/8">
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_datainventory.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_datainventory.csv" />
         <dct:title xml:lang="de">Dateninventar-Metadaten</dct:title>

--- a/src/test/resources/dcat/zonesDeTranquillite-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/zonesDeTranquillite-dcat-ap-ch.xml
@@ -22,7 +22,7 @@
       </foaf:Agent>
     </dct:publisher>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/1">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.bafu.wrz-wildruhezonen_portal" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -47,7 +47,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/2">
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.bafu.wrz-wildruhezonen_portal</dct:title>
         <dct:title xml:lang="fr">ch.bafu.wrz-wildruhezonen_portal</dct:title>
@@ -74,7 +74,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/3">
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.bafu.wrz-wildruhezonen_portal</dct:title>
         <dct:title xml:lang="fr">ch.bafu.wrz-wildruhezonen_portal</dct:title>
@@ -101,7 +101,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/6">
         <dcat:accessURL rdf:resource="https://www.geodienste.ch/services/wildruhezonen" />
         <dcat:downloadURL rdf:resource="https://www.geodienste.ch/services/wildruhezonen" />
         <dct:description xml:lang="de">Abteilung Biodiversität und Landschaft</dct:description>
@@ -123,7 +123,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution>
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/7">
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.bafu.wrz-wildruhezonen_portal" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>
@@ -203,6 +203,9 @@
     <dcat:keyword xml:lang="en">FSDI Federal Spatial Data Infrastructure</dcat:keyword>
     <dct:spatial>Schweiz</dct:spatial>
     <dct:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/ANNUAL" />
+    <foaf:page>
+      <foaf:Document rdf:about="https://www.wildruhezonen.ch/news/aenderungen-und-allgemeine-hinweise" />
+    </foaf:page>
   </dcat:Dataset>
   <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_by">
     <rdf:type rdf:resource="http://purl.org/dc/terms/LicenseDocument" />

--- a/src/test/resources/dcat/zonesDeTranquillite-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/zonesDeTranquillite-dcat-ap-ch.xml
@@ -21,6 +21,12 @@
         <foaf:name xml:lang="rm">Bundesamt für Umwelt</foaf:name>
       </foaf:Agent>
     </dct:publisher>
+    <dcat:contactPoint>
+      <vcard:Organization>
+        <vcard:fn>Bundesamt für Umwelt / Abteilung Biodiversität und Landschaft</vcard:fn>
+        <vcard:hasEmail rdf:resource="mailto:bnl@bafu.admin.ch" />
+      </vcard:Organization>
+    </dcat:contactPoint>
     <dcat:distribution>
       <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/1">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.bafu.wrz-wildruhezonen_portal" />
@@ -38,6 +44,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-11-19T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-11-19T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
@@ -65,6 +72,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-11-19T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-11-19T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
@@ -92,6 +100,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-11-19T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-11-19T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
@@ -114,6 +123,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-11-19T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-11-19T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
@@ -141,6 +151,7 @@
         <dct:rights>
           <dct:RightsStatement rdf:about="http://dcat-ap.ch/vocabulary/licenses/terms_open" />
         </dct:rights>
+        <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-11-19T00:00:00+00:00</dct:issued>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-11-19T00:00:00+00:00</dct:modified>
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/DEU" />
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/FRA" />
@@ -149,7 +160,7 @@
         <dct:language rdf:resource="http://publications.europa.eu/resource/authority/language/ROH" />
       </dcat:Distribution>
     </dcat:distribution>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-11-19T00:00:00</dct:modified>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-11-19T00:00:00+00:00</dct:modified>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dcat:landingPage rdf:resource="https://www.wildruhezonen.ch/news/aenderungen-und-allgemeine-hinweise" />
     <dct:relation>

--- a/src/test/resources/dcat/zonesDeTranquillite-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/zonesDeTranquillite-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/formatters/dcat-ap-ch">
     <dct:identifier>4a0c8bc7-89d1-484e-a34a-454a31267c41</dct:identifier>
     <dct:title xml:lang="de">Wildruhezonen</dct:title>
     <dct:title xml:lang="fr">Zones de tranquillité</dct:title>
@@ -28,7 +28,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/1">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/1">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.bafu.wrz-wildruhezonen_portal" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -54,7 +54,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/2">
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.bafu.wrz-wildruhezonen_portal</dct:title>
         <dct:title xml:lang="fr">ch.bafu.wrz-wildruhezonen_portal</dct:title>
@@ -82,7 +82,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/3">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/3">
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.bafu.wrz-wildruhezonen_portal</dct:title>
         <dct:title xml:lang="fr">ch.bafu.wrz-wildruhezonen_portal</dct:title>
@@ -110,7 +110,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/6">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/6">
         <dcat:accessURL rdf:resource="https://www.geodienste.ch/services/wildruhezonen" />
         <dcat:downloadURL rdf:resource="https://www.geodienste.ch/services/wildruhezonen" />
         <dct:description xml:lang="de">Abteilung Biodiversität und Landschaft</dct:description>
@@ -133,7 +133,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/7">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/7">
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.bafu.wrz-wildruhezonen_portal" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/dcat/zonesDeTranquillite-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/zonesDeTranquillite-dcat-ap-ch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:dct="http://purl.org/dc/terms/" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:org="http://www.w3.org/ns/org#" xmlns:pav="http://purl.org/pav/" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcatapch="http://dcat-ap.ch/ns/">
-  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/formatters/dcat-ap-ch">
+  <dcat:Dataset rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/formatters/dcat-ap-ch">
     <dct:identifier>4a0c8bc7-89d1-484e-a34a-454a31267c41</dct:identifier>
     <dct:title xml:lang="de">Wildruhezonen</dct:title>
     <dct:title xml:lang="fr">Zones de tranquillité</dct:title>
@@ -28,7 +28,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/1">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/1">
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.bafu.wrz-wildruhezonen_portal" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -54,7 +54,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/2">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/2">
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.bafu.wrz-wildruhezonen_portal</dct:title>
         <dct:title xml:lang="fr">ch.bafu.wrz-wildruhezonen_portal</dct:title>
@@ -82,7 +82,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/3">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/3">
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.bafu.wrz-wildruhezonen_portal</dct:title>
         <dct:title xml:lang="fr">ch.bafu.wrz-wildruhezonen_portal</dct:title>
@@ -110,7 +110,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/6">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/6">
         <dcat:accessURL rdf:resource="https://www.geodienste.ch/services/wildruhezonen" />
         <dcat:downloadURL rdf:resource="https://www.geodienste.ch/services/wildruhezonen" />
         <dct:description xml:lang="de">Abteilung Biodiversität und Landschaft</dct:description>
@@ -133,7 +133,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/7">
+      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/7">
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.bafu.wrz-wildruhezonen_portal" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/shacl/dcat-ap-2.1.1-base-SHACL.ttl
+++ b/src/test/resources/shacl/dcat-ap-2.1.1-base-SHACL.ttl
@@ -1,0 +1,7771 @@
+# FROM https://www.itb.ec.europa.eu/shacl/dcat-ap/upload
+@prefix adms:    <http://www.w3.org/ns/adms#> .
+@prefix cc:      <http://creativecommons.org/ns#> .
+@prefix dc:      <http://purl.org/dc/elements/1.1/> .
+@prefix dcam:    <http://purl.org/dc/dcam/> .
+@prefix dcat:    <http://www.w3.org/ns/dcat#> .
+@prefix dcatap:  <http://data.europa.eu/r5r/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype:  <http://purl.org/dc/dcmitype/> .
+@prefix doap:    <http://usefulinc.com/ns/doap#> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+@prefix geo:     <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix gsp:     <http://www.opengis.net/ont/geosparql#> .
+@prefix j.0:     <https://schema.org/> .
+@prefix locn:    <http://www.w3.org/ns/locn#> .
+@prefix odrl:    <http://www.w3.org/ns/odrl/2/> .
+@prefix org:     <http://www.w3.org/ns/org#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix prov:    <http://www.w3.org/ns/prov#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rec:     <http://www.w3.org/2001/02pd/rec54#> .
+@prefix sdo:     <http://schema.org/> .
+@prefix sf:      <http://www.opengis.net/ont/sf#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix sioc:    <http://rdfs.org/sioc/ns#> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+@prefix spdx:    <http://spdx.org/rdf/terms#> .
+@prefix time:    <http://www.w3.org/2006/time#> .
+@prefix vann:    <http://purl.org/vocab/vann/> .
+@prefix vcard:   <http://www.w3.org/2006/vcard/ns#> .
+@prefix voaf:    <http://purl.org/vocommons/voaf#> .
+@prefix vs:      <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix wdsr:    <http://www.w3.org/2007/05/powder-s#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+prov:entity  rdf:type           owl:ObjectProperty ;
+             rdfs:domain             prov:EntityInfluence ;
+             rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+             rdfs:label              "entity" ;
+             rdfs:range              prov:Entity ;
+             rdfs:subPropertyOf      prov:influencer ;
+             prov:category           "qualified" ;
+             prov:editorialNote      "This property behaves in spirit like rdf:object; it references the object of a prov:wasInfluencedBy triple."@en ;
+             prov:editorsDefinition  "The prov:entity property references an prov:Entity which influenced a resource. This property applies to an prov:EntityInfluence, which is given by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity or prov:Agent." ;
+             prov:inverse            "entityOfInfluence" .
+
+spdx:relationshipType_packageOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "To be used when SPDXRef-A is used as a package as part of SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+dcat:DataService  rdf:type  owl:Class ;
+                  rdfs:comment     "A site or end-point providing operations related to the discovery of, access to, or processing functions on, data or related resources."@en , "Umístění či přístupový bod poskytující operace související s hledáním, přistupem k, či výkonem funkcí na datech či souvisejících zdrojích."@cs , "Et websted eller endpoint der udstiller operationer relateret til opdagelse af, adgang til eller behandlende funktioner på data eller relaterede ressourcer."@da , "Un sitio o end-point que provee operaciones relacionadas a funciones de descubrimiento, acceso, o procesamiento de datos o recursos relacionados."@es , "Un sito o end-point che fornisce operazioni relative alla scoperta, all'accesso o all'elaborazione di funzioni su dati o risorse correlate."@it ;
+                  rdfs:label       "Servizio di dati"@it , "Data service"@en , "Servicio de datos"@es , "Datatjeneste"@da ;
+                  rdfs:subClassOf  dctype:Service , dcat:Resource ;
+                  skos:altLabel    "Dataservice"@da ;
+                  skos:changeNote  "New class added in DCAT 2.0."@en , "Nová třída přidaná ve verzi DCAT 2.0."@cs , "Ny klasse tilføjet i DCAT 2.0."@da , "Nueva clase añadida en DCAT 2.0."@es , "Nuova classe aggiunta in DCAT 2.0."@it ;
+                  skos:definition  "Umístění či přístupový bod poskytující operace související s hledáním, přistupem k, či výkonem funkcí na datech či souvisejících zdrojích."@cs , "Un sitio o end-point que provee operaciones relacionadas a funciones de descubrimiento, acceso, o procesamiento de datos o recursos relacionados."@es , "A site or end-point providing operations related to the discovery of, access to, or processing functions on, data or related resources."@en , "Et site eller endpoint der udstiller operationer relateret til opdagelse af, adgang til eller behandlende funktioner på data eller relaterede ressourcer."@da , "Un sito o end-point che fornisce operazioni relative alla scoperta, all'accesso o all'elaborazione di funzioni su dati o risorse correlate."@it ;
+                  skos:scopeNote   "Pokud je dcat:DataService navázána na jednu či více Datových sad, jsou tyto indikovány vlstností dcat:servesDataset."@cs , "El tipo de servicio puede indicarse usando la propiedad dct:type. Su valor puede provenir de un vocabulario controlado, como por ejemplo el vocabulario de servicios de datos espaciales de INSPIRE."@es , "Hvis en dcat:DataService er bundet til en eller flere specifikke datasæt kan dette indikeres ved hjælp af egenskaben dcat:servesDataset. "@da , "Druh služby může být indikován vlastností dct:type. Její hodnota může být z řízeného slovníku, kterým je například slovník typů prostorových datových služeb INSPIRE."@cs , "If a dcat:DataService is bound to one or more specified Datasets, they are indicated by the dcat:servesDataset property."@en , "Si un dcat:DataService está asociado con uno o más conjuntos de datos especificados, dichos conjuntos de datos pueden indicarse con la propiedad dcat:servesDataset."@es , "Il tipo di servizio può essere indicato usando la proprietà dct:type. Il suo valore può essere preso da un vocabolario controllato come il vocabolario dei tipi di servizi per dati spaziali di INSPIRE."@it , "Se un dcat:DataService è associato a uno o più Dataset specificati, questi sono indicati dalla proprietà dcat:serveDataset."@it , "The kind of service can be indicated using the dct:type property. Its value may be taken from a controlled vocabulary such as the INSPIRE spatial data service type vocabulary."@en , "Datatjenestetypen kan indikeres ved hjælp af egenskaben dct:type. Værdien kan tages fra kontrollerede udfaldsrum såsom INSPIRE spatial data service vocabulary."@da .
+
+spdx:relationshipType
+  rdf:type        owl:ObjectProperty ;
+  rdfs:comment    "Describes the type of relationship between two SPDX elements."@en ;
+  rdfs:domain     spdx:Relationship ;
+  rdfs:range      [ rdf:type     owl:Class ;
+                    owl:unionOf  ( [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_amendment ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_ancestorOf ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_buildToolOf ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_containedBy ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_contains ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_copyOf ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_dataFile ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_dataFileOf ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_descendantOf ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_describedBy ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_describes ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_distributionArtifact ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_documentation ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_dynamicLink ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_expandedFromArchive ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_fileAdded ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_fileDeleted ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_fileModified ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_generatedFrom ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_generates ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_hasPrerequisite ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_metafileOf ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_optionalComponentOf ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_other ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_packageOf ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_patchApplied ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_patchFor ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_prerequisiteFor ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_staticLink ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_testcaseOf ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:relationshipType_variantOf ;
+                                     owl:onProperty  spdx:relationshipType
+                                   ]
+                                 )
+                  ] ;
+  vs:term_status  "stable"@en .
+
+spdx:packageName  rdf:type  owl:DatatypeProperty ;
+                  rdfs:comment        "Identify the full name of the package as given by Package Originator."@en ;
+                  rdfs:domain         spdx:Package ;
+                  rdfs:range          xsd:string ;
+                  rdfs:subPropertyOf  spdx:name ;
+                  vs:term_status      "stable"@en .
+
+spdx:licenseInfoFromFiles
+  rdf:type        owl:ObjectProperty ;
+  rdfs:comment    "The licensing information that was discovered directly within the package. There will be an instance of this property for each distinct value of alllicenseInfoInFile properties of all files contained in the package.\n\nIf the licenseInfoFromFiles field is not present for a package and filesAnalyzed property for that same pacakge is true or omitted, it implies an equivalent meaning to NOASSERTION."@en ;
+  rdfs:domain     spdx:Package ;
+  rdfs:range      [ rdf:type     owl:Class ;
+                    owl:unionOf  ( spdx:AnyLicenseInfo
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:noassertion ;
+                                     owl:onProperty  spdx:licenseInfoFromFiles
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:none ;
+                                     owl:onProperty  spdx:licenseInfoFromFiles
+                                   ]
+                                 )
+                  ] ;
+  vs:term_status  "stable"@en .
+
+vcard:Msg  rdf:type       owl:Class ;
+           rdfs:comment      "This class is deprecated"@en ;
+           rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label        "Msg"@en ;
+           rdfs:subClassOf   vcard:TelephoneType ;
+           owl:deprecated    true .
+
+[ rdf:type             owl:AllDifferent ;
+  owl:distinctMembers  ( spdx:annotationType_other spdx:annotationType_review )
+] .
+
+vcard:Intl  rdf:type      owl:Class ;
+            rdfs:comment      "This class is deprecated"@en ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "Intl"@en ;
+            rdfs:subClassOf   vcard:Type ;
+            owl:deprecated    true .
+
+spdx:licenseComments  rdf:type  owl:DatatypeProperty ;
+                      rdfs:comment    "The licenseComments property allows the preparer of the SPDX document to describe why the licensing in spdx:licenseConcluded was chosen."@en ;
+                      rdfs:domain     spdx:SpdxItem ;
+                      rdfs:range      xsd:string ;
+                      vs:term_status  "stable"@en .
+
+spdx:packageVerificationCodeValue
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "The actual package verification code as a hex encoded value."@en ;
+  rdfs:domain     spdx:PackageVerificationCode ;
+  rdfs:range      xsd:hexBinary ;
+  vs:term_status  "stable"@en .
+
+dcterms:creator  rdf:type       rdf:Property ;
+                 rdfs:comment            "An entity responsible for making the resource."@en ;
+                 rdfs:isDefinedBy        dcterms: ;
+                 rdfs:label              "Creator"@en ;
+                 rdfs:subPropertyOf      dcterms:contributor , dc:creator ;
+                 dcam:rangeIncludes      dcterms:Agent ;
+                 dcterms:description     "Recommended practice is to identify the creator with a URI.  If this is not possible or feasible, a literal value that identifies the creator may be provided."@en ;
+                 dcterms:issued          "2008-01-14"^^xsd:date ;
+                 owl:equivalentProperty  foaf:maker .
+
+dcterms:contributor  rdf:type  rdf:Property ;
+                     rdfs:comment         "An entity responsible for making contributions to the resource."@en ;
+                     rdfs:isDefinedBy     dcterms: ;
+                     rdfs:label           "Contributor"@en ;
+                     rdfs:subPropertyOf   dc:contributor ;
+                     dcam:rangeIncludes   dcterms:Agent ;
+                     dcterms:description  "The guidelines for using names of persons or organizations as creators apply to contributors."@en ;
+                     dcterms:issued       "2008-01-14"^^xsd:date .
+
+vcard:Car  rdf:type       owl:Class ;
+           rdfs:comment      "This class is deprecated"@en ;
+           rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label        "Car"@en ;
+           rdfs:subClassOf   vcard:TelephoneType ;
+           owl:deprecated    true .
+
+spdx:ListedLicense  rdf:type  owl:Class ;
+                    rdfs:comment     "A license which is included in the SPDX License List (http://spdx.org/licenses)."@en ;
+                    rdfs:subClassOf  spdx:License ;
+                    rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                       owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                       owl:onDataRange              xsd:string ;
+                                       owl:onProperty               spdx:deprecatedVersion
+                              ] ;
+                    rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                       owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                       owl:onDataRange              xsd:boolean ;
+                                       owl:onProperty               spdx:isDeprecatedLicenseId
+                              ] ;
+                    rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                       owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                       owl:onDataRange              xsd:string ;
+                                       owl:onProperty               spdx:licenseTextHtml
+                              ] ;
+                    rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                       owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                       owl:onDataRange              xsd:string ;
+                                       owl:onProperty               spdx:standardLicenseHeaderHtml
+                              ] ;
+                    vs:term_status   "stable"@en .
+
+vcard:hasValue  rdf:type  owl:ObjectProperty ;
+                rdfs:comment      "Used to indicate the resource value of an object property that requires property parameters"@en ;
+                rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                rdfs:label        "has value"@en .
+
+vcard:n  rdf:type               owl:ObjectProperty ;
+         rdfs:comment            "This object property has been mapped"@en ;
+         rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+         rdfs:label              "name"@en ;
+         owl:equivalentProperty  vcard:hasName .
+
+vcard:honorific-suffix
+  rdf:type          owl:DatatypeProperty ;
+  rdfs:comment      "The honorific suffix of the name associated with the object"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "honorific suffix"@en ;
+  rdfs:range        xsd:string .
+
+dcterms:dateSubmitted
+  rdf:type             rdf:Property ;
+  rdfs:comment         "Date of submission of the resource."@en ;
+  rdfs:isDefinedBy     dcterms: ;
+  rdfs:label           "Date Submitted"@en ;
+  rdfs:range           rdfs:Literal ;
+  rdfs:subPropertyOf   dc:date , dcterms:date ;
+  dcterms:description  "Recommended practice is to describe the date, date/time, or period of time as recommended for the property Date, of which this is a subproperty.  Examples of resources to which a 'Date Submitted' may be relevant include a thesis (submitted to a university department) or an article (submitted to a journal)."@en ;
+  dcterms:issued       "2002-07-13"^^xsd:date .
+
+prov:editorsDefinition
+  rdf:type            owl:AnnotationProperty ;
+  rdfs:comment        "When the prov-o term does not have a definition drawn from prov-dm, and the prov-o editor provides one."@en ;
+  rdfs:isDefinedBy    <http://www.w3.org/ns/prov-o#> ;
+  rdfs:subPropertyOf  prov:definition .
+
+dcat:compressFormat  rdf:type  rdf:Property , owl:ObjectProperty ;
+                     rdfs:comment        "Il formato di compressione della distribuzione nel quale i dati sono in forma compressa, ad es. per ridurre le dimensioni del file da scaricare."@it , "Formát komprese souboru, ve kterém jsou data poskytována v komprimované podobě, např. ke snížení velikosti souboru ke stažení."@cs , "The compression format of the distribution in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file."@en , "Kompressionsformatet for distributionen som indeholder data i et komprimeret format, fx for at reducere størrelsen af downloadfilen."@da , "El formato de la distribución en el que los datos están en forma comprimida, e.g. para reducir el tamaño del archivo a bajar."@es ;
+                     rdfs:domain         dcat:Distribution ;
+                     rdfs:isDefinedBy    <https://www.w3.org/TR/vocab-dcat-2/> ;
+                     rdfs:label          "compression format"@en , "kompressionsformat"@da , "formato de compresión"@es , "formato di compressione"@it , "formát komprese"@cs ;
+                     rdfs:range          dcterms:MediaType ;
+                     rdfs:subPropertyOf  dcterms:format ;
+                     skos:changeNote     "Ny egenskab tilføjet i DCAT 2.0."@da , "Nueva propiedad agregada en DCAT 2.0."@es , "Nuova proprietà aggiunta in DCAT 2.0."@it , "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs , "New property added in DCAT 2.0."@en ;
+                     skos:definition     "Kompressionsformatet for distributionen som indeholder data i et komprimeret format, fx for at reducere størrelsen af downloadfilen."@da , "Formát komprese souboru, ve kterém jsou data poskytována v komprimované podobě, např. ke snížení velikosti souboru ke stažení."@cs , "El formato de la distribución en el que los datos están en forma comprimida, e.g. para reducir el tamaño del archivo a bajar."@es , "Il formato di compressione della distribuzione nel quale i dati sono in forma compressa, ad es. per ridurre le dimensioni del file da scaricare."@it , "The compression format of the distribution in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file."@en ;
+                     skos:scopeNote      "Questa proprietà deve essere utilizzata quando i file nella distribuzione sono compressi, ad es. in un file ZIP. Il formato DOVREBBE essere espresso usando un tipo di media come definito dal registro dei tipi di media IANA https://www.iana.org/assignments/media-types/, se disponibile."@it , "Denne egenskab kan anvendes når filerne i en distribution er blevet komprimeret, fx i en ZIP-fil. Formatet BØR udtrykkes ved en medietype som defineret i 'IANA media types registry', hvis der optræder en relevant medietype dér: https://www.iana.org/assignments/media-types/."@da , "This property is to be used when the files in the distribution are compressed, e.g. in a ZIP file. The format SHOULD be expressed using a media type as defined by IANA media types registry https://www.iana.org/assignments/media-types/, if available."@en , "Tato vlastnost se použije, když jsou soubory v distribuci komprimovány, např. v ZIP souboru. Formát BY MĚL být vyjádřen pomocí typu média definovaného v registru IANA https://www.iana.org/assignments/media-types/, pokud existuje."@cs , "Esta propiedad se debe usar cuando los archivos de la distribución están comprimidos, por ejemplo en un archivo ZIP. El formato DEBERÍA expresarse usando un 'media type', tales como los definidos en el registro IANA de 'media types' https://www.iana.org/assignments/media-types/, si está disponibles."@es .
+
+dcat:keyword  rdf:type      rdf:Property , owl:DatatypeProperty ;
+              rdfs:comment        "Una parola chiave o un'etichetta per descrivere la risorsa."@it , "Et nøgleord eller tag til beskrivelse af en ressource."@da , "Μία λέξη-κλειδί ή μία ετικέτα που περιγράφει το σύνολο δεδομένων."@el , "Un mot-clé ou étiquette décrivant une ressource."@fr , "Una palabra clave o etiqueta que describe un recurso."@es , "Klíčové slovo nebo značka popisující zdroj."@cs , "A keyword or tag describing a resource."@en , "データセットを記述しているキーワードまたはタグ。"@ja , "كلمة  مفتاحيه توصف قائمة البيانات"@ar ;
+              rdfs:isDefinedBy    <http://www.w3.org/TR/vocab-dcat/> ;
+              rdfs:label          "كلمة  مفتاحية "@ar , "mot-clés "@fr , "λέξη-κλειδί"@el , "キーワード/タグ"@ja , "nøgleord"@da , "palabra clave"@es , "keyword"@en , "parola chiave"@it , "klíčové slovo"@cs ;
+              rdfs:range          rdfs:Literal ;
+              rdfs:subPropertyOf  dcterms:subject ;
+              skos:definition     "Klíčové slovo nebo značka popisující zdroj."@cs , "データセットを記述しているキーワードまたはタグ。"@ja , "Un mot-clé ou étiquette décrivant une ressource."@fr , "A keyword or tag describing a resource."@en , "Una palabra clave o etiqueta que describe un recurso."@es , "Et nøgleord eller tag til beskrivelse af en ressource."@da , "كلمة  مفتاحيه توصف قائمة البيانات"@ar , "Μία λέξη-κλειδί ή μία ετικέτα που περιγράφει το σύνολο δεδομένων."@el , "Una parola chiave o un'etichetta per descrivere la risorsa."@it .
+
+[ rdf:type               owl:Axiom ;
+  owl:annotatedProperty  rdfs:range ;
+  owl:annotatedSource    prov:wasInfluencedBy ;
+  owl:annotatedTarget    [ rdf:type     owl:Class ;
+                           owl:unionOf  ( prov:Activity prov:Agent prov:Entity )
+                         ] ;
+  prov:definition        "influencer: an identifier (o1) for an ancestor entity, activity, or agent that the former depends on;" ;
+  prov:dm                "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence"
+] .
+
+vcard:sort-string  rdf:type  owl:DatatypeProperty ;
+                   rdfs:comment      "To specify the string to be used for national-language-specific sorting. Used as a property parameter only."@en ;
+                   rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                   rdfs:label        "sort as"@en ;
+                   rdfs:range        xsd:string .
+
+dcat:centroid  rdf:type  owl:DatatypeProperty , rdf:Property ;
+               rdfs:domain      dcterms:Location ;
+               rdfs:label       "centroid"@cs , "centroide"@it , "centroide"@es , "centroid"@en , "geometrisk tyngdepunkt"@da ;
+               rdfs:range       rdfs:Literal ;
+               skos:altLabel    "centroide"@da ;
+               skos:changeNote  "Ny egenskab tilføjet i DCAT 2.0."@da , "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs , "Nuova proprietà aggiunta in DCAT 2.0."@it , "Nueva propiedad agregada en DCAT 2.0."@es , "New property added in DCAT 2.0."@en ;
+               skos:definition  "Il centro geografico (centroide) di una risorsa."@it , "Geografický střed (centroid) zdroje."@cs , "Det geometrisk tyngdepunkt (centroid) for en ressource."@da , "El centro geográfico (centroide) de un recurso."@es , "The geographic center (centroid) of a resource."@en ;
+               skos:scopeNote   "Rækkevidden for denne egenskab er bevidst generisk definere med det formål at tillade forskellige geokodninger. Geometrien kan eksempelvis repræsenteres som WKT (geosparql:asWKT [GeoSPARQL]) eller [GML] (geosparql:asGML [GeoSPARQL])."@da , "The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:wktLiteral [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL])."@en , "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL])."@cs , "El rango de esta propiedad es intencionalmente genérico con el objetivo de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede codificarse como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@es , "Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@it .
+
+spdx:relationshipType_dataFile
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is a data file used in SPDXRef-B.  Replaced by relationshipType_dataFileOf"@en ;
+  owl:deprecated  true ;
+  vs:term_status  "deprecated"@en .
+
+dcterms:hasVersion  rdf:type  rdf:Property ;
+                    rdfs:comment         "A related resource that is a version, edition, or adaptation of the described resource."@en ;
+                    rdfs:isDefinedBy     dcterms: ;
+                    rdfs:label           "Has Version"@en ;
+                    rdfs:subPropertyOf   dc:relation , dcterms:relation ;
+                    dcterms:description  "Changes in version imply substantive changes in content rather than differences in format. This property is intended to be used with non-literal values. This property is an inverse property of Is Version Of."@en ;
+                    dcterms:issued       "2000-07-11"^^xsd:date .
+
+skos:changeNote  rdf:type   owl:AnnotationProperty , rdf:Property ;
+                 rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+                 rdfs:label          "change note"@en ;
+                 rdfs:subPropertyOf  skos:note ;
+                 skos:definition     "A note about a modification to a concept."@en .
+
+spdx:relationshipType_ancestorOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "A Relationship of relationshipType_ancestorOf expresses that an SPDXElement is an ancestor of (same lineage but pre-dates) the relatedSPDXElement.  For example, an upstream File is an ancestor of a modified downstream File"@en ;
+  vs:term_status  "stable"@en .
+
+vcard:hasUID  rdf:type    owl:ObjectProperty ;
+              rdfs:comment      "To specify a value that represents a globally unique identifier corresponding to the object"@en ;
+              rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+              rdfs:label        "has uid"@en .
+
+prov:Usage  rdf:type          owl:Class ;
+            rdfs:comment          "An instance of prov:Usage provides additional descriptions about the binary prov:used relation from some prov:Activity to an prov:Entity that it used. For example, :keynote prov:used :podium; prov:qualifiedUsage [ a prov:Usage; prov:entity :podium; :foo :bar ]."@en ;
+            rdfs:isDefinedBy      <http://www.w3.org/ns/prov-o#> ;
+            rdfs:label            "Usage" ;
+            rdfs:subClassOf       prov:InstantaneousEvent , prov:EntityInfluence ;
+            prov:category         "qualified" ;
+            prov:component        "entities-activities" ;
+            prov:constraints      "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+            prov:definition       "Usage is the beginning of utilizing an entity by an activity. Before usage, the activity had not begun to utilize this entity and could not have been affected by the entity."@en ;
+            prov:dm               "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Usage"^^xsd:anyURI ;
+            prov:n                "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Usage"^^xsd:anyURI ;
+            prov:unqualifiedForm  prov:used .
+
+time:TRS  rdf:type       owl:Class ;
+          rdfs:comment     "A temporal reference system, such as a temporal coordinate system (with an origin, direction, and scale), a calendar-clock combination, or a (possibly hierarchical) ordinal system. \n\nThis is a stub class, representing the set of all temporal reference systems."@en , "Un sistema de referencia temporal, tal como un sistema de coordenadas temporales (con un origen, una dirección y una escala), una combinación calendario-reloj, o un sistema ordinal (posiblemente jerárquico).\n        Esta clase comodín representa el conjunto de todos los sistemas de referencia temporal."@es ;
+          rdfs:label       "Temporal Reference System"@en , "sistema de referencia temporal"@es ;
+          skos:definition  "A temporal reference system, such as a temporal coordinate system (with an origin, direction, and scale), a calendar-clock combination, or a (possibly hierarchical) ordinal system. \n\nThis is a stub class, representing the set of all temporal reference systems."@en , "Un sistema de referencia temporal, tal como un sistema de coordenadas temporales (con un origen, una dirección y una escala), una combinación calendario-reloj, o un sistema ordinal (posiblemente jerárquico).\n    Esta clase comodín representa el conjunto de todos los sistemas de referencia temporal."@es ;
+          skos:note        "A taxonomy of temporal reference systems is provided in ISO 19108:2002 [ISO19108], including (a) calendar + clock systems; (b) temporal coordinate systems (i.e. numeric offset from an epoch); (c) temporal ordinal reference systems (i.e. ordered sequence of named intervals, not necessarily of equal duration)."@en , "En el ISO 19108:2002 [ISO19108] se proporciona una taxonomía de sistemas de referencia temporal, incluyendo (a) sistemas de calendario + reloj; (b) sistemas de coordenadas temporales (es decir, desplazamiento numérico a partir de una época); (c) sistemas de referencia ordinales temporales (es decir, secuencia ordenada de intervalos nombrados, no necesariamente de igual duración)."@es .
+
+vcard:given-name  rdf:type  owl:DatatypeProperty ;
+                  rdfs:comment      "The given name associated with the object"@en ;
+                  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                  rdfs:label        "given name"@en ;
+                  rdfs:range        xsd:string .
+
+dcterms:source  rdf:type     rdf:Property ;
+                rdfs:comment         "A related resource from which the described resource is derived."@en ;
+                rdfs:isDefinedBy     dcterms: ;
+                rdfs:label           "Source"@en ;
+                rdfs:subPropertyOf   dc:source , dcterms:relation ;
+                dcterms:description  "This property is intended to be used with non-literal values. The described resource may be derived from the related resource in whole or in part. Best practice is to identify the related resource by means of a URI or a string conforming to a formal identification system."@en ;
+                dcterms:issued       "2008-01-14"^^xsd:date .
+
+spdx:checksumAlgorithm_blake2b384
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was BLAKE2b-384."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:licenseExceptionText
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "Full text of the license exception."@en ;
+  rdfs:domain     spdx:LicenseException ;
+  rdfs:range      xsd:string ;
+  vs:term_status  "stable"@en .
+
+dcterms:PhysicalMedium
+  rdf:type             rdfs:Class ;
+  rdfs:comment         "A physical material or carrier."@en ;
+  rdfs:isDefinedBy     dcterms: ;
+  rdfs:label           "Physical Medium"@en ;
+  rdfs:subClassOf      dcterms:MediaType ;
+  dcterms:description  "Examples include paper, canvas, or DVD."@en ;
+  dcterms:issued       "2008-01-14"^^xsd:date .
+
+spdx:relationshipType_testOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is used for testing SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+vcard:value  rdf:type     owl:DatatypeProperty ;
+             rdfs:comment      "Used to indicate the literal value of a data property that requires property parameters"@en ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "value"@en .
+
+spdx:relationshipType_generates
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "A Relationship of relationshipType_generates expresses that an SPDXElement generates the relatedSPDXElement.  For example, a source File generates a binary File."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:referenceCategory
+  rdf:type        owl:ObjectProperty ;
+  rdfs:comment    "Category for the external reference"@en ;
+  rdfs:domain     spdx:ExternalRef ;
+  rdfs:range      spdx:ReferenceCategory ;
+  vs:term_status  "stable"@en .
+
+spdx:relationshipType_fileDeleted
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "A Relationship of relationshipType_fileDeleted expresses that the SPDXElement is a package where the relatedSPDXElement file has been removed.  For example, a package has been patched to remove a file a file (the relatedSPDXElement resulting in the patched package (the SPDXElement).  This relationship is typically used to express the result of a patched package when the actual patchfile is not present."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:checksumAlgorithm_md6
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was MD6"@en ;
+  vs:term_status  "stable" .
+
+dcat:temporalResolution
+  rdf:type            owl:DatatypeProperty ;
+  rdfs:comment        "minimum time period resolvable in a dataset."@en , "minimální doba trvání rozlišitelná v datové sadě."@cs , "período de tiempo mínimo en el conjunto de datos."@es , "mindste tidsperiode der kan resolveres i datasættet."@da , "periodo di tempo minimo risolvibile in un set di dati."@it ;
+  rdfs:label          "resolución temporal"@es , "tidslig opløsning"@da , "temporal resolution"@en , "časové rozlišení"@cs , "risoluzione temporale"@it ;
+  rdfs:range          xsd:duration ;
+  skos:changeNote     "Nueva propiedad añadida en DCAT 2.0."@es , "New property added in DCAT 2.0."@en , "Nuova proprietà aggiunta in DCAT 2.0."@it , "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs ;
+  skos:definition     "minimální doba trvání rozlišitelná v datové sadě."@cs , "período de tiempo mínimo en el conjunto de datos."@es , "minimum time period resolvable in a dataset."@en , "periodo di tempo minimo risolvibile in un set di dati."@it , "mindste tidsperiode der kan resolveres i datasættet."@da ;
+  skos:editorialNote  "Může se vyskytnout v popisu Datové sady nebo Distribuce, takže nebyl specifikován definiční obor."@cs , "Might appear in the description of a Dataset or a Distribution, so no domain is specified."@en , "Kan optræde i forbindelse med beskrivelse af datasættet eller datasætditributionen, så der er ikke angivet et domæne for egenskaben."@da ;
+  skos:scopeNote      "Alternative temporal resolutions might be provided as different dataset distributions."@en , "Různá časová rozlišení mohou být poskytována jako různé distribuce datové sady."@cs , "Si el conjunto de datos es una serie temporal, debe corresponder al espaciado de los elementos de la serie. Para otro tipo de conjuntos de datos, esta propiedad indicará usualmente la menor diferencia de tiempo entre elementos en el dataset."@es , "Alternative tidslige opløsninger kan leveres som forskellige datasætdistributioner."@da , "Pokud je datová sada časovou řadou, měla by tato vlastnost odpovídat rozestupu položek v řadě. Pro ostatní druhy datových sad bude tato vlastnost obvykle indikovat nejmenší časovou vzdálenost mezi položkami této datové sady."@cs , "Distintas distribuciones del conjunto de datos pueden tener resoluciones temporales diferentes."@es , "If the dataset is a time-series this should correspond to the spacing of items in the series. For other kinds of dataset, this property will usually indicate the smallest time difference between items in the dataset."@en , "Se il set di dati è una serie temporale, questo dovrebbe corrispondere alla spaziatura degli elementi della serie. Per altri tipi di set di dati, questa proprietà di solito indica la più piccola differenza di tempo tra gli elementi nel set di dati."@it , "Hvis datasættet er en tidsserie, så bør denne egenskab svare til afstanden mellem elementerne i tidsserien. For andre typer af datasæt indikerer denne egenskab den mindste tidsforskel mellem elementer i datasættet."@da , "Risoluzioni temporali alternative potrebbero essere fornite come diverse distribuzioni di set di dati."@it .
+
+spdx:externalReferenceSite
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "Website for the maintainers of the external reference site"@en ;
+  rdfs:domain     spdx:ReferenceType ;
+  rdfs:range      xsd:anyURI ;
+  vs:term_status  "stable"@en .
+
+spdx:relationshipType_testcaseOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is a test case used in testing SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+time:intervalAfter  rdf:type  owl:ObjectProperty ;
+                    rdfs:comment        "If a proper interval T1 is intervalAfter another proper interval T2, then the beginning of T1 is after the end of T2."@en , "Si un intervalo propio T1 es posterior a otro intervalo propio T2, entonces el principio de T1 está después que el final de T2." ;
+                    rdfs:domain         time:ProperInterval ;
+                    rdfs:label          "interval after"@en , "intervalo posterior"@es ;
+                    rdfs:range          time:ProperInterval ;
+                    rdfs:subPropertyOf  time:after , time:intervalDisjoint ;
+                    owl:inverseOf       time:intervalBefore ;
+                    skos:definition     "If a proper interval T1 is intervalAfter another proper interval T2, then the beginning of T1 is after the end of T2."@en , "Si un intervalo propio T1 es posterior a otro intervalo propio T2, entonces el principio de T1 está después que el final de T2."@es .
+
+spdx:none  rdf:type   owl:NamedIndividual ;
+           rdfs:comment  "Individual to indicate that no value is applicable for the Object." .
+
+locn:postCode  rdf:type     rdf:Property ;
+               rdfs:comment        "The post code (a.k.a postal code, zip code etc.). Post codes are common elements in many countries' postal address systems. The domain of locn:postCode is locn:Address."@en ;
+               rdfs:domain         locn:Address ;
+               rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+               rdfs:label          "post code"@en ;
+               rdfs:range          rdfs:Literal ;
+               dcterms:identifier  "locn:postCode" ;
+               vs:term_status      "testing"@en .
+
+vcard:X400  rdf:type      owl:Class ;
+            rdfs:comment      "This class is deprecated"@en ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "X400"@en ;
+            rdfs:subClassOf   vcard:Type ;
+            owl:deprecated    true .
+
+spdx:checksumAlgorithm_sha3_256
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was SHA3-256."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:relationshipType_distributionArtifact
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "A Relationship of relationshipType_distributionArtifact expresses that distributing the SPDXElement requires that the relatedSPDXElement also be distributed.  For example, distributing a binary File may require that a source tarball (another File) be made available with the distribuiton. "@en ;
+  vs:term_status  "stable"@en .
+
+vcard:hasLanguage  rdf:type  owl:ObjectProperty ;
+                   rdfs:comment      "Used to support property parameters for the language data property"@en ;
+                   rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                   rdfs:label        "has language"@en .
+
+vcard:Work  rdf:type      owl:Class ;
+            rdfs:comment      "This implies that the property is related to an individual's work place"@en ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "Work"@en ;
+            rdfs:subClassOf   vcard:Type .
+
+time:DateTimeInterval
+  rdf:type         owl:Class ;
+  rdfs:comment     "DateTimeInterval is a subclass of ProperInterval, defined using the multi-element DateTimeDescription."@en , "'intervalo de fecha-hora' es una subclase de 'intervalo propio', definida utilizando el multi-elemento 'descripción de fecha-hora'."@es ;
+  rdfs:label       "intervalo de fecha-hora"@es , "Date-time interval"@en ;
+  rdfs:subClassOf  time:ProperInterval ;
+  skos:definition  "DateTimeInterval is a subclass of ProperInterval, defined using the multi-element DateTimeDescription."@en , "'intervalo de fecha-hora' es una subclase de 'intervalo propio', definida utilizando el multi-elemento 'descripción de fecha-hora'."@es ;
+  skos:note        ":DateTimeInterval can only be used for an interval whose limits coincide with a date-time element aligned to the calendar and timezone indicated. For example, while both have a duration of one day, the 24-hour interval beginning at midnight at the beginning of 8 May in Central Europe can be expressed as a :DateTimeInterval, but the 24-hour interval starting at 1:30pm cannot."@en , "'intervalo de fecha-hora' se puede utilizar sólo para un intervalo cuyos límites coinciden con un elemento de fecha-hora alineados con el calendario y la zona horaria indicados. Por ejemplo, aunque ambos tienen una duración de un día, el intervalo de 24 horas que empieza en la media noche del comienzo del 8 mayo en Europa Central se puede expresar como un 'intervalo de fecha-hora', el intervalo de 24 horas que empieza a las 1:30pm no."@es .
+
+vcard:org  rdf:type             owl:ObjectProperty ;
+           rdfs:comment            "This object property has been mapped. Use the organization-name data property."@en ;
+           rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label              "organization"@en ;
+           owl:equivalentProperty  vcard:organization-name .
+
+rdfs:isDefinedBy  rdf:type  owl:AnnotationProperty .
+
+vcard:Tel  rdf:type       owl:Class ;
+           rdfs:comment      "This class is deprecated. Use the hasTelephone object property."@en ;
+           rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label        "Tel"@en ;
+           owl:deprecated    true .
+
+prov:wasAssociatedWith
+  rdf:type                owl:ObjectProperty ;
+  rdfs:comment            "An prov:Agent that had some (unspecified) responsibility for the occurrence of this prov:Activity."@en ;
+  rdfs:domain             prov:Activity ;
+  rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label              "wasAssociatedWith" ;
+  rdfs:range              prov:Agent ;
+  rdfs:subPropertyOf      prov:wasInfluencedBy ;
+  owl:propertyChainAxiom  ( prov:qualifiedAssociation prov:agent ) ;
+  owl:propertyChainAxiom  ( prov:qualifiedAssociation prov:agent ) ;
+  prov:category           "starting-point" ;
+  prov:component          "agents-responsibility" ;
+  prov:inverse            "wasAssociateFor" ;
+  prov:qualifiedForm      prov:Association , prov:qualifiedAssociation .
+
+vcard:PCS  rdf:type       owl:Class ;
+           rdfs:comment      "This class is deprecated"@en ;
+           rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label        "PCS"@en ;
+           rdfs:subClassOf   vcard:TelephoneType ;
+           owl:deprecated    true .
+
+prov:Generation  rdf:type     owl:Class ;
+                 rdfs:comment          "An instance of prov:Generation provides additional descriptions about the binary prov:wasGeneratedBy relation from a generated prov:Entity to the prov:Activity that generated it. For example, :cake prov:wasGeneratedBy :baking; prov:qualifiedGeneration [ a prov:Generation; prov:activity :baking; :foo :bar ]."@en ;
+                 rdfs:isDefinedBy      <http://www.w3.org/ns/prov-o#> ;
+                 rdfs:label            "Generation" ;
+                 rdfs:subClassOf       prov:ActivityInfluence , prov:InstantaneousEvent ;
+                 prov:category         "qualified" ;
+                 prov:component        "entities-activities" ;
+                 prov:constraints      "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+                 prov:definition       "Generation is the completion of production of a new entity by an activity. This entity did not exist before generation and becomes available for usage after this generation."@en ;
+                 prov:dm               "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Generation"^^xsd:anyURI ;
+                 prov:n                "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Generation"^^xsd:anyURI ;
+                 prov:unqualifiedForm  prov:wasGeneratedBy .
+
+dcterms:isRequiredBy  rdf:type  rdf:Property ;
+                      rdfs:comment         "A related resource that requires the described resource to support its function, delivery, or coherence."@en ;
+                      rdfs:isDefinedBy     dcterms: ;
+                      rdfs:label           "Is Required By"@en ;
+                      rdfs:subPropertyOf   dc:relation , dcterms:relation ;
+                      dcterms:description  "This property is intended to be used with non-literal values. This property is an inverse property of Requires."@en ;
+                      dcterms:issued       "2000-07-11"^^xsd:date .
+
+dcterms:mediator  rdf:type   rdf:Property ;
+                  rdfs:comment         "An entity that mediates access to the resource."@en ;
+                  rdfs:isDefinedBy     dcterms: ;
+                  rdfs:label           "Mediator"@en ;
+                  rdfs:subPropertyOf   dcterms:audience ;
+                  dcam:rangeIncludes   dcterms:AgentClass ;
+                  dcterms:description  "In an educational context, a mediator might be a parent, teacher, teaching assistant, or care-giver."@en ;
+                  dcterms:issued       "2001-05-21"^^xsd:date .
+
+adms:Identifier  rdf:type  owl:Class ;
+                 rdfs:comment      "This is based on the UN/CEFACT Identifier class."@en ;
+                 rdfs:isDefinedBy  <http://www.w3.org/ns/adms> ;
+                 rdfs:label        "Identifier"@en .
+
+dcterms:URI  rdf:type     rdfs:Datatype ;
+             rdfs:comment      "The set of identifiers constructed according to the generic syntax for Uniform Resource Identifiers as specified by the Internet Engineering Task Force."@en ;
+             rdfs:isDefinedBy  dcterms: ;
+             rdfs:label        "URI"@en ;
+             rdfs:seeAlso      <http://www.ietf.org/rfc/rfc3986.txt> ;
+             dcterms:issued    "2000-07-11"^^xsd:date .
+
+locn:adminUnitL2  rdf:type  rdf:Property ;
+                  rdfs:comment        "The region of the address, usually a county, state or other such area that typically encompasses several localities. The domain of  locn:adminUnitL2 is locn:Address and the range is a literal, conceptually defined by the INSPIRE Geographical Name data type."@en ;
+                  rdfs:domain         locn:Address ;
+                  rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+                  rdfs:label          "admin unit level 2"@en ;
+                  dcterms:identifier  "locn:adminUnitL2" ;
+                  vs:term_status      "testing"@en .
+
+dcterms:rights  rdf:type     rdf:Property ;
+                rdfs:comment         "Information about rights held in and over the resource."@en ;
+                rdfs:isDefinedBy     dcterms: ;
+                rdfs:label           "Rights"@en ;
+                rdfs:subPropertyOf   dc:rights ;
+                dcam:rangeIncludes   dcterms:RightsStatement ;
+                dcterms:description  "Typically, rights information includes a statement about various property rights associated with the resource, including intellectual property rights.  Recommended practice is to refer to a rights statement with a URI.  If this is not possible or feasible, a literal value (name, label, or short text) may be provided."@en ;
+                dcterms:issued       "2008-01-14"^^xsd:date .
+
+vcard:nickname  rdf:type  owl:DatatypeProperty ;
+                rdfs:comment      "The nick name associated with the object"@en ;
+                rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                rdfs:label        "nickname"@en ;
+                rdfs:range        xsd:string .
+
+spdx:relationshipType_fileModified
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "A Relationship of relationshipType_fileModified expresses that the SPDXElement is a file which is a modified version of the relatedSPDXElement file.  For example, a file (the SPDXElement) has been patched to modify the contents of the original file (the SPDXElement).  This relationship is typically used to express the result of a patched package when the actual patchfile is not present."@en ;
+  vs:term_status  "stable"@en .
+
+adms:status  rdf:type     owl:ObjectProperty ;
+             rdfs:comment      "The status of the Asset in the context of a particular workflow process."@en ;
+             rdfs:domain       rdfs:Resource ;
+             rdfs:isDefinedBy  <http://www.w3.org/ns/adms> ;
+             rdfs:label        "status"@en ;
+             rdfs:range        skos:Concept .
+
+prov:Agent  rdf:type      owl:Class ;
+            rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+            rdfs:label        "Agent" ;
+            owl:disjointWith  prov:InstantaneousEvent ;
+            prov:category     "starting-point" ;
+            prov:component    "agents-responsibility" ;
+            prov:definition   "An agent is something that bears some form of responsibility for an activity taking place, for the existence of an entity, or for another agent's activity. "@en ;
+            prov:dm           "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
+            prov:n            "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Agent"^^xsd:anyURI .
+
+spdx:ChecksumAlgorithm
+  rdf:type        owl:Class ;
+  rdfs:comment    "Algorighm for Checksums."@en ;
+  vs:term_status  "stable"@en .
+
+skos:narrowMatch  rdf:type  owl:ObjectProperty , rdf:Property ;
+                  rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+                  rdfs:label          "has narrower match"@en ;
+                  rdfs:subPropertyOf  skos:mappingRelation , skos:narrower ;
+                  owl:inverseOf       skos:broadMatch ;
+                  skos:definition     "skos:narrowMatch is used to state a hierarchical mapping link between two conceptual resources in different concept schemes."@en .
+
+dcat:themeTaxonomy  rdf:type  owl:ObjectProperty , rdf:Property ;
+                    rdfs:comment       "Il sistema di organizzazione della conoscenza (KOS) usato per classificare i dataset del catalogo."@it , "The knowledge organization system (KOS) used to classify catalog's datasets."@en , "Le systhème d'ogranisation de connaissances utilisé pour classifier les jeux de données du catalogue."@fr , "El sistema de organización del conocimiento utilizado para clasificar conjuntos de datos de catálogos."@es , "Vidensorganiseringssystem (KOS) som anvendes til at klassificere datasæt i kataloget."@da , "Systém organizace znalostí (KOS) použitý pro klasifikaci datových sad v katalogu."@cs , "カタログのデータセットを分類するために用いられる知識組織化体系（KOS；knowledge organization system）。"@ja , "لائحة التصنيفات المستخدمه لتصنيف قوائم البيانات ضمن الفهرس"@ar , "Το σύστημα οργάνωσης γνώσης που χρησιμοποιείται για την κατηγοριοποίηση των συνόλων δεδομένων του καταλόγου."@el ;
+                    rdfs:domain        dcat:Catalog ;
+                    rdfs:isDefinedBy   <http://www.w3.org/TR/vocab-dcat/> ;
+                    rdfs:label         "taxonomie de thèmes"@fr , "tassonomia dei temi"@it , "テーマ"@ja , "theme taxonomy"@en , "قائمة التصنيفات"@ar , "Ταξινομία θεματικών κατηγοριών."@el , "emnetaksonomi"@da , "taxonomie témat"@cs , "taxonomía de temas"@es ;
+                    rdfs:range         rdfs:Resource ;
+                    sdo:rangeIncludes  skos:ConceptScheme , owl:Ontology , skos:Collection ;
+                    skos:altLabel      "temataksonomi"@da ;
+                    skos:definition    "Vidensorganiseringssystem (KOS) som anvendes til at klassificere datasæt i kataloget."@da , "لائحة التصنيفات المستخدمه لتصنيف قوائم البيانات ضمن الفهرس"@ar , "El sistema de organización del conocimiento utilizado para clasificar conjuntos de datos de catálogos."@es , "Systém organizace znalostí (KOS) použitý pro klasifikaci datových sad v katalogu."@cs , "カタログのデータセットを分類するために用いられる知識組織化体系（KOS；knowledge organization system）。"@ja , "The knowledge organization system (KOS) used to classify catalog's datasets."@en , "Il sistema di organizzazione della conoscenza (KOS) usato per classificare i dataset del catalogo."@it , "Το σύστημα οργάνωσης γνώσης που χρησιμοποιείται για την κατηγοριοποίηση των συνόλων δεδομένων του καταλόγου."@el , "Le systhème d'ogranisation de connaissances utilisé pour classifier les jeux de données du catalogue."@fr ;
+                    skos:scopeNote     "Det anbefales at taksonomien organiseres i et skos:ConceptScheme, skos:Collection, owl:Ontology eller lignende, som giver mulighed for at ethvert medlem af taksonomien kan forsynes med en IRI og udgives som linked-data."@da , "It is recommended that the taxonomy is organized in a skos:ConceptScheme, skos:Collection, owl:Ontology or similar, which allows each member to be denoted by an IRI and published as linked-data."@en , "Je doporučeno, aby byla taxonomie vyjádřena jako skos:ConceptScheme, skos:Collection, owl:Ontology nebo podobné, aby mohla být každá položka identifikována pomocí IRI a publikována jako propojená data."@cs , "Se recomienda que la taxonomía se organice como un skos:ConceptScheme, skos:Collection, owl:Ontology o similar, los cuáles permiten que cada miembro se denote con una IRI y se publique como datos enlazados."@es , "Si raccomanda che la tassonomia sia organizzata in uno skos:ConceptScheme, skos:Collection, owl:Ontology o simili, che permette ad ogni membro di essere indicato da un IRI e pubblicato come linked-data."@it .
+
+spdx:packageFileName  rdf:type  owl:DatatypeProperty ;
+                      rdfs:comment    "The base name of the package file name. For example, zlib-1.2.5.tar.gz."@en ;
+                      rdfs:domain     spdx:Package ;
+                      rdfs:range      xsd:string ;
+                      vs:term_status  "stable"@en .
+
+prov:influenced  rdf:type          owl:ObjectProperty ;
+                 rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+                 rdfs:label                 "influenced" ;
+                 owl:inverseOf              prov:wasInfluencedBy ;
+                 prov:category              "expanded" ;
+                 prov:component             "agents-responsibility" ;
+                 prov:inverse               "wasInfluencedBy" ;
+                 prov:sharesDefinitionWith  prov:Influence .
+
+[ rdf:type               owl:Axiom ;
+  rdfs:comment           "Attribution is a particular case of trace (see http://www.w3.org/TR/prov-dm/#concept-trace), in the sense that it links an entity to the agent that ascribed it." ;
+  owl:annotatedProperty  rdfs:subPropertyOf ;
+  owl:annotatedSource    prov:wasAttributedTo ;
+  owl:annotatedTarget    prov:wasInfluencedBy ;
+  prov:definition        "IF wasAttributedTo(e2,ag1,aAttr) holds, THEN wasInfluencedBy(e2,ag1) also holds. "
+] .
+
+dcterms:accessRights  rdf:type  rdf:Property ;
+                      rdfs:comment         "Information about who access the resource or an indication of its security status."@en ;
+                      rdfs:isDefinedBy     dcterms: ;
+                      rdfs:label           "Access Rights"@en ;
+                      rdfs:subPropertyOf   dc:rights , dcterms:rights ;
+                      dcam:rangeIncludes   dcterms:RightsStatement ;
+                      dcterms:description  "Access Rights may include information regarding access or restrictions based on privacy, security, or other policies."@en ;
+                      dcterms:issued       "2003-02-15"^^xsd:date .
+
+spdx:checksumAlgorithm_sha384
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was SHA384"@en ;
+  vs:term_status  "stable"@en .
+
+[ rdf:type               owl:Axiom ;
+  rdfs:comment           "Quotation is a particular case of derivation (see http://www.w3.org/TR/prov-dm/#term-quotation) in which an entity is derived from an original entity by copying, or \"quoting\", some or all of it. " ;
+  owl:annotatedProperty  rdfs:subPropertyOf ;
+  owl:annotatedSource    prov:wasQuotedFrom ;
+  owl:annotatedTarget    prov:wasDerivedFrom
+] .
+
+skos:hiddenLabel  rdf:type  owl:AnnotationProperty , rdf:Property ;
+                  rdfs:comment        "The range of skos:hiddenLabel is the class of RDF plain literals."@en , "skos:prefLabel, skos:altLabel and skos:hiddenLabel are pairwise disjoint properties."@en ;
+                  rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+                  rdfs:label          "hidden label"@en ;
+                  rdfs:subPropertyOf  rdfs:label ;
+                  skos:definition     "A lexical label for a resource that should be hidden when generating visual displays of the resource, but should still be accessible to free text search operations."@en .
+
+prov:Plan  rdf:type       owl:Class ;
+           rdfs:comment      "There exist no prescriptive requirement on the nature of plans, their representation, the actions or steps they consist of, or their intended goals. Since plans may evolve over time, it may become necessary to track their provenance, so plans themselves are entities. Representing the plan explicitly in the provenance can be useful for various tasks: for example, to validate the execution as represented in the provenance record, to manage expectation failures, or to provide explanations."@en ;
+           rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+           rdfs:label        "Plan" ;
+           rdfs:subClassOf   prov:Entity ;
+           prov:category     "expanded" , "qualified" ;
+           prov:component    "agents-responsibility" ;
+           prov:definition   "A plan is an entity that represents a set of actions or steps intended by one or more agents to achieve some goals." ;
+           prov:dm           "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Association"^^xsd:anyURI ;
+           prov:n            "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Association"^^xsd:anyURI .
+
+vcard:anniversary  rdf:type  owl:DatatypeProperty ;
+                   rdfs:comment      "The date of marriage, or equivalent, of the object"@en ;
+                   rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                   rdfs:label        "anniversary"@en ;
+                   rdfs:range        [ rdf:type     rdfs:Datatype ;
+                                       owl:unionOf  ( xsd:dateTime xsd:gYear )
+                             ] .
+
+prov:inverse  rdf:type    owl:AnnotationProperty ;
+              rdfs:comment      "PROV-O does not define all property inverses. The directionalities defined in PROV-O should be given preference over those not defined. However, if users wish to name the inverse of a PROV-O property, the local name given by prov:inverse should be used."@en ;
+              rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+              rdfs:seeAlso      <http://www.w3.org/TR/prov-o/#names-of-inverse-properties> .
+
+dcterms:accrualPeriodicity
+  rdf:type             rdf:Property ;
+  rdfs:comment         "The frequency with which items are added to a collection."@en ;
+  rdfs:domain          dctype:Collection ;
+  rdfs:isDefinedBy     dcterms: ;
+  rdfs:label           "Accrual Periodicity"@en ;
+  dcam:rangeIncludes   dcterms:Frequency ;
+  dcterms:description  "Recommended practice is to use a value from the Collection Description Frequency Vocabulary [[DCMI-COLLFREQ](https://dublincore.org/groups/collections/frequency/)]."@en ;
+  dcterms:issued       "2005-06-13"^^xsd:date .
+
+vs:term_status  rdf:type  owl:AnnotationProperty .
+
+skos:ConceptScheme  rdf:type  owl:Class ;
+                    rdfs:isDefinedBy  <http://www.w3.org/2004/02/skos/core> ;
+                    rdfs:label        "Concept Scheme"@en ;
+                    owl:disjointWith  skos:Concept ;
+                    skos:definition   "A set of concepts, optionally including statements about semantic relationships between those concepts."@en ;
+                    skos:example      "Thesauri, classification schemes, subject heading lists, taxonomies, 'folksonomies', and other types of controlled vocabulary are all examples of concept schemes. Concept schemes are also embedded in glossaries and terminologies."@en ;
+                    skos:scopeNote    "A concept scheme may be defined to include concepts from different sources."@en .
+
+dcterms:ProvenanceStatement
+  rdf:type          rdfs:Class ;
+  rdfs:comment      "Any changes in ownership and custody of a resource since its creation that are significant for its authenticity, integrity, and interpretation."@en ;
+  rdfs:isDefinedBy  dcterms: ;
+  rdfs:label        "Provenance Statement"@en ;
+  dcterms:issued    "2008-01-14"^^xsd:date .
+
+dcterms:identifier  rdf:type  rdf:Property ;
+                    rdfs:comment         "An unambiguous reference to the resource within a given context."@en ;
+                    rdfs:isDefinedBy     dcterms: ;
+                    rdfs:label           "Identifier"@en ;
+                    rdfs:range           rdfs:Literal ;
+                    rdfs:subPropertyOf   dc:identifier ;
+                    dcterms:description  "Recommended practice is to identify the resource by means of a string conforming to an identification system. Examples include International Standard Book Number (ISBN), Digital Object Identifier (DOI), and Uniform Resource Name (URN).  Persistent identifiers should be provided as HTTP URIs."@en ;
+                    dcterms:issued       "2008-01-14"^^xsd:date .
+
+time:hasTRS  rdf:type    owl:FunctionalProperty , owl:ObjectProperty ;
+             rdfs:comment     "El sistema de referencia temporal utilizado por una posición temporal o descripción de extensión."@es , "The temporal reference system used by a temporal position or extent description. "@en ;
+             rdfs:domain      [ rdf:type     owl:Class ;
+                                owl:unionOf  ( time:TemporalPosition time:GeneralDurationDescription )
+                         ] ;
+             rdfs:label       "sistema de referencia temporal utilizado"@es , "Temporal reference system used"@en ;
+             rdfs:range       time:TRS ;
+             skos:definition  "The temporal reference system used by a temporal position or extent description. "@en , "El sistema de referencia temporal utilizado por una posición temporal o descripción de extensión."@es .
+
+spdx:timestamp  rdf:type  owl:DatatypeProperty ;
+                rdfs:comment  "Timestamp"@en ;
+                rdfs:domain   spdx:CrossRef ;
+                rdfs:range    xsd:dateTime .
+
+spdx:standardLicenseHeaderHtml
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "HTML representation of the standard license header"@en ;
+  rdfs:domain     spdx:ListedLicense ;
+  rdfs:range      xsd:string ;
+  vs:term_status  "stable"@en .
+
+vcard:Organization  rdf:type  owl:Class ;
+                    rdfs:comment      "An object representing an organization.  An organization is a single entity, and might represent a business or government, a department or division within a business or government, a club, an association, or the like.\n"@en ;
+                    rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                    rdfs:label        "Organization"@en ;
+                    rdfs:subClassOf   vcard:Kind .
+
+spdx:Review  rdf:type    owl:Class ;
+             rdfs:comment     "This class has been deprecated in favor of an Annotation with an Annotation type of review."@en ;
+             rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                owl:onDataRange           xsd:dateTime ;
+                                owl:onProperty            spdx:reviewDate ;
+                                owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                         ] ;
+             rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                owl:onDataRange              xsd:string ;
+                                owl:onProperty               spdx:reviewer
+                         ] ;
+             rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                owl:onDataRange              xsd:string ;
+                                owl:onProperty               rdfs:comment
+                         ] ;
+             owl:deprecated   true ;
+             vs:term_status   "deprecated"@en .
+
+spdx:checksumAlgorithm_sha224
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was SHA224"@en ;
+  vs:term_status  "stable"@en .
+
+spdx:checksumAlgorithm_sha1
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was SHA-1" ;
+  vs:term_status  "stable" .
+
+prov:aq  rdf:type           owl:AnnotationProperty ;
+         rdfs:isDefinedBy    <http://www.w3.org/ns/prov-o#> ;
+         rdfs:subPropertyOf  rdfs:seeAlso .
+
+spdx:Snippet  rdf:type   owl:Class ;
+              rdfs:comment     "The set of bytes in a file. The name of the snippet is the name of the file appended with the byte range in parenthesis (ie: \"./file/name(2145:5532)\")"@en ;
+              rdfs:subClassOf  spdx:SpdxItem ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                                 owl:onClass                  spdx:AnyLicenseInfo ;
+                                 owl:onProperty               spdx:licenseInfoInSnippet
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:minQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onClass                  <http://www.w3.org/2009/pointers#StartEndPointer> ;
+                                 owl:onProperty               spdx:range
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                 owl:onClass               spdx:File ;
+                                 owl:onProperty            spdx:snippetFromFile ;
+                                 owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                         ] ;
+              vs:term_status   "stable"@en .
+
+time:inXSDDateTimeStamp
+  rdf:type         owl:DatatypeProperty ;
+  rdfs:comment     "Position of an instant, expressed using xsd:dateTimeStamp"@en , "Posición de un instante, expresado utilizando xsd:dateTimeStamp."@es ;
+  rdfs:domain      time:Instant ;
+  rdfs:label       "in XSD Date-Time-Stamp"@en , "en fecha-sello de tiempo XSD"@es ;
+  rdfs:range       xsd:dateTimeStamp ;
+  skos:definition  "Position of an instant, expressed using xsd:dateTimeStamp"@en , "Posición de un instante, expresado utilizando xsd:dateTimeStamp."@es .
+
+dcat:bbox  rdf:type      rdf:Property , owl:DatatypeProperty ;
+           rdfs:domain      dcterms:Location ;
+           rdfs:label       "bounding box"@da , "bounding box"@en , "cuadro delimitador"@es , "ohraničení oblasti"@cs , "quadro di delimitazione"@it ;
+           rdfs:range       rdfs:Literal ;
+           skos:changeNote  "Ny egenskab tilføjet i DCAT 2.0."@da , "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs , "Propiedad nueva agregada en DCAT 2.0."@es , "New property added in DCAT 2.0."@en , "Nuova proprietà aggiunta in DCAT 2.0."@it ;
+           skos:definition  "Den geografiske omskrevne firkant af en ressource."@da , "Il riquadro di delimitazione geografica di una risorsa."@it , "Ohraničení geografické oblasti zdroje."@cs , "El cuadro delimitador geográfico para un recurso."@es , "The geographic bounding box of a resource."@en ;
+           skos:scopeNote   "El rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede ser codificada como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@es , "The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:wktLiteral [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL])."@en , "Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@it , "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL])."@cs , "Rækkevidden for denne egenskab er bevidst generisk defineret med det formål at tillade forskellige kodninger af geometrier. Geometrien kan eksempelvis repræsenteres som WKT (geosparql:asWKT [GeoSPARQL]) eller [GML] (geosparql:asGML [GeoSPARQL])."@da .
+
+spdx:SimpleLicensingInfo
+  rdf:type         owl:Class ;
+  rdfs:comment     "The SimpleLicenseInfo class includes all resources that represent simple, atomic, licensing information."@en ;
+  rdfs:subClassOf  spdx:AnyLicenseInfo ;
+  rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                     owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                     owl:onClass                  spdx:CrossRef ;
+                     owl:onProperty               spdx:crossRef
+                   ] ;
+  rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                     owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                     owl:onDataRange              xsd:anyURI ;
+                     owl:onProperty               rdfs:seeAlso
+                   ] ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onDataRange           xsd:string ;
+                     owl:onProperty            spdx:licenseId ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                     owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onDataRange              xsd:string ;
+                     owl:onProperty               spdx:name
+                   ] ;
+  rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                     owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onDataRange              xsd:string ;
+                     owl:onProperty               rdfs:comment
+                   ] ;
+  vs:term_status   "stable"@en .
+
+locn:Geometry  rdf:type     rdfs:Class ;
+               rdfs:comment        "The locn:Geometry class provides the means to identify a location as a point, line, polygon, etc. expressed using coordinates in some coordinate reference system."@en ;
+               rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+               rdfs:label          "Geometry"@en ;
+               dcterms:identifier  "locn:Geometry" ;
+               vann:usageNote      "This class defines the notion of \"geometry\" at the conceptual level, and it shall be encoded by using different formats (see usage note of the locn:geometry property)."@en ;
+               vs:term_status      "unstable"@en .
+
+time:intervalDuring  rdf:type  owl:ObjectProperty ;
+                     rdfs:comment        "Si un intervalo propio T1 está durante otro intervalo propio T2, entonces del principio de T1 está después del principio de T2, y el final de T1 está antes que el final de T2."@es , "If a proper interval T1 is intervalDuring another proper interval T2, then the beginning of T1 is after the beginning of T2, and the end of T1 is before the end of T2."@en ;
+                     rdfs:domain         time:ProperInterval ;
+                     rdfs:label          "intervalo durante"@es , "interval during"@en ;
+                     rdfs:range          time:ProperInterval ;
+                     rdfs:subPropertyOf  time:intervalIn ;
+                     owl:inverseOf       time:intervalContains ;
+                     skos:definition     "Si un intervalo propio T1 está durante otro intervalo propio T2, entonces del principio de T1 está después del principio de T2, y el final de T1 está antes que el final de T2."@es , "If a proper interval T1 is intervalDuring another proper interval T2, then the beginning of T1 is after the beginning of T2, and the end of T1 is before the end of T2."@en .
+
+spdx:relationshipType_contains
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "A Relationship of relationshipType_contains expresses that an SPDXElement contains the relatedSPDXElement.  For example, a Package contains a File. (relationshipType_contains introduced in SPDX 2.0 deprecates property 'hasFile' from SPDX 1.2)"@en ;
+  vs:term_status  "stable"@en .
+
+dcat:catalog  rdf:type      owl:ObjectProperty ;
+              rdfs:comment        "Un catálogo cuyo contenido es de interés en el contexto del catálogo que está siendo descripto."@es , "Un catalogo i cui contenuti sono di interesse nel contesto di questo catalogo."@it , "Et katalog hvis indhold er relevant i forhold til det aktuelle katalog."@da , "Katalog, jehož obsah je v kontextu tohoto katalogu zajímavý."@cs , "A catalog whose contents are of interest in the context of this catalog."@en ;
+              rdfs:domain         dcat:Catalog ;
+              rdfs:label          "catálogo"@es , "catalogo"@it , "katalog"@cs , "katalog"@da , "catalog"@en ;
+              rdfs:range          dcat:Catalog ;
+              rdfs:subPropertyOf  rdfs:member , dcterms:hasPart ;
+              skos:altLabel       "har delkatalog"@da ;
+              skos:changeNote     "Nuova proprietà aggiunta in DCAT 2.0."@it , "New property added in DCAT 2.0."@en , "Nueva propiedad agregada en DCAT 2.0."@es , "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs ;
+              skos:definition     "Un catalogo i cui contenuti sono di interesse nel contesto di questo catalogo."@it , "Katalog, jehož obsah je v kontextu tohoto katalogu zajímavý."@cs , "Et katalog hvis indhold er relevant i forhold til det aktuelle katalog."@da , "Un catálogo cuyo contenido es de interés en el contexto del catálogo que está siendo descripto."@es , "A catalog whose contents are of interest in the context of this catalog."@en .
+
+time:weeks  rdf:type  owl:DatatypeProperty ;
+            rdfs:comment  "length of, or element of the length of, a temporal extent expressed in weeks"@en , "Longitud de, o elemento de la longitud de, una extensión temporal expresada en semanas."@es ;
+            rdfs:domain   time:GeneralDurationDescription ;
+            rdfs:label    "weeks duration"@en , "duración en semanas"@es ;
+            rdfs:range    xsd:decimal .
+
+<http://data.europa.eu/r5r#CatalogRecord_Shape>
+  rdf:type        sh:NodeShape ;
+  sh:name         "Catalog Record"@en ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:minCount  1 ;
+                    sh:node      <http://data.europa.eu/r5r#DcatResource_Shape> ;
+                    sh:path      foaf:primaryTopic ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcterms:source ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:language ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      adms:status ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:nodeKind  sh:Literal ;
+                    sh:path      dcterms:description ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:nodeKind  sh:Literal ;
+                    sh:path      dcterms:title ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:minCount  1 ;
+                    sh:node      <http://data.europa.eu/r5r#DateOrDateTimeDataType_Shape> ;
+                    sh:path      dcterms:modified ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcterms:conformsTo ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:node      <http://data.europa.eu/r5r#DateOrDateTimeDataType_Shape> ;
+                    sh:path      dcterms:issued ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:targetClass  dcat:CatalogRecord .
+
+spdx:SpdxElement  rdf:type  owl:Class ;
+                  rdfs:comment     "An SpdxElement is any thing described in SPDX, either a document or an SpdxItem. SpdxElements can be related to other SpdxElements."@en ;
+                  rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                     owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                                     owl:onClass                  spdx:Annotation ;
+                                     owl:onProperty               spdx:annotation
+                            ] ;
+                  rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                     owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                                     owl:onClass                  spdx:Relationship ;
+                                     owl:onProperty               spdx:relationship
+                            ] ;
+                  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                     owl:onDataRange           xsd:string ;
+                                     owl:onProperty            spdx:name ;
+                                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                            ] ;
+                  rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                     owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                     owl:onDataRange              xsd:string ;
+                                     owl:onProperty               rdfs:comment
+                            ] ;
+                  vs:term_status   "stable" .
+
+time:monthOfYear  rdf:type  owl:ObjectProperty ;
+                  rdfs:comment        "The month of the year, whose value is a member of the class time:MonthOfYear"@en , "El mes del año, cuyo valor es un miembro de la clase 'mes del año'."@es ;
+                  rdfs:domain         time:GeneralDateTimeDescription ;
+                  rdfs:label          "month of year"@en , "mes del año"@es ;
+                  rdfs:range          time:MonthOfYear ;
+                  skos:definition     "The month of the year, whose value is a member of the class time:MonthOfYear"@en , "El mes del año, cuyo valor es un miembro de la clase 'mes del año'."@es ;
+                  skos:editorialNote  "Característica arriesgada - añadida en la revisión de 2017, y todavía no ampliamente utilizada."@es , "Feature at risk - added in 2017 revision, and not yet widely used. "@en .
+
+skos:member  rdf:type     owl:ObjectProperty , rdf:Property ;
+             rdfs:domain       skos:Collection ;
+             rdfs:isDefinedBy  <http://www.w3.org/2004/02/skos/core> ;
+             rdfs:label        "has member"@en ;
+             rdfs:range        [ rdf:type     owl:Class ;
+                                 owl:unionOf  ( skos:Concept skos:Collection )
+                          ] ;
+             skos:definition   "Relates a collection to one of its members."@en .
+
+vcard:organization-name
+  rdf:type          owl:DatatypeProperty ;
+  rdfs:comment      "To specify the organizational name associated with the object"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "organization name"@en ;
+  rdfs:range        xsd:string .
+
+dcterms:hasPart  rdf:type    rdf:Property ;
+                 rdfs:comment         "A related resource that is included either physically or logically in the described resource."@en ;
+                 rdfs:isDefinedBy     dcterms: ;
+                 rdfs:label           "Has Part"@en ;
+                 rdfs:subPropertyOf   dc:relation , dcterms:relation ;
+                 dcterms:description  "This property is intended to be used with non-literal values. This property is an inverse property of Is Part Of."@en ;
+                 dcterms:issued       "2000-07-11"^^xsd:date .
+
+prov:qualifiedPrimarySource
+  rdf:type                   owl:ObjectProperty ;
+  rdfs:comment               "If this Entity prov:hadPrimarySource Entity :e, then it can qualify how using prov:qualifiedPrimarySource [ a prov:PrimarySource; prov:entity :e; :foo :bar ]."@en ;
+  rdfs:domain                prov:Entity ;
+  rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label                 "qualifiedPrimarySource" ;
+  rdfs:range                 prov:PrimarySource ;
+  rdfs:subPropertyOf         prov:qualifiedInfluence ;
+  prov:category              "qualified" ;
+  prov:component             "derivations" ;
+  prov:inverse               "qualifiedSourceOf" ;
+  prov:sharesDefinitionWith  prov:PrimarySource ;
+  prov:unqualifiedForm       prov:hadPrimarySource .
+
+time:hour  rdf:type      owl:DatatypeProperty ;
+           rdfs:comment     "Hour position in a calendar-clock system."@en , "Posición de hora en un sistema calendario-reloj."@es ;
+           rdfs:domain      time:GeneralDateTimeDescription ;
+           rdfs:label       "hour"@en , "hora"@es ;
+           rdfs:range       xsd:nonNegativeInteger ;
+           skos:definition  "Hour position in a calendar-clock system."@en , "Posición de hora en un sistema calendario-reloj."@es .
+
+dcat:endDate  rdf:type   rdf:Property , owl:DatatypeProperty ;
+              rdfs:domain      dcterms:PeriodOfTime ;
+              rdfs:label       "data di fine"@it , "datum konce"@cs , "slutdato"@da , "end date"@en , "fecha final"@es ;
+              rdfs:range       rdfs:Literal ;
+              skos:altLabel    "sluttidspunkt"@da ;
+              skos:changeNote  "New property added in DCAT 2.0."@en , "Nueva propiedad agregada en DCAT 2.0."@es , "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs , "Nuova proprietà aggiunta in DCAT 2.0."@it , "Ny egenskab i DCAT 2.0."@da ;
+              skos:definition  "El fin del período."@es , "Slutningen på perioden."@da , "La fine del periodo."@it , "Konec doby trvání."@cs , "The end of the period."@en ;
+              skos:scopeNote   "La range di questa proprietà è volutamente generico, con lo scopo di consentire diversi livelli di precisione temporale per specificare la fine di un periodo. Ad esempio, può essere espresso con una data (xsd:date), una data e un'ora (xsd:dateTime), o un anno (xsd:gYear)."@it , "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé úrovně časového rozlišení pro specifikaci konce doby trvání. Ten může být kupříkladu vyjádřen datumem (xsd:date), datumem a časem (xsd:dateTime) či rokem (xsd:gYear)."@cs , "Rækkeviden for denne egenskab er bevidst generisk defineret med det formål at tillade forskellige niveauer af tidslig præcision ifm. angivelse af slutdatoen for en periode. Den kan eksempelvis udtrykkes som en dato (xsd:date), en dato og et tidspunkt (xsd:dateTime), eller et årstal (xsd:gYear)."@da , "El rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintos niveles de precisión temporal para especificar el fin del período. Por ejemplo, puede expresarse como una fecha (xsd:date), una fecha y un tiempo (xsd:dateTime), o un año (xsd:gYear)."@es , "The range of this property is intentionally generic, with the purpose of allowing different level of temporal precision for specifying the end of a period. E.g., it can be expressed with a date (xsd:date), a date and time (xsd:dateTime), or a year (xsd:gYear)."@en .
+
+prov:End  rdf:type            owl:Class ;
+          rdfs:comment          "An instance of prov:End provides additional descriptions about the binary prov:wasEndedBy relation from some ended prov:Activity to an prov:Entity that ended it. For example, :ball_game prov:wasEndedBy :buzzer; prov:qualifiedEnd [ a prov:End; prov:entity :buzzer; :foo :bar; prov:atTime '2012-03-09T08:05:08-05:00'^^xsd:dateTime ]."@en ;
+          rdfs:isDefinedBy      <http://www.w3.org/ns/prov-o#> ;
+          rdfs:label            "End" ;
+          rdfs:subClassOf       prov:EntityInfluence , prov:InstantaneousEvent ;
+          prov:category         "qualified" ;
+          prov:component        "entities-activities" ;
+          prov:constraints      "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+          prov:definition       "End is when an activity is deemed to have been ended by an entity, known as trigger. The activity no longer exists after its end. Any usage, generation, or invalidation involving an activity precedes the activity's end. An end may refer to a trigger entity that terminated the activity, or to an activity, known as ender that generated the trigger."@en ;
+          prov:dm               "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-End"^^xsd:anyURI ;
+          prov:n                "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-End"^^xsd:anyURI ;
+          prov:unqualifiedForm  prov:wasEndedBy .
+
+prov:invalidatedAtTime
+  rdf:type            owl:DatatypeProperty ;
+  rdfs:comment        "The time at which an entity was invalidated (i.e., no longer usable)."@en ;
+  rdfs:domain         prov:Entity ;
+  rdfs:isDefinedBy    <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label          "invalidatedAtTime" ;
+  rdfs:range          xsd:dateTime ;
+  prov:category       "expanded" ;
+  prov:component      "entities-activities" ;
+  prov:editorialNote  "It is the intent that the property chain holds: (prov:qualifiedInvalidation o prov:atTime) rdfs:subPropertyOf prov:invalidatedAtTime."@en ;
+  prov:qualifiedForm  prov:atTime , prov:Invalidation .
+
+time:after  rdf:type     owl:ObjectProperty ;
+            rdfs:comment     "Gives directionality to time. If a temporal entity T1 is after another temporal entity T2, then the beginning of T1 is after the end of T2."@en , "Asume una dirección en el tiempo. Si una entidad temporal T1 está después de otra entidad temporal T2, entonces el principio de T1 está después del final de T2."@es ;
+            rdfs:domain      time:TemporalEntity ;
+            rdfs:label       "después"@es , "after"@en ;
+            rdfs:range       time:TemporalEntity ;
+            owl:inverseOf    time:before ;
+            skos:definition  "Asume una dirección en el tiempo. Si una entidad temporal T1 está después de otra entidad temporal T2, entonces el principio de T1 está después del final de T2."@es , "Gives directionality to time. If a temporal entity T1 is after another temporal entity T2, then the beginning of T1 is after the end of T2."@en .
+
+prov:agent  rdf:type            owl:ObjectProperty ;
+            rdfs:domain             prov:AgentInfluence ;
+            rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+            rdfs:label              "agent" ;
+            rdfs:range              prov:Agent ;
+            rdfs:subPropertyOf      prov:influencer ;
+            prov:category           "qualified" ;
+            prov:editorialNote      "This property behaves in spirit like rdf:object; it references the object of a prov:wasInfluencedBy triple."@en ;
+            prov:editorsDefinition  "The prov:agent property references an prov:Agent which influenced a resource. This property applies to an prov:AgentInfluence, which is given by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity or prov:Agent."@en ;
+            prov:inverse            "agentOfInfluence" .
+
+rdfs:seeAlso  rdf:type      owl:AnnotationProperty , owl:DatatypeProperty ;
+              rdfs:comment        ""@en , "rdfs:seeAlso fully represents the ISA Programme Location Core Vocabulary concept of a geographic identifier."@en ;
+              rdfs:isDefinedBy    rdfs: ;
+              rdfs:label          "geographic identifier"@en ;
+              dcterms:identifier  "rdfs:seeAlso" ;
+              vann:usageNote      "Used in the ISA Programme Location Core Vocabulary to provide a URI that identifies the location. This should be expressed using the rdfs:seeAlso property unless the identifier is already the subject of the description. Examples include URIs from GeoNames.org and DBpedia such as http://dbpedia.org/resource/ISO_3166-2:XX where XX is the ISO 3166 two character code for a country."@en ;
+              vs:term_status      "unstable"@en .
+
+vcard:fn  rdf:type        owl:DatatypeProperty ;
+          rdfs:comment      "The formatted text corresponding to the name of the object"@en ;
+          rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+          rdfs:label        "formatted name"@en ;
+          rdfs:range        xsd:string .
+
+skos:definition  rdf:type   owl:AnnotationProperty , rdf:Property ;
+                 rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+                 rdfs:label          "definition"@en ;
+                 rdfs:subPropertyOf  skos:note ;
+                 skos:definition     "A statement or formal explanation of the meaning of a concept."@en .
+
+time:TemporalPosition
+  rdf:type         owl:Class ;
+  rdfs:comment     "A position on a time-line"@en , "Una posición sobre una línea de tiempo."@es ;
+  rdfs:label       "Temporal position"@en , "posición temporal"@es ;
+  rdfs:subClassOf  [ rdf:type         owl:Restriction ;
+                     owl:cardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty   time:hasTRS
+                   ] ;
+  skos:definition  "A position on a time-line"@en , "Una posición sobre una línea de tiempo."@es .
+
+spdx:DisjunctiveLicenseSet
+  rdf:type         owl:Class ;
+  rdfs:comment     "A DisjunctiveLicenseSet represents a set of licensing information where only one license applies at a time. This class implies that the recipient gets to choose one of these licenses they would prefer to use."@en ;
+  rdfs:subClassOf  spdx:AnyLicenseInfo , rdfs:Container ;
+  rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                     owl:minQualifiedCardinality  "2"^^xsd:nonNegativeInteger ;
+                     owl:onClass                  spdx:AnyLicenseInfo ;
+                     owl:onProperty               spdx:member
+                   ] ;
+  vs:term_status   "stable"@en .
+
+<http://data.europa.eu/r5r#LicenceDocument_Shape>
+  rdf:type        sh:NodeShape ;
+  sh:name         "Licence Document"@en ;
+  sh:property     [ sh:path      dcterms:type ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:targetClass  dcterms:LicenseDocument .
+
+spdx:relationshipType_buildToolOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "To be used when SPDXRef-A is used to to build SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:originator  rdf:type  owl:DatatypeProperty ;
+                 rdfs:comment  "The name and, optionally, contact information of the person or organization that originally created the package. Values of this property must conform to the agent and tool syntax."@en ;
+                 rdfs:domain   spdx:Package ;
+                 rdfs:range    xsd:string .
+
+dcterms:MediaType  rdf:type  rdfs:Class ;
+                   rdfs:comment      "A file format or physical medium."@en ;
+                   rdfs:isDefinedBy  dcterms: ;
+                   rdfs:label        "Media Type"@en ;
+                   rdfs:subClassOf   dcterms:MediaTypeOrExtent ;
+                   dcterms:issued    "2008-01-14"^^xsd:date .
+
+spdx:SpdxDocument  rdf:type  owl:Class ;
+                   rdfs:comment     "An SpdxDocument is a summary of the contents, provenance, ownership and licensing analysis of a specific software package. This is, effectively, the top level of SPDX information."@en ;
+                   rdfs:subClassOf  spdx:SpdxElement ;
+                   rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                      owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                                      owl:onClass                  spdx:ExternalDocumentRef ;
+                                      owl:onProperty               spdx:externalDocumentRef
+                             ] ;
+                   rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                      owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                                      owl:onClass                  spdx:Package ;
+                                      owl:onProperty               spdx:describesPackage
+                             ] ;
+                   rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                      owl:onDataRange           xsd:string ;
+                                      owl:onProperty            spdx:specVersion ;
+                                      owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                             ] ;
+                   rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                      owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                                      owl:onClass                  spdx:Review ;
+                                      owl:onProperty               spdx:reviewed
+                             ] ;
+                   rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                      owl:onClass               spdx:CreationInfo ;
+                                      owl:onProperty            spdx:creationInfo ;
+                                      owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                             ] ;
+                   rdfs:subClassOf  [ rdf:type        owl:Restriction ;
+                                      owl:hasValue    <http://spdx.org/licenses/CC0-1.0> ;
+                                      owl:onProperty  spdx:dataLicense
+                             ] ;
+                   rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                      owl:onClass               spdx:AnyLicenseInfo ;
+                                      owl:onProperty            spdx:dataLicense ;
+                                      owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                             ] ;
+                   rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                      owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                                      owl:onClass                  spdx:ExtractedLicensingInfo ;
+                                      owl:onProperty               spdx:hasExtractedLicensingInfo
+                             ] ;
+                   vs:term_status   "stable" .
+
+skos:related  rdf:type      owl:ObjectProperty , owl:SymmetricProperty , rdf:Property ;
+              rdfs:comment        "skos:related is disjoint with skos:broaderTransitive"@en ;
+              rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+              rdfs:label          "has related"@en ;
+              rdfs:subPropertyOf  skos:semanticRelation ;
+              skos:definition     "Relates a concept to a concept with which there is an associative semantic relationship."@en .
+
+vcard:category  rdf:type  owl:DatatypeProperty ;
+                rdfs:comment      "The category information about the object, also known as tags"@en ;
+                rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                rdfs:label        "category"@en ;
+                rdfs:range        xsd:string .
+
+[ rdf:type               owl:Axiom ;
+  rdfs:comment           "A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections."@en ;
+  owl:annotatedProperty  rdfs:range ;
+  owl:annotatedSource    prov:hadMember ;
+  owl:annotatedTarget    prov:Entity ;
+  prov:dm                "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-collection"
+] .
+
+vcard:Child  rdf:type     owl:Class ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "Child"@en ;
+             rdfs:subClassOf   vcard:RelatedType .
+
+spdx:licenseId  rdf:type  owl:DatatypeProperty ;
+                rdfs:comment    "A human readable short form license identifier for a license. The license ID is either on the standard license list or the form \"LicenseRef-[idString]\" where [idString] is a unique string containing letters, numbers, \".\" or \"-\".  When used within a license expression, the license ID can optionally include a reference to an external document in the form \"DocumentRef-[docrefIdString]:LicenseRef-[idString]\" where docRefIdString is an ID for an external document reference."@en ;
+                rdfs:domain     spdx:SimpleLicensingInfo ;
+                rdfs:range      xsd:string ;
+                vs:term_status  "stable"@en .
+
+spdx:annotator  rdf:type  owl:DatatypeProperty ;
+                rdfs:comment    "This field identifies the person, organization, or tool that has commented on a file, package, snippet, or the entire document." ;
+                rdfs:domain     spdx:Annotation ;
+                rdfs:range      xsd:string ;
+                vs:term_status  "stable"@en .
+
+time:intervalDisjoint
+  rdf:type         owl:ObjectProperty ;
+  rdfs:comment     "Si un intervalo propio T1 es disjunto con otro intervalo propio T2, entonces el principio de T1 está después del final de T2, o el final de T1 está antes que el principio de T2, es decir, los intervalos no se solapan de ninguna forma, aunque su relación de orden no se conozca."@es , "If a proper interval T1 is intervalDisjoint another proper interval T2, then the beginning of T1 is after the end of T2, or the end of T1 is before the beginning of T2, i.e. the intervals do not overlap in any way, but their ordering relationship is not known."@en ;
+  rdfs:domain      time:ProperInterval ;
+  rdfs:label       "interval disjoint"@en , "intervalo disjunto"@es ;
+  rdfs:range       time:ProperInterval ;
+  skos:definition  "If a proper interval T1 is intervalDisjoint another proper interval T2, then the beginning of T1 is after the end of T2, or the end of T1 is before the beginning of T2, i.e. the intervals do not overlap in any way, but their ordering relationship is not known."@en , "Si un intervalo propio T1 es disjunto con otro intervalo propio T2, entonces el principio de T1 está después del final de T2, o el final de T1 está antes que el principio de T2, es decir, los intervalos no se solapan de ninguna forma, aunque su relación de orden no se conozca."@es ;
+  skos:note        "This interval relation is not included in the 13 basic relationships defined in Allen (1984), but is defined in (T.3) as the union of :intervalBefore v :intervalAfter . However, that is outside OWL2 expressivity, so is implemented as an explicit property, with :intervalBefore , :intervalAfter as sub-properties"@en , "Esta relación entre intervalos no estaba incluida en las 13 relaciones básicas definidas por Allen (1984), pero está definida en T.3 como la unión de 'intervalo anterior' con 'intervalo posterior'. Sin embargo, esto está fuera de la expresividad de OWL2, por tanto, está implementado como una propiedad explícita, con 'intervalo anterior' e 'intervalo posterior' como sub-propiedades."@es .
+
+<http://www.w3.org/2009/pointers#lineNumber>
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:domain     <http://www.w3.org/2009/pointers#LineCharPointer> ;
+  rdfs:range      xsd:positiveInteger ;
+  vs:term_status  "stable"@en .
+
+time:Duration  rdf:type  owl:Class ;
+               rdfs:comment     "Duration of a temporal extent expressed as a number scaled by a temporal unit"@en , "Duración de una extensión temporal expresada como un número escalado por una unidad temporal."@es ;
+               rdfs:label       "duración de tiempo" , "Time duration"@en ;
+               rdfs:subClassOf  time:TemporalDuration ;
+               rdfs:subClassOf  [ rdf:type         owl:Restriction ;
+                                  owl:cardinality  "1"^^xsd:nonNegativeInteger ;
+                                  owl:onProperty   time:unitType
+                         ] ;
+               rdfs:subClassOf  [ rdf:type         owl:Restriction ;
+                                  owl:cardinality  "1"^^xsd:nonNegativeInteger ;
+                                  owl:onProperty   time:numericDuration
+                         ] ;
+               skos:definition  "Duration of a temporal extent expressed as a number scaled by a temporal unit"@en , "Duración de una extensión temporal expresada como un número escalado por una unidad temporal."@es ;
+               skos:note        "Alternative to time:DurationDescription to support description of a temporal duration other than using a calendar/clock system."@en , "Alternativa a 'descripción de tiempo' para proporcionar descripción soporte a una duración temporal diferente a utilizar un sistema de calendario/reloj."@es .
+
+locn:address  rdf:type      rdf:Property ;
+              rdfs:comment        "The locn:address property relationship associates any resource with the locn:Address class "@en ;
+              rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+              rdfs:label          "address"@en ;
+              rdfs:range          locn:Address ;
+              dcterms:identifier  "locn:address" ;
+              vs:term_status      "testing"@en .
+
+dcterms:ISO639-3  rdf:type  rdfs:Datatype ;
+                  rdfs:comment      "The set of three-letter codes listed in ISO 639-3 for the representation of names of languages."@en ;
+                  rdfs:isDefinedBy  dcterms: ;
+                  rdfs:label        "ISO 639-3"@en ;
+                  rdfs:seeAlso      <http://www.sil.org/iso639-3/> ;
+                  dcterms:issued    "2008-01-14"^^xsd:date .
+
+spdx:fileName  rdf:type     owl:DatatypeProperty ;
+               rdfs:comment        "The name of the file relative to the root of the package."@en ;
+               rdfs:domain         spdx:File ;
+               rdfs:range          xsd:string ;
+               rdfs:subPropertyOf  spdx:name ;
+               vs:term_status      "stable"@en .
+
+time:days  rdf:type      owl:DatatypeProperty ;
+           rdfs:comment     "length of, or element of the length of, a temporal extent expressed in days"@en , "Longitud de, o elemento de la longitud de, una extensión temporal expresada en días."@es ;
+           rdfs:domain      time:GeneralDurationDescription ;
+           rdfs:label       "days duration"@en , "duración en días"@es ;
+           rdfs:range       xsd:decimal ;
+           skos:definition  "length of, or element of the length of, a temporal extent expressed in days"@en , "Longitud de, o elemento de la longitud de, una extensión temporal expresada en días."@es .
+
+dcterms:isPartOf  rdf:type   rdf:Property ;
+                  rdfs:comment         "A related resource in which the described resource is physically or logically included."@en ;
+                  rdfs:isDefinedBy     dcterms: ;
+                  rdfs:label           "Is Part Of"@en ;
+                  rdfs:subPropertyOf   dc:relation , dcterms:relation ;
+                  dcterms:description  "This property is intended to be used with non-literal values. This property is an inverse property of Has Part."@en ;
+                  dcterms:issued       "2000-07-11"^^xsd:date .
+
+vcard:hasOrganizationUnit
+  rdf:type          owl:ObjectProperty ;
+  rdfs:comment      "Used to support property parameters for the organization unit name data property"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "has organization unit name"@en .
+
+spdx:versionInfo  rdf:type  owl:DatatypeProperty ;
+                  rdfs:comment    "Provides an indication of the version of the package that is described by this SpdxDocument."@en ;
+                  rdfs:domain     spdx:Package ;
+                  rdfs:range      xsd:string ;
+                  vs:term_status  "stable"@en .
+
+vcard:hasAddress  rdf:type  owl:ObjectProperty ;
+                  rdfs:comment      "To specify the components of the delivery address for the object"@en ;
+                  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                  rdfs:label        "has address"@en ;
+                  rdfs:range        vcard:Address .
+
+prov:Bundle  rdf:type     owl:Class ;
+             rdfs:comment      "Note that there are kinds of bundles (e.g. handwritten letters, audio recordings, etc.) that are not expressed in PROV-O, but can be still be described by PROV-O."@en ;
+             rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+             rdfs:label        "Bundle" ;
+             rdfs:subClassOf   prov:Entity ;
+             prov:category     "expanded" ;
+             prov:definition   "A bundle is a named set of provenance descriptions, and is itself an Entity, so allowing provenance of provenance to be expressed."@en ;
+             prov:dm           "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-bundle-entity"^^xsd:anyURI ;
+             prov:n            "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-bundle-declaration"^^xsd:anyURI .
+
+<http://www.w3.org/2009/pointers#reference>
+  rdf:type        owl:ObjectProperty ;
+  rdfs:domain     <http://www.w3.org/2009/pointers#SinglePointer> ;
+  vs:term_status  "stable"@en .
+
+time:intervalOverlaps
+  rdf:type         owl:ObjectProperty ;
+  rdfs:comment     "If a proper interval T1 is intervalOverlaps another proper interval T2, then the beginning of T1 is before the beginning of T2, the end of T1 is after the beginning of T2, and the end of T1 is before the end of T2."@en , "Si un intervalo propio T1 se solapa con otro intervalo propio T2, entonces el principio de T1 es anterior al principio de T2, el final de T1 es posterior al principio de T2, y el final de T1 es anterior al final de T2."@es , "Asume una dirección en el tiempo. Si una entidad temporal T1 está después de otra entidad temporal T2, entonces el principio de T1 está después del final de T2."@es ;
+  rdfs:domain      time:ProperInterval ;
+  rdfs:label       "interval overlaps"@en , "intervalo se solapa"@es ;
+  rdfs:range       time:ProperInterval ;
+  owl:inverseOf    time:intervalOverlappedBy ;
+  skos:definition  "If a proper interval T1 is intervalOverlaps another proper interval T2, then the beginning of T1 is before the beginning of T2, the end of T1 is after the beginning of T2, and the end of T1 is before the end of T2."@en , "Si un intervalo propio T1 se solapa con otro intervalo propio T2, entonces el principio de T1 es anterior al principio de T2, el final de T1 es posterior al principio de T2, y el final de T1 es anterior al final de T2."@es .
+
+time:hasEnd  rdf:type       owl:ObjectProperty ;
+             rdfs:comment        "End of a temporal entity."@en , "Final de una entidad temporal."@es ;
+             rdfs:domain         time:TemporalEntity ;
+             rdfs:label          "tiene fin"@es , "has end"@en ;
+             rdfs:range          time:Instant ;
+             rdfs:subPropertyOf  time:hasTime ;
+             skos:definition     "Final de una entidad temporal."@es , "End of a temporal entity."@en .
+
+spdx:checksumAlgorithm_sha3_512
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was SHA3-512."@en ;
+  vs:term_status  "stable"@en .
+
+skos:altLabel  rdf:type     owl:AnnotationProperty , rdf:Property ;
+               rdfs:comment        "The range of skos:altLabel is the class of RDF plain literals."@en , "skos:prefLabel, skos:altLabel and skos:hiddenLabel are pairwise disjoint properties."@en ;
+               rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+               rdfs:label          "alternative label"@en ;
+               rdfs:subPropertyOf  rdfs:label ;
+               skos:definition     "An alternative lexical label for a resource."@en ;
+               skos:example        "Acronyms, abbreviations, spelling variants, and irregular plural/singular forms may be included among the alternative labels for a concept. Mis-spelled terms are normally included as hidden labels (see skos:hiddenLabel)."@en .
+
+spdx:purpose_device  rdf:type  owl:NamedIndividual , spdx:Purpose ;
+                     rdfs:comment    "The package refers to a chipset, processor, or electronic board."@en ;
+                     vs:term_status  "stable"@en .
+
+spdx:standardLicenseHeader
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "License author's preferred text to indicated that a file is covered by the license."@en ;
+  rdfs:domain     spdx:License ;
+  rdfs:range      xsd:string ;
+  vs:term_status  "stable"@en .
+
+vcard:locality  rdf:type  owl:DatatypeProperty ;
+                rdfs:comment      "The locality (e.g. city or town) associated with the address of the object"@en ;
+                rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                rdfs:label        "locality"@en ;
+                rdfs:range        xsd:string .
+
+time:unitMonth  rdf:type  time:TemporalUnit ;
+                rdfs:label      "Month (unit of temporal duration)"@en ;
+                skos:prefLabel  "month"@en , "mese"@it , "mois"@fr , "mes"@es , "한달"@kr , "один месяц"@ru , "Monat"@de , "maand"@nl , "miesiąc"@pl , "一個月"@zh , "شهر واحد"@ar , "一か月"@jp ;
+                time:days       "0"^^xsd:decimal ;
+                time:hours      "0"^^xsd:decimal ;
+                time:minutes    "0"^^xsd:decimal ;
+                time:months     "1"^^xsd:decimal ;
+                time:seconds    "0"^^xsd:decimal ;
+                time:weeks      "0"^^xsd:decimal ;
+                time:years      "0"^^xsd:decimal .
+
+vcard:Coresident  rdf:type  owl:Class ;
+                  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                  rdfs:label        "Coresident"@en ;
+                  rdfs:subClassOf   vcard:RelatedType .
+
+<http://data.europa.eu/r5r#Agent_Shape>
+  rdf:type        sh:NodeShape ;
+  sh:name         "Agent"@en ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcterms:type ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:minCount  1 ;
+                    sh:nodeKind  sh:Literal ;
+                    sh:path      foaf:name ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:targetClass  foaf:Agent .
+
+prov:invalidated  rdf:type         owl:ObjectProperty ;
+                  rdfs:domain                prov:Activity ;
+                  rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+                  rdfs:label                 "invalidated" ;
+                  rdfs:range                 prov:Entity ;
+                  rdfs:subPropertyOf         prov:influenced ;
+                  owl:inverseOf              prov:wasInvalidatedBy ;
+                  prov:category              "expanded" ;
+                  prov:component             "entities-activities" ;
+                  prov:editorialNote         "prov:invalidated is one of few inverse property defined, to allow Activity-oriented assertions in addition to Entity-oriented assertions."@en ;
+                  prov:inverse               "wasInvalidatedBy" ;
+                  prov:sharesDefinitionWith  prov:Invalidation .
+
+vcard:Group  rdf:type        owl:Class ;
+             rdfs:comment         "Object representing a group of persons or entities.  A group object will usually contain hasMember properties to specify the members of the group."@en ;
+             rdfs:isDefinedBy     <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label           "Group"@en ;
+             rdfs:subClassOf      vcard:Kind ;
+             owl:disjointWith     vcard:Individual , vcard:Location , vcard:Organization ;
+             owl:equivalentClass  [ rdf:type            owl:Class ;
+                                    owl:intersectionOf  ( [ rdf:type            owl:Restriction ;
+                                                            owl:onProperty      vcard:hasMember ;
+                                                            owl:someValuesFrom  vcard:Kind
+                                                          ]
+                                                          [ rdf:type                     owl:Restriction ;
+                                                            owl:minQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                                            owl:onClass                  vcard:Kind ;
+                                                            owl:onProperty               vcard:hasMember
+                                                          ]
+                                                        )
+                             ] .
+
+spdx:reviewed  rdf:type  owl:ObjectProperty , owl:NamedIndividual ;
+               rdfs:comment    "This property has been deprecated since SPDX version 2.0.  It has been replaced by an Annotation with an annotation type review."@en , "Reviewed" ;
+               rdfs:domain     spdx:SpdxDocument ;
+               rdfs:range      spdx:Review ;
+               owl:deprecated  true ;
+               vs:term_status  "deprecated"@en .
+
+skos:scopeNote  rdf:type    owl:AnnotationProperty , rdf:Property ;
+                rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+                rdfs:label          "scope note"@en ;
+                rdfs:subPropertyOf  skos:note ;
+                skos:definition     "A note that helps to clarify the meaning and/or the use of a concept."@en .
+
+prov:ActivityInfluence
+  rdf:type                owl:Class ;
+  rdfs:comment            "It is not recommended that the type ActivityInfluence be asserted without also asserting one of its more specific subclasses."@en , "ActivityInfluence provides additional descriptions of an Activity's binary influence upon any other kind of resource. Instances of ActivityInfluence use the prov:activity property to cite the influencing Activity."@en ;
+  rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label              "ActivityInfluence" ;
+  rdfs:seeAlso            prov:activity ;
+  rdfs:subClassOf         prov:Influence ;
+  rdfs:subClassOf         [ rdf:type            owl:Restriction ;
+                            owl:maxCardinality  "0"^^xsd:nonNegativeInteger ;
+                            owl:onProperty      prov:hadActivity
+                          ] ;
+  rdfs:subClassOf         [ rdf:type            owl:Restriction ;
+                            owl:maxCardinality  "0"^^xsd:nonNegativeInteger ;
+                            owl:onProperty      prov:hadActivity
+                          ] ;
+  owl:disjointWith        prov:EntityInfluence ;
+  prov:category           "qualified" ;
+  prov:editorsDefinition  "ActivitiyInfluence is the capacity of an activity to have an effect on the character, development, or behavior of another by means of generation, invalidation, communication, or other."@en .
+
+spdx:annotationType_review
+  rdf:type        owl:NamedIndividual , spdx:AnnotationType ;
+  rdfs:comment    "A Review represents an audit and signoff by an individual, organization or tool on the information for an SpdxElement."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:order  rdf:type  owl:DatatypeProperty ;
+            rdfs:comment  "The ordinal order of this element within a list"@en ;
+            rdfs:domain   spdx:CrossRef ;
+            rdfs:range    xsd:nonNegativeInteger .
+
+spdx:filesAnalyzed  rdf:type  owl:DatatypeProperty ;
+                    rdfs:comment    "Indicates whether the file content of this package has been available for or subjected to analysis when creating the SPDX document. If false indicates packages that represent metadata or URI references to a project, product, artifact, distribution or a component. If set to false, the package must not contain any files."@en ;
+                    rdfs:domain     spdx:Package ;
+                    rdfs:range      xsd:boolean ;
+                    vs:term_status  "stable"@en .
+
+spdx:relationshipType_requirementDescriptionFor
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A describes, illustrates, or specifies a requirement statement for SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+vcard:RelatedType  rdf:type  owl:Class ;
+                   rdfs:comment      "Used for relation type codes. The URI of the relation type code must be used as the value for the Relation Type."@en ;
+                   rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                   rdfs:label        "Relation Type"@en .
+
+prov:Invalidation  rdf:type   owl:Class ;
+                   rdfs:comment          "An instance of prov:Invalidation provides additional descriptions about the binary prov:wasInvalidatedBy relation from an invalidated prov:Entity to the prov:Activity that invalidated it. For example, :uncracked_egg prov:wasInvalidatedBy :baking; prov:qualifiedInvalidation [ a prov:Invalidation; prov:activity :baking; :foo :bar ]."@en ;
+                   rdfs:isDefinedBy      <http://www.w3.org/ns/prov-o#> ;
+                   rdfs:label            "Invalidation" ;
+                   rdfs:subClassOf       prov:ActivityInfluence , prov:InstantaneousEvent ;
+                   prov:category         "qualified" ;
+                   prov:component        "entities-activities" ;
+                   prov:constraints      "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+                   prov:definition       "Invalidation is the start of the destruction, cessation, or expiry of an existing entity by an activity. The entity is no longer available for use (or further invalidation) after invalidation. Any generation or usage of an entity precedes its invalidation." ;
+                   prov:dm               "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Invalidation"^^xsd:anyURI ;
+                   prov:n                "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Invalidation"^^xsd:anyURI ;
+                   prov:unqualifiedForm  prov:wasInvalidatedBy .
+
+[ owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger ] .
+
+vcard:Parcel  rdf:type    owl:Class ;
+              rdfs:comment      "This class is deprecated"@en ;
+              rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+              rdfs:label        "Parcel"@en ;
+              rdfs:subClassOf   vcard:Type ;
+              owl:deprecated    true .
+
+<http://www.w3.org/2009/pointers#OffsetPointer>
+  rdf:type         owl:Class ;
+  rdfs:subClassOf  <http://www.w3.org/2009/pointers#SinglePointer> ;
+  vs:term_status   "stable" .
+
+vcard:Female  rdf:type    owl:Class ;
+              rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+              rdfs:label        "Female"@en ;
+              rdfs:subClassOf   vcard:Gender .
+
+skos:example  rdf:type      owl:AnnotationProperty , rdf:Property ;
+              rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+              rdfs:label          "example"@en ;
+              rdfs:subPropertyOf  skos:note ;
+              skos:definition     "An example of the use of a concept."@en .
+
+spdx:annotationType  rdf:type  owl:ObjectProperty ;
+                     rdfs:comment    "Type of the annotation."@en ;
+                     rdfs:domain     spdx:Annotation ;
+                     rdfs:range      [ rdf:type     owl:Class ;
+                                       owl:unionOf  ( [ rdf:type        owl:Restriction ;
+                                                        owl:hasValue    spdx:annotationType_other ;
+                                                        owl:onProperty  spdx:annotationType
+                                                      ]
+                                                      [ rdf:type        owl:Restriction ;
+                                                        owl:hasValue    spdx:annotationType_review ;
+                                                        owl:onProperty  spdx:annotationType
+                                                      ]
+                                                    )
+                               ] ;
+                     vs:term_status  "stable"@en .
+
+prov:hadPrimarySource
+  rdf:type                owl:ObjectProperty ;
+  rdfs:domain             prov:Entity ;
+  rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label              "hadPrimarySource" ;
+  rdfs:range              prov:Entity ;
+  rdfs:subPropertyOf      prov:wasDerivedFrom ;
+  owl:propertyChainAxiom  ( prov:qualifiedPrimarySource prov:entity ) ;
+  owl:propertyChainAxiom  ( prov:qualifiedPrimarySource prov:entity ) ;
+  prov:category           "expanded" ;
+  prov:component          "derivations" ;
+  prov:inverse            "wasPrimarySourceOf" ;
+  prov:qualifiedForm      prov:PrimarySource , prov:qualifiedPrimarySource .
+
+prov:wasQuotedFrom  rdf:type    owl:ObjectProperty ;
+                    rdfs:comment            "An entity is derived from an original entity by copying, or 'quoting', some or all of it."@en ;
+                    rdfs:domain             prov:Entity ;
+                    rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+                    rdfs:label              "wasQuotedFrom" ;
+                    rdfs:range              prov:Entity ;
+                    rdfs:subPropertyOf      prov:wasDerivedFrom ;
+                    owl:propertyChainAxiom  ( prov:qualifiedQuotation prov:entity ) ;
+                    owl:propertyChainAxiom  ( prov:qualifiedQuotation prov:entity ) ;
+                    prov:category           "expanded" ;
+                    prov:component          "derivations" ;
+                    prov:inverse            "quotedAs" ;
+                    prov:qualifiedForm      prov:qualifiedQuotation , prov:Quotation .
+
+dcterms:instructionalMethod
+  rdf:type             rdf:Property ;
+  rdfs:comment         "A process, used to engender knowledge, attitudes and skills, that the described resource is designed to support."@en ;
+  rdfs:isDefinedBy     dcterms: ;
+  rdfs:label           "Instructional Method"@en ;
+  dcam:rangeIncludes   dcterms:MethodOfInstruction ;
+  dcterms:description  "Instructional Method typically includes ways of presenting instructional materials or conducting instructional activities, patterns of learner-to-learner and learner-to-instructor interactions, and mechanisms by which group and individual levels of learning are measured.  Instructional methods include all aspects of the instruction and learning processes from planning and implementation through evaluation and feedback."@en ;
+  dcterms:issued       "2005-06-13"^^xsd:date .
+
+skos:hasTopConcept  rdf:type  owl:ObjectProperty , rdf:Property ;
+                    rdfs:domain       skos:ConceptScheme ;
+                    rdfs:isDefinedBy  <http://www.w3.org/2004/02/skos/core> ;
+                    rdfs:label        "has top concept"@en ;
+                    rdfs:range        skos:Concept ;
+                    owl:inverseOf     skos:topConceptOf ;
+                    skos:definition   "Relates, by convention, a concept scheme to a concept which is topmost in the broader/narrower concept hierarchies for that scheme, providing an entry point to these hierarchies."@en .
+
+prov:influencer  rdf:type       owl:ObjectProperty ;
+                 rdfs:comment            "Subproperties of prov:influencer are used to cite the object of an unqualified PROV-O triple whose predicate is a subproperty of prov:wasInfluencedBy (e.g. prov:used, prov:wasGeneratedBy). prov:influencer is used much like rdf:object is used."@en ;
+                 rdfs:domain             prov:Influence ;
+                 rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+                 rdfs:label              "influencer" ;
+                 rdfs:range              owl:Thing ;
+                 prov:category           "qualified" ;
+                 prov:dm                 "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence"^^xsd:anyURI ;
+                 prov:editorialNote      "This property and its subproperties are used in the same way as the rdf:object property, i.e. to reference the object of an unqualified prov:wasInfluencedBy or prov:influenced triple."@en ;
+                 prov:editorsDefinition  "This property is used as part of the qualified influence pattern. Subclasses of prov:Influence use these subproperties to reference the resource (Entity, Agent, or Activity) whose influence is being qualified."@en ;
+                 prov:inverse            "hadInfluence" .
+
+time:timeZone  rdf:type   owl:ObjectProperty ;
+               rdfs:comment      "The time zone for clock elements in the temporal position"@en ;
+               rdfs:domain       time:GeneralDateTimeDescription ;
+               rdfs:label        "in time zone"@en , "en huso horario"@es ;
+               rdfs:range        time:TimeZone ;
+               skos:historyNote  "En la versión original de OWL-Time de 2006, el rango de 'en huso horario' se definió en un espacio de nombres diferente \"http://www.w3.org/2006/timezone#\".\n            Un axioma de alineación permite que los datos codificados de acuerdo con la versión anterior sean consistentes con la ontología actualizada."@es , "In the original 2006 version of OWL-Time, the range of time:timeZone was a TimeZone class in a separate namespace \"http://www.w3.org/2006/timezone#\". \nAn alignment axiom \n\ttzont:TimeZone rdfs:subClassOf time:TimeZone . \nallows data encoded according to the previous version to be consistent with the updated ontology. " ;
+               skos:note         "IANA maintains a database of timezones. These are well maintained and generally considered authoritative, but individual items are not available at individual URIs, so cannot be used directly in data expressed using OWL-Time.\n\nDBPedia provides a set of resources corresponding to the IANA timezones, with a URI for each (e.g. http://dbpedia.org/resource/Australia/Eucla). The World Clock service also provides a list of time zones with the description of each available as an individual webpage with a convenient individual URI (e.g. https://www.timeanddate.com/time/zones/acwst). These or other, similar, resources might be used as a value of the time:timeZone property." , "IANA mantiene una base de datos de husos horarios. Éstas están bien mantenidas y generalmente se consideran autorizadas, pero los ítems individuales no están disponibles en URIs individuales, por tanto, no se pueden utilizar directamente en datos expresados utilizando OWL-Time.\n            La BDPedia proporciona un conjunto de recursos correspondientes a los husos horarios de IANA, con una URI para cada uno (por ejemplo, http://dbpedia.org/resource/Australia/Eucla). El Servicio de Reloj Mundial también proporciona una lista de husos horarios con la descripción de cada uno de los disponibles como una página Web individual con una URI adecuada individual (por ejemplo, https://www.timeanddate.com/time/zones/acwst). Éstos, y otros recursos similares, se puden usar como un valor de la propiedad 'huso horario'."@es .
+
+locn:locatorName  rdf:type  rdf:Property ;
+                  rdfs:comment        "Proper noun(s) applied to the real world entity identified by the locator. The locator name could be the name of the property or complex, of the building or part of the building, or it could be the name of a room inside a building. \n    "@en ;
+                  rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+                  rdfs:label          "locator name"@en ;
+                  dcterms:identifier  "locn:locatorName" ;
+                  vs:term_status      "testing"@en .
+
+spdx:referenceCategory_persistentId
+  rdf:type        owl:NamedIndividual , spdx:ReferenceCategory ;
+  rdfs:comment    "These point to objects present in the Software Heritage archive by the means of persistent identifiers that are guaranteed to remain stable (persistent) over time."@en ;
+  vs:term_status  "stable"@en .
+
+dcterms:references  rdf:type  rdf:Property ;
+                    rdfs:comment         "A related resource that is referenced, cited, or otherwise pointed to by the described resource."@en ;
+                    rdfs:isDefinedBy     dcterms: ;
+                    rdfs:label           "References"@en ;
+                    rdfs:subPropertyOf   dc:relation , dcterms:relation ;
+                    dcterms:description  "This property is intended to be used with non-literal values. This property is an inverse property of Is Referenced By."@en ;
+                    dcterms:issued       "2000-07-11"^^xsd:date .
+
+spdx:relatedSpdxElement
+  rdf:type        owl:ObjectProperty ;
+  rdfs:comment    "A related SpdxElement."@en ;
+  rdfs:domain     spdx:Relationship ;
+  rdfs:range      spdx:SpdxElement ;
+  vs:term_status  "stable"@en .
+
+prov:hadRole  rdf:type             owl:ObjectProperty ;
+              rdfs:comment               "The _optional_ Role that an Entity assumed in the context of an Activity. For example, :baking prov:used :spoon; prov:qualified [ a prov:Usage; prov:entity :spoon; prov:hadRole roles:mixing_implement ]."@en , "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." ;
+              rdfs:domain                prov:Influence ;
+              rdfs:domain                [ rdf:type     owl:Class ;
+                                           owl:unionOf  ( prov:Association prov:InstantaneousEvent )
+                                   ] ;
+              rdfs:domain                [ rdf:type     owl:Class ;
+                                           owl:unionOf  ( prov:Association prov:InstantaneousEvent )
+                                   ] ;
+              rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+              rdfs:label                 "hadRole" ;
+              rdfs:range                 prov:Role ;
+              prov:category              "qualified" ;
+              prov:component             "agents-responsibility" ;
+              prov:editorsDefinition     "prov:hadRole references the Role (i.e. the function of an entity with respect to an activity), in the context of an instantaneous usage, generation, association, start, and end."@en ;
+              prov:inverse               "wasRoleIn" ;
+              prov:sharesDefinitionWith  prov:Role .
+
+dcterms:MethodOfAccrual
+  rdf:type          rdfs:Class ;
+  rdfs:comment      "A method by which resources are added to a collection."@en ;
+  rdfs:isDefinedBy  dcterms: ;
+  rdfs:label        "Method of Accrual"@en ;
+  dcterms:issued    "2008-01-14"^^xsd:date .
+
+vcard:Sweetheart  rdf:type  owl:Class ;
+                  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                  rdfs:label        "Sweetheart"@en ;
+                  rdfs:subClassOf   vcard:RelatedType .
+
+prov:wasInfluencedBy  rdf:type     owl:ObjectProperty ;
+                      rdfs:comment               "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." , "Because prov:wasInfluencedBy is a broad relation, its more specific subproperties (e.g. prov:wasInformedBy, prov:actedOnBehalfOf, prov:wasEndedBy, etc.) should be used when applicable."@en ;
+                      rdfs:domain                [ rdf:type     owl:Class ;
+                                                   owl:unionOf  ( prov:Activity prov:Agent prov:Entity )
+                                   ] ;
+                      rdfs:domain                [ rdf:type     owl:Class ;
+                                                   owl:unionOf  ( prov:Activity prov:Agent prov:Entity )
+                                   ] ;
+                      rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+                      rdfs:label                 "wasInfluencedBy" ;
+                      rdfs:range                 [ rdf:type     owl:Class ;
+                                                   owl:unionOf  ( prov:Activity prov:Agent prov:Entity )
+                                   ] ;
+                      rdfs:range                 [ rdf:type     owl:Class ;
+                                                   owl:unionOf  ( prov:Activity prov:Agent prov:Entity )
+                                   ] ;
+                      prov:category              "qualified" ;
+                      prov:component             "agents-responsibility" ;
+                      prov:editorialNote         "The sub-properties of prov:wasInfluencedBy can be elaborated in more detail using the Qualification Pattern. For example, the binary relation :baking prov:used :spoon can be qualified by asserting :baking prov:qualifiedUsage [ a prov:Usage; prov:entity :spoon; prov:atLocation :kitchen ] .\n\nSubproperties of prov:wasInfluencedBy may also be asserted directly without being qualified.\n\nprov:wasInfluencedBy should not be used without also using one of its subproperties. \n"@en ;
+                      prov:inverse               "influenced" ;
+                      prov:qualifiedForm         prov:Influence , prov:qualifiedInfluence ;
+                      prov:sharesDefinitionWith  prov:Influence .
+
+time:Thursday  rdf:type  time:DayOfWeek ;
+               rdfs:label      "Thursday"@en ;
+               skos:prefLabel  "Четверг"@ru , "الخميس"@ar , "Donnerstag"@de , "Czwartek"@pl , "Donderdag"@nl , "Jeudi"@fr , "Quinta-feira"@pt , "Jueves"@es , "星期四"@zh , "Thursday"@en , "木曜日"@ja , "Giovedì"@it .
+
+time:inXSDDateTime  rdf:type  owl:DeprecatedProperty , owl:DatatypeProperty ;
+                    rdfs:comment     "Posición de un instante, expresado utilizando xsd:dateTime."@es , "Position of an instant, expressed using xsd:dateTime"@en ;
+                    rdfs:domain      time:Instant ;
+                    rdfs:label       "en fecha-tiempo XSD"@es , "in XSD Date-Time"@en ;
+                    rdfs:range       xsd:dateTime ;
+                    owl:deprecated   true ;
+                    skos:definition  "Posición de un instante, expresado utilizando xsd:dateTime."@es , "Position of an instant, expressed using xsd:dateTime"@en ;
+                    skos:note        "La propiedad 'en fecha-hora XSD' ha sido reemplazada por 'en fecha-sello de tiempo XSD' que hace obligatorio el campo 'huso horario'."@es , "The property :inXSDDateTime is replaced by :inXSDDateTimeStamp which makes the time-zone field mandatory."@en .
+
+dcterms:LinguisticSystem
+  rdf:type             rdfs:Class ;
+  rdfs:comment         "A system of signs, symbols, sounds, gestures, or rules used in communication."@en ;
+  rdfs:isDefinedBy     dcterms: ;
+  rdfs:label           "Linguistic System"@en ;
+  dcterms:description  "Written, spoken, sign, and computer languages are linguistic systems."@en ;
+  dcterms:issued       "2008-01-14"^^xsd:date .
+
+spdx:ConjunctiveLicenseSet
+  rdf:type         owl:Class ;
+  rdfs:comment     "A ConjunctiveLicenseSet represents a set of licensing information all of which apply."@en ;
+  rdfs:subClassOf  spdx:AnyLicenseInfo , rdfs:Container ;
+  rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                     owl:minQualifiedCardinality  "2"^^xsd:nonNegativeInteger ;
+                     owl:onClass                  spdx:AnyLicenseInfo ;
+                     owl:onProperty               spdx:member
+                   ] ;
+  vs:term_status   "stable"@en .
+
+vcard:Label  rdf:type     owl:Class ;
+             rdfs:comment      "This class is deprecated"@en ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "Label"@en ;
+             rdfs:subClassOf   vcard:Type ;
+             owl:deprecated    true .
+
+vcard:logo  rdf:type            owl:ObjectProperty ;
+            rdfs:comment            "This object property has been mapped"@en ;
+            rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label              "logo"@en ;
+            owl:equivalentProperty  vcard:hasLogo .
+
+spdx:snippetName  rdf:type  owl:DatatypeProperty ;
+                  rdfs:comment        "Identify a specific snippet in a human convenient manner."@en ;
+                  rdfs:domain         spdx:Snippet ;
+                  rdfs:range          xsd:string ;
+                  rdfs:subPropertyOf  spdx:name ;
+                  vs:term_status      "stable"@en .
+
+spdx:relationshipType_exampleOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is an example of SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+dcat:downloadURL  rdf:type  owl:ObjectProperty , rdf:Property ;
+                  rdfs:comment        "URL til fil der kan downloades i et bestemt format. Fx en CSV-fil eller en RDF-fil. Formatet for distributionen angives ved hjælp af egenskaberne dct:format og/eller dcat:mediaType."@da , "The URL of the downloadable file in a given format. E.g. CSV file or RDF file. The format is indicated by the distribution's dct:format and/or dcat:mediaType."@en , "Ceci est un lien direct à un fichier téléchargeable en un format donnée. Exple fichier CSV ou RDF. Le format est décrit par les propriétés de distribution dct:format et/ou dcat:mediaType."@fr , "La URL de un archivo descargable en el formato dato. Por ejemplo, archivo CSV o archivo RDF. El formato se describe con las propiedades de la distribución dct:format y/o dcat:mediaType."@es , "Questo è un link diretto al file scaricabile in un dato formato. E.g. un file CSV o un file RDF. Il formato è descritto dal dct:format e/o dal dcat:mediaType della distribuzione."@it , "URL souboru ke stažení v daném formátu, například CSV nebo RDF soubor. Formát je popsán vlastností distribuce dct:format a/nebo dcat:mediaType."@cs , "dcat:downloadURLはdcat:accessURLの特定の形式です。しかし、DCATプロファイルが非ダウンロード・ロケーションに対してのみaccessURLを用いる場合には、より強い分離を課すことを望む可能性があるため、この含意を強化しないように、DCATは、dcat:downloadURLをdcat:accessURLのサブプロパティーであると定義しません。"@ja , "Είναι ένας σύνδεσμος άμεσης μεταφόρτωσης ενός αρχείου σε μια δεδομένη μορφή. Π.χ. ένα αρχείο CSV ή RDF. Η μορφη αρχείου περιγράφεται από τις ιδιότητες dct:format ή/και dcat:mediaType της διανομής."@el , "رابط مباشر لملف يمكن تحميله. نوع الملف يتم توصيفه باستخدام الخاصية dct:format dcat:mediaType "@ar ;
+                  rdfs:domain         dcat:Distribution ;
+                  rdfs:isDefinedBy    <http://www.w3.org/TR/vocab-dcat/> ;
+                  rdfs:label          "downloadURL"@da , "URL de descarga"@es , "رابط تحميل"@ar , "ダウンロードURL"@ja , "URL di scarico"@it , "download URL"@en , "URL souboru ke stažení"@cs , "URL μεταφόρτωσης"@el , "URL de téléchargement"@fr ;
+                  rdfs:range          rdfs:Resource ;
+                  skos:definition     "Ceci est un lien direct à un fichier téléchargeable en un format donnée. Exple fichier CSV ou RDF. Le format est décrit par les propriétés de distribution dct:format et/ou dcat:mediaType."@fr , "dcat:downloadURLはdcat:accessURLの特定の形式です。しかし、DCATプロファイルが非ダウンロード・ロケーションに対してのみaccessURLを用いる場合には、より強い分離を課すことを望む可能性があるため、この含意を強化しないように、DCATは、dcat:downloadURLをdcat:accessURLのサブプロパティーであると定義しません。"@ja , "Questo è un link diretto al file scaricabile in un dato formato. E.g. un file CSV o un file RDF. Il formato è descritto dal dct:format e/o dal dcat:mediaType della distribuzione."@it , "The URL of the downloadable file in a given format. E.g. CSV file or RDF file. The format is indicated by the distribution's dct:format and/or dcat:mediaType."@en , "رابط مباشر لملف يمكن تحميله. نوع الملف يتم توصيفه باستخدام الخاصية dct:format dcat:mediaType "@ar , "URL souboru ke stažení v daném formátu, například CSV nebo RDF soubor. Formát je popsán vlastností distribuce dct:format a/nebo dcat:mediaType."@cs , "Είναι ένας σύνδεσμος άμεσης μεταφόρτωσης ενός αρχείου σε μια δεδομένη μορφή. Π.χ. ένα αρχείο CSV ή RDF. Η μορφη αρχείου περιγράφεται από τις ιδιότητες dct:format ή/και dcat:mediaType της διανομής."@el , "URL til fil der kan downloades i et bestemt format. Fx en CSV-fil eller en RDF-fil. Formatet for distributionen angives ved hjælp af egenskaberne dct:format og/eller dcat:mediaType."@da , "La URL de un archivo descargable en el formato dato. Por ejemplo, archivo CSV o archivo RDF. El formato se describe con las propiedades de la distribución dct:format y/o dcat:mediaType."@es ;
+                  skos:editorialNote  "Status: English  Definition text modified by DCAT revision team, Italian, Spanish and Czech translation updated, other translations pending."@en , "rdfs:label, rdfs:comment and/or skos:scopeNote have been modified. Non-english versions must be updated."@en ;
+                  skos:scopeNote      "La valeur est une URL."@fr , "dcat:downloadURL SHOULD be used for the address at which this distribution is available directly, typically through a HTTP Get request."@en , "dcat:downloadURL BY MĚLA být použita pro adresu, ze které je distribuce přímo přístupná, typicky skrze požadavek HTTP Get."@cs , "dcat:downloadURL DOVREBBE essere utilizzato per l'indirizzo a cui questa distribuzione è disponibile direttamente, in genere attraverso una richiesta Get HTTP."@it , "El valor es una URL."@es , "dcat:downloadURL BØR anvendes til angivelse af den adresse hvor distributionen er tilgængelig direkte, typisk gennem et HTTP Get request."@da , "Η τιμή είναι ένα URL."@el .
+
+spdx:referenceType  rdf:type  owl:ObjectProperty ;
+                    rdfs:comment    "Type of the external reference. These are definined in an appendix in the SPDX specification."@en ;
+                    rdfs:domain     spdx:ExternalRef ;
+                    rdfs:range      spdx:ReferenceType ;
+                    vs:term_status  "stable"@en .
+
+adms:translation  rdf:type  owl:ObjectProperty ;
+                  rdfs:comment      "Links Assets that are translations of each other."@en ;
+                  rdfs:domain       rdfs:Resource ;
+                  rdfs:isDefinedBy  <http://www.w3.org/ns/adms> ;
+                  rdfs:label        "translation"@en ;
+                  rdfs:range        rdfs:Resource .
+
+vcard:tel  rdf:type             owl:ObjectProperty ;
+           rdfs:comment            "This object property has been mapped"@en ;
+           rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label              "telephone"@en ;
+           owl:equivalentProperty  vcard:hasTelephone .
+
+spdx:referenceCategory_packageManager
+  rdf:type        owl:NamedIndividual , spdx:ReferenceCategory ;
+  vs:term_status  "stable"@en .
+
+spdx:RelationshipType
+  rdf:type        owl:Class ;
+  rdfs:comment    "Type of relationship."@en ;
+  vs:term_status  "stable"@en .
+
+vcard:hasRole  rdf:type   owl:ObjectProperty ;
+               rdfs:comment      "Used to support property parameters for the role data property"@en ;
+               rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+               rdfs:label        "has role"@en .
+
+dcterms:relation  rdf:type   rdf:Property ;
+                  rdfs:comment         "A related resource."@en ;
+                  rdfs:isDefinedBy     dcterms: ;
+                  rdfs:label           "Relation"@en ;
+                  rdfs:subPropertyOf   dc:relation ;
+                  dcterms:description  "Recommended practice is to identify the related resource by means of a URI.  If this is not possible or feasible, a string conforming to a formal identification system may be provided."@en ;
+                  dcterms:issued       "2008-01-14"^^xsd:date .
+
+dcat:landingPage  rdf:type  owl:ObjectProperty , rdf:Property ;
+                  rdfs:comment        "Una página web que puede ser visitada en un explorador Web para tener acceso el catálogo, un conjunto de datos, sus distribuciones y/o información adicional."@es , "A Web page that can be navigated to in a Web browser to gain access to the catalog, a dataset, its distributions and/or additional information."@en , "Μία ιστοσελίδα πλοηγίσιμη μέσω ενός φυλλομετρητή (Web browser) που δίνει πρόσβαση στο σύνολο δεδομένων, τις διανομές αυτού ή/και επιπρόσθετες πληροφορίες."@el , "Una pagina web che può essere navigata per ottenere l'accesso al catalogo, ad un dataset, alle distribuzioni del dataset e/o ad informazioni addizionali."@it , "データセット、その配信および（または）追加情報にアクセスするためにウエブ・ブラウザでナビゲートできるウェブページ。"@ja , "صفحة وب يمكن من خلالها الوصول الى قائمة البيانات أو إلى معلومات إضافية متعلقة بها "@ar , "En webside som der kan navigeres til i en webbrowser for at få adgang til kataloget, et datasæt, dets distributioner og/eller yderligere information."@da , "Webová stránka, na kterou lze pro získání přístupu ke katalogu, datové sadě, jejím distribucím a/nebo dalším informacím přistoupit webovým prohlížečem."@cs , "Une page Web accessible par un navigateur Web donnant accès au catalogue, un jeu de données, ses distributions et/ou des informations additionnelles."@fr ;
+                  rdfs:isDefinedBy    <http://www.w3.org/TR/vocab-dcat/> ;
+                  rdfs:label          "página de destino"@es , "landing page"@en , "vstupní stránka"@cs , "destinationsside"@da , "ランディング・ページ"@ja , "page d'atterrissage"@fr , "صفحة وصول"@ar , "pagina di destinazione"@it , "ιστοσελίδα αρχικής πρόσβασης"@el ;
+                  rdfs:range          foaf:Document ;
+                  rdfs:subPropertyOf  foaf:page ;
+                  skos:definition     "Una pagina web che può essere navigata per ottenere l'accesso al catalogo, ad un dataset, alle distribuzioni del dataset e/o ad informazioni addizionali."@it , "A Web page that can be navigated to in a Web browser to gain access to the catalog, a dataset, its distributions and/or additional information."@en , "Una página web que puede ser visitada en un explorador Web para tener acceso el catálogo, un conjunto de datos, sus distribuciones y/o información adicional."@es , "صفحة وب يمكن من خلالها الوصول الى قائمة البيانات أو إلى معلومات إضافية متعلقة بها "@ar , "En webside som en webbrowser kan navigeres til for at få adgang til kataloget, et datasæt, dets distritbutioner og/eller yderligere information."@da , "Webová stránka, na kterou lze pro získání přístupu ke katalogu, datové sadě, jejím distribucím a/nebo dalším informacím přistoupit webovým prohlížečem."@cs , "Μία ιστοσελίδα πλοηγίσιμη μέσω ενός φυλλομετρητή (Web browser) που δίνει πρόσβαση στο σύνολο δεδομένων, τις διανομές αυτού ή/και επιπρόσθετες πληροφορίες."@el , "Une page Web accessible par un navigateur Web donnant accès au catalogue, un jeu de données, ses distributions et/ou des informations additionnelles."@fr , "データセット、その配信および（または）追加情報にアクセスするためにウエブ・ブラウザでナビゲートできるウェブページ。"@ja ;
+                  skos:scopeNote      "Hvis en eller flere distributioner kun er tilgængelige via en destinationsside (dvs. en URL til direkte download er ikke kendt), så bør destinationssidelinket gentages som adgangsadresse for en distribution."@da , "Si la distribución es accesible solamente través de una página de aterrizaje (i.e., no se conoce una URL de descarga directa), entonces el enlance a la página de aterrizaje debe ser duplicado como accessURL sobre la distribución."@es , "ランディング・ページを通じてしか配信にアクセスできない場合（つまり、直接的なダウンロードURLが不明）には、配信におけるaccessURLとしてランディング・ページのリンクをコピーすべきです（SHOULD）。"@ja , "If the distribution(s) are accessible only through a landing page (i.e. direct download URLs are not known), then the landing page link should be duplicated as accessURL on a distribution."@en , "Αν η/οι διανομή/ές είναι προσβάσιμη/ες μόνο μέσω μίας ιστοσελίδας αρχικής πρόσβασης (δηλαδή αν δεν υπάρχουν γνωστές διευθύνσεις άμεσης μεταφόρτωσης), τότε ο σύνδεσμος της ιστοσελίδας αρχικής πρόσβασης πρέπει να αναπαραχθεί ως accessURL σε μία διανομή."@el , "Pokud je distribuce dostupná pouze přes vstupní stránku, t.j. přímý URL odkaz ke stažení není znám, URL přístupové stránky by mělo být duplikováno ve vlastnosti distribuce accessURL."@cs , "Se la distribuzione è accessibile solo attraverso una pagina di destinazione (cioè, un URL di download diretto non è noto), il link alla pagina di destinazione deve essere duplicato come accessURL sulla distribuzione."@it , "Si la distribution est seulement accessible à travers une page d'atterrissage (exple. pas de connaissance d'URLS de téléchargement direct ), alors le lien de la page d'atterrissage doit être dupliqué comme accessURL sur la distribution."@fr .
+
+dcterms:RFC1766  rdf:type  rdfs:Datatype ;
+                 rdfs:comment      "The set of tags, constructed according to RFC 1766, for the identification of languages."@en ;
+                 rdfs:isDefinedBy  dcterms: ;
+                 rdfs:label        "RFC 1766"@en ;
+                 rdfs:seeAlso      <http://www.ietf.org/rfc/rfc1766.txt> ;
+                 dcterms:issued    "2000-07-11"^^xsd:date .
+
+dcat:Role  rdf:type         owl:Class ;
+           rdfs:comment        "Role je funkce zdroje či agenta ve vztahu k jinému zdroji, v kontextu přiřazení zdrojů či vztahů mezi zdroji."@cs , "A role is the function of a resource or agent with respect to another resource, in the context of resource attribution or resource relationships."@en , "Un rol es la función de un recurso o agente con respecto a otro recuros, en el contexto de atribución del recurso o de las relaciones entre recursos."@es , "En rolle er den funktion en ressource eller aktør har i forhold til en anden ressource, i forbindelse med ressourcekreditering eller ressourcerelationer."@da , "Un ruolo è la funzione di una risorsa o di un agente rispetto ad un'altra risorsa, nel contesto dell'attribuzione delle risorse o delle relazioni tra risorse."@it ;
+           rdfs:label          "Rolle"@da , "Rol"@es , "Ruolo"@it , "Role"@cs , "Role"@en ;
+           rdfs:seeAlso        dcat:hadRole ;
+           rdfs:subClassOf     skos:Concept ;
+           skos:changeNote     "Nuova classe aggiunta in DCAT 2.0."@it , "Nueva clase agregada en DCAT 2.0."@es , "Ny klasse tilføjet i DCAT 2.0."@en , "Nová třída přidaná ve verzi DCAT 2.0."@cs , "New class added in DCAT 2.0."@en ;
+           skos:definition     "Role je funkce zdroje či agenta ve vztahu k jinému zdroji, v kontextu přiřazení zdrojů či vztahů mezi zdroji."@cs , "A role is the function of a resource or agent with respect to another resource, in the context of resource attribution or resource relationships."@en , "Un ruolo è la funzione di una risorsa o di un agente rispetto ad un'altra risorsa, nel contesto dell'attribuzione delle risorse o delle relazioni tra risorse."@it , "Un rol es la función de un recurso o agente con respecto a otro recuros, en el contexto de atribución del recurso o de las relaciones entre recursos."@es , "En rolle er den funktion en ressource eller aktør har i forhold til en anden ressource, i forbindelse med ressourcekreditering eller ressourcerelationer."@da ;
+           skos:editorialNote  "Introduced into DCAT to complement prov:Role (whose use is limited to roles in the context of an activity, as the range of prov:hadRole)."@en , "Introduceret i DCAT for at supplere prov:Role (hvis anvendelse er begrænset til roller i forbindelse med en aktivitet, som er rækkevidde for prov:hadRole)."@da , "Přidáno do DCAT pro doplnění třídy prov:Role (jejíž užití je omezeno na role v kontextu aktivit, jakožto obor hodnot vlastnosti prov:hadRole)."@cs , "Introdotta in DCAT per completare prov:Role (il cui uso è limitato ai ruoli nel contesto di un'attività, in conseguenza alla definizione del codominio di prov:hadRole)."@it , "Incluída en DCAT para complementar prov:Role (cuyo uso está limitado a roles en el contexto de una actividad, ya que es el rango es prov:hadRole)."@es ;
+           skos:scopeNote      "Se usa en una relación cualificada para especificar el rol de una Entidad con respecto a otra Entidad. Se recomienda que los valores se administren como los valores de un vocabulario controlado de roles de entidad como por ejemplo: ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode; IANA Registry of Link Relations https://www.iana.org/assignments/link-relation; el esquema de metadatos de DataCite; MARC relators https://id.loc.gov/vocabulary/relators."@es , "Used in a qualified-attribution to specify the role of an Agent with respect to an Entity. It is recommended that the values be managed as a controlled vocabulary of agent roles, such as http://registry.it.csiro.au/def/isotc211/CI_RoleCode."@en , "Anvendes i forbindelse med kvalificerede krediteringer til at angive aktørens rolle i forhold til en entitet. Det anbefales at værdierne styres som et kontrolleret udfaldsrum med aktørroller, såsom http://registry.it.csiro.au/def/isotc211/CI_RoleCode."@da , "Used in a qualified-relation to specify the role of an Entity with respect to another Entity. It is recommended that the values be managed as a controlled vocabulary of entity roles such as: ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode; IANA Registry of Link Relations https://www.iana.org/assignments/link-relation;  DataCite metadata schema;  MARC relators https://id.loc.gov/vocabulary/relators."@en , "Použito v kvalifikovaném přiřazení pro specifikaci role Agenta ve vztahu k Entitě. Je doporučeno množinu hodnot spravovat jako řízený slovník rolí agentů, jako například http://registry.it.csiro.au/def/isotc211/CI_RoleCode."@cs , "Se usa en una atribución cualificada para especificar el rol de un Agente con respecto a una Entidad. Se recomienda que los valores se administren como un vocabulario controlado de roles de agente, como por ejemplo http://registry.it.csiro.au/def/isotc211/CI_RoleCode."@es , "Utilizzato in un'attribuzione qualificata per specificare il ruolo di un agente rispetto a un'entità. Si consiglia di attribuire i valori considerando un vocabolario controllato dei ruoli dell'agente, ad esempio http://registry.it.csiro.au/def/isotc211/CI_RoleCode."@it , "Utilizzato in una relazione qualificata per specificare il ruolo di un'entità rispetto a un'altra entità. Si raccomanda che il valore sia preso da un vocabolario controllato di ruoli di entità come ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode, IANA Registry of Link Relations https://www.iana.org/assignments/link-relation, DataCite metadata schema, o MARC relators https://id.loc.gov/vocabulary/relators."@it , "Anvendes i forbindelse med kvalificerede relationer til at specificere en entitets rolle i forhold til en anden entitet. Det anbefales at værdierne styres med et kontrolleret udfaldsrum for for entitetsroller såsom: ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode; IANA Registry of Link Relations https://www.iana.org/assignments/link-relation;  DataCite metadata schema;  MARC relators https://id.loc.gov/vocabulary/relators."@da , "Použito v kvalifikovaném vztahu pro specifikaci role Entity ve vztahu k jiné Entitě. Je doporučeno množinu hodnot spravovat jako řízený slovník rolí entit, jako například ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode, IANA Registry of Link Relations https://www.iana.org/assignments/link-relation, DataCite metadata schema, či MARC relators https://id.loc.gov/vocabulary/relators."@cs .
+
+dcterms:available  rdf:type  rdf:Property ;
+                   rdfs:comment         "Date that the resource became or will become available."@en ;
+                   rdfs:isDefinedBy     dcterms: ;
+                   rdfs:label           "Date Available"@en ;
+                   rdfs:range           rdfs:Literal ;
+                   rdfs:subPropertyOf   dc:date , dcterms:date ;
+                   dcterms:description  "Recommended practice is to describe the date, date/time, or period of time as recommended for the property Date, of which this is a subproperty."@en ;
+                   dcterms:issued       "2000-07-11"^^xsd:date .
+
+time:hours  rdf:type     owl:DatatypeProperty ;
+            rdfs:comment     "length of, or element of the length of, a temporal extent expressed in hours"@en , "Longitud de, o elemento de la longitud de, una extensión temporal expresada en horas."@es ;
+            rdfs:domain      time:GeneralDurationDescription ;
+            rdfs:label       "hours duration"@en , "duración en horas"@es ;
+            rdfs:range       xsd:decimal ;
+            skos:definition  "length of, or element of the length of, a temporal extent expressed in hours"@en , "Longitud de, o elemento de la longitud de, una extensión temporal expresada en horas."@es .
+
+spdx:checksumAlgorithm_md5
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was MD5"@en ;
+  vs:term_status  "stable"@en .
+
+spdx:member  rdf:type   owl:ObjectProperty ;
+             rdfs:comment    "A license, or other licensing information, that is a member of the subject license set."@en ;
+             rdfs:domain     [ rdf:type     owl:Class ;
+                               owl:unionOf  ( spdx:ConjunctiveLicenseSet spdx:DisjunctiveLicenseSet spdx:WithExceptionOperator )
+                        ] ;
+             rdfs:range      spdx:AnyLicenseInfo ;
+             vs:term_status  "stable"@en .
+
+spdx:checksumAlgorithm_blake3
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was BLAKE3."@en ;
+  vs:term_status  "stable"@en .
+
+doap:homepage  rdf:type  owl:DatatypeProperty ;
+               rdfs:domain     spdx:Package ;
+               rdfs:range      xsd:anyURI ;
+               vs:term_status  "stable"@en .
+
+time:TemporalEntity  rdf:type  owl:Class ;
+                     rdfs:comment     "A temporal interval or instant."@en , "Un intervalo temporal o un instante."@es ;
+                     rdfs:label       "Temporal entity"@en , "entidad temporal"@es ;
+                     rdfs:subClassOf  owl:Thing ;
+                     owl:unionOf      ( time:Instant time:Interval ) ;
+                     skos:definition  "A temporal interval or instant."@en , "Un intervalo temporal o un instante."@es .
+
+vcard:Spouse  rdf:type    owl:Class ;
+              rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+              rdfs:label        "Spouse"@en ;
+              rdfs:subClassOf   vcard:RelatedType .
+
+spdx:validUntilDate  rdf:type  owl:DatatypeProperty ;
+                     rdfs:comment        "This field provides a place for recording the end of the support period for a package from the supplier."@en ;
+                     rdfs:domain         spdx:Package ;
+                     rdfs:range          xsd:dateTime ;
+                     rdfs:subPropertyOf  spdx:date ;
+                     vs:term_status      "stable"@en .
+
+time:minute  rdf:type    owl:DatatypeProperty ;
+             rdfs:comment     "Minute position in a calendar-clock system."@en , "Posición de minuto en un sistema calendario-reloj."@es ;
+             rdfs:domain      time:GeneralDateTimeDescription ;
+             rdfs:label       "minute"@en , "minuto"@es ;
+             rdfs:range       xsd:nonNegativeInteger ;
+             skos:definition  "Minute position in a calendar-clock system."@en , "Posición de minuto en un sistema calendario-reloj."@es .
+
+spdx:isLive  rdf:type  owl:DatatypeProperty ;
+             rdfs:comment  "Indicate a URL is still a live accessible location on the public internet"@en ;
+             rdfs:domain   spdx:CrossRef ;
+             rdfs:range    xsd:boolean .
+
+dcterms:educationLevel
+  rdf:type            rdf:Property ;
+  rdfs:comment        "A class of agents, defined in terms of progression through an educational or training context, for which the described resource is intended."@en ;
+  rdfs:isDefinedBy    dcterms: ;
+  rdfs:label          "Audience Education Level"@en ;
+  rdfs:subPropertyOf  dcterms:audience ;
+  dcam:rangeIncludes  dcterms:AgentClass ;
+  dcterms:issued      "2002-07-13"^^xsd:date .
+
+vcard:key  rdf:type             owl:ObjectProperty ;
+           rdfs:comment            "This object property has been mapped"@en ;
+           rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label              "key"@en ;
+           owl:equivalentProperty  vcard:hasKey .
+
+skos:prefLabel  rdf:type    owl:AnnotationProperty , rdf:Property ;
+                rdfs:comment        "A resource has no more than one value of skos:prefLabel per language tag, and no more than one value of skos:prefLabel without language tag."@en , "The range of skos:prefLabel is the class of RDF plain literals."@en , "skos:prefLabel, skos:altLabel and skos:hiddenLabel are pairwise\n      disjoint properties."@en ;
+                rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+                rdfs:label          "preferred label"@en ;
+                rdfs:subPropertyOf  rdfs:label ;
+                skos:definition     "The preferred lexical label for a resource, in a given language."@en .
+
+dcterms:valid  rdf:type      rdf:Property ;
+               rdfs:comment         "Date (often a range) of validity of a resource."@en ;
+               rdfs:isDefinedBy     dcterms: ;
+               rdfs:label           "Date Valid"@en ;
+               rdfs:range           rdfs:Literal ;
+               rdfs:subPropertyOf   dc:date , dcterms:date ;
+               dcterms:description  "Recommended practice is to describe the date, date/time, or period of time as recommended for the property Date, of which this is a subproperty."@en ;
+               dcterms:issued       "2000-07-11"^^xsd:date .
+
+vcard:hasGender  rdf:type  owl:ObjectProperty ;
+                 rdfs:comment      "To specify  the sex or gender identity of the object. URIs are recommended to enable interoperable sex and gender codes to be used."@en ;
+                 rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                 rdfs:label        "has gender"@en .
+
+vcard:Individual  rdf:type  owl:Class ;
+                  rdfs:comment      "An object representing a single person or entity"@en ;
+                  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                  rdfs:label        "Individual"@en ;
+                  rdfs:subClassOf   vcard:Kind ;
+                  owl:disjointWith  vcard:Location , vcard:Organization .
+
+dcterms:DDC  rdf:type     dcam:VocabularyEncodingScheme ;
+             rdfs:comment      "The set of conceptual resources specified by the Dewey Decimal Classification."@en ;
+             rdfs:isDefinedBy  dcterms: ;
+             rdfs:label        "DDC"@en ;
+             rdfs:seeAlso      <http://www.oclc.org/dewey/> ;
+             dcterms:issued    "2000-07-11"^^xsd:date .
+
+spdx:standardLicenseHeaderTemplate
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "License template which describes sections of the license header which can be varied. See License Template section of the specification for format information."@en ;
+  rdfs:domain     spdx:License ;
+  rdfs:range      xsd:string ;
+  vs:term_status  "stable"@en .
+
+vcard:label  rdf:type     owl:DatatypeProperty ;
+             rdfs:comment      "This data property has been deprecated"@en ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "label"@en ;
+             owl:deprecated    true .
+
+vcard:Muse  rdf:type      owl:Class ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "Muse"@en ;
+            rdfs:subClassOf   vcard:RelatedType .
+
+vcard:Email  rdf:type     owl:Class ;
+             rdfs:comment      "To specify the electronic mail address for communication with the object the vCard represents. Use the hasEmail object property."@en ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "Email"@en ;
+             owl:deprecated    true .
+
+[ rdf:type               owl:Axiom ;
+  rdfs:comment           "Revision is a derivation (see http://www.w3.org/TR/prov-dm/#term-Revision). Moreover, according to \nhttp://www.w3.org/TR/2013/REC-prov-constraints-20130430/#term-Revision 23 April 2012 'wasRevisionOf is a strict sub-relation of wasDerivedFrom since two entities e2 and e1 may satisfy wasDerivedFrom(e2,e1) without being a variant of each other.'" ;
+  owl:annotatedProperty  rdfs:subPropertyOf ;
+  owl:annotatedSource    prov:wasRevisionOf ;
+  owl:annotatedTarget    prov:wasDerivedFrom
+] .
+
+spdx:packageVerificationCode
+  rdf:type        owl:ObjectProperty ;
+  rdfs:comment    "A manifest based verification code (the algorithm is defined in section 3.9.4 of the full specification) of the package. This allows consumers of this data and/or database to determine if a package they have in hand is identical to the package from which the data was produced. This algorithm works even if the SPDX document is included in the package."@en ;
+  rdfs:domain     spdx:Package ;
+  rdfs:range      spdx:PackageVerificationCode ;
+  vs:term_status  "stable"@en .
+
+locn:adminUnitL1  rdf:type  rdf:Property ;
+                  rdfs:comment        "The uppermost administrative unit for the address, almost always a country. The domain of locn:adminUnitL1 is locn:Address and the range is a literal, conceptually defined by the INSPIRE Geographical Name data type."@en ;
+                  rdfs:domain         locn:Address ;
+                  rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+                  rdfs:label          "admin unit level 1"@en ;
+                  dcterms:identifier  "locn:adminUnitL1" ;
+                  vann:usageNote      "Best practice is to use the ISO 3166-1 code but if this is inappropriate for the context, country names should be provided in a consistent manner to reduce ambiguity. For example, either write 'United Kingdom' or 'UK' consistently throughout the data set and avoid mixing the two."@en ;
+                  vs:term_status      "testing"@en .
+
+dcat:Dataset  rdf:type      rdfs:Class , owl:Class ;
+              rdfs:comment        "1つのエージェントによって公開またはキュレートされ、1つ以上の形式でアクセスまたはダウンロードできるデータの集合。"@ja , "Raccolta di dati, pubblicati o curati da un'unica fonte, disponibili per l'accesso o il download in uno o più formati."@it , "Μία συλλογή από δεδομένα, δημοσιευμένη ή επιμελημένη από μία και μόνο πηγή, διαθέσιμη δε προς πρόσβαση ή μεταφόρτωση σε μία ή περισσότερες μορφές."@el , "قائمة بيانات منشورة أو مجموعة من قبل مصدر ما و متاح الوصول إليها أو تحميلها"@ar , "A collection of data, published or curated by a single source, and available for access or download in one or more representations."@en , "Une collection de données, publiée ou élaborée par une seule source, et disponible pour accès ou téléchargement dans un ou plusieurs formats."@fr , "Kolekce dat poskytovaná či řízená jedním zdrojem, která je k dispozici pro přístup či stažení v jednom či více formátech."@cs , "Una colección de datos, publicados o conservados por una única fuente, y disponibles para ser accedidos o descargados en uno o más formatos."@es , "En samling af data, udgivet eller udvalgt og arrangeret af en enkelt kilde og som er til råde for adgang til eller download af i en eller flere repræsentationer."@da ;
+              rdfs:isDefinedBy    <http://www.w3.org/TR/vocab-dcat/> ;
+              rdfs:label          "データセット"@ja , "Dataset"@en , "Dataset"@it , "قائمة بيانات"@ar , "Conjunto de datos"@es , "Σύνολο Δεδομένων"@el , "Jeu de données"@fr , "Datová sada"@cs , "Datasæt"@da ;
+              rdfs:subClassOf     dcat:Resource ;
+              skos:altLabel       "Datasamling"@da ;
+              skos:changeNote     "2018-02 - subklasse af dctype:Dataset fjernet da scope af dcat:Dataset omfatter flere forskellige typer fra dctype-vokabularet."@da , "2018-02 - odstraněno tvrzení o podtřídě dctype:Dataset, jelikož rozsah dcat:Dataset zahrnuje několik dalších typů ze slovníku dctype."@cs , "2018-02 - subclass of dctype:Dataset removed because scope of dcat:Dataset includes several other types from the dctype vocabulary."@en , "2018-02 - se eliminó el axioma de subclase con dctype:Dataset porque el alcance de dcat:Dataset incluye muchos otros tipos del vocabulario dctype."@es , "2018-02 - sottoclasse di dctype:Dataset rimosso perché l'ambito di dcat:Dataset include diversi altri tipi dal vocabolario dctype."@it ;
+              skos:definition     "Une collection de données, publiée ou élaborée par une seule source, et disponible pour accès ou téléchargement dans un ou plusieurs formats."@fr , "قائمة بيانات منشورة أو مجموعة من قبل مصدر ما و متاح الوصول إليها أو تحميلها"@ar , "Una colección de datos, publicados o conservados por una única fuente, y disponibles para ser accedidos o descargados en uno o más formatos."@es , "Raccolta di dati, pubblicati o curati da un'unica fonte, disponibili per l'accesso o il download in uno o più formati."@it , "Kolekce dat poskytovaná či řízená jedním zdrojem, která je k dispozici pro přístup či stažení v jednom či více formátech."@cs , "En samling a data, udgivet eller udvalgt og arrangeret af en enkelt kilde og som der er adgang til i en eller flere repræsentationer."@da , "1つのエージェントによって公開またはキュレートされ、1つ以上の形式でアクセスまたはダウンロードできるデータの集合。"@ja , "Μία συλλογή από δεδομένα, δημοσιευμένη ή επιμελημένη από μία και μόνο πηγή, διαθέσιμη δε προς πρόσβαση ή μεταφόρτωση σε μία ή περισσότερες μορφές."@el , "A collection of data, published or curated by a single source, and available for access or download in one or more represenations."@en ;
+              skos:editorialNote  "2020-03-16 A new scopenote added and need to be translated"@en ;
+              skos:scopeNote      "Questa classe rappresenta il dataset come pubblicato dall’editore. Nel caso in cui sia necessario operare  una distinzione fra i metadati originali del dataset e il record dei metadati ad esso associato nel catalogo (ad esempio, per distinguere la data di modifica del dataset da quella del dataset nel catalogo) si può impiegare la classe catalog record."@it , "Cette classe représente le jeu de données publié par le fournisseur de données. Dans les cas où une distinction est nécessaire entre le jeu de donénes et son entrée dans le catalogue, la classe registre de données peut être utilisée pour ce dernier."@fr , "Esta clase representa el conjunto de datos publicados. En los casos donde es necesario distinguir entre el conjunto de datos y su entrada en el catálogo de datos, se debe utilizar la clase 'registro del catálogo'."@es , "Η κλάση αυτή αναπαριστά το σύνολο δεδομένων αυτό καθ'εαυτό, όπως έχει δημοσιευθεί από τον εκδότη. Σε περιπτώσεις όπου είναι απαραίτητος ο διαχωρισμός μεταξύ του συνόλου δεδομένων και της καταγραφής αυτού στον κατάλογο (γιατί μεταδεδομένα όπως η ημερομηνία αλλαγής και ο συντηρητής μπορεί να διαφέρουν) η κλάση της καταγραφής καταλόγου μπορεί να χρησιμοποιηθεί για το τελευταίο."@el , "This class represents the actual dataset as published by the dataset provider. In cases where a distinction between the actual dataset and its entry in the catalog is necessary (because metadata such as modification date and maintainer might differ), the catalog record class can be used for the latter."@en , "Tato třída reprezentuje datovou sadu tak, jak je publikována poskytovatelem dat. V případě potřeby rozlišení datové sady a jejího katalogizačního záznamu (jelikož metadata jako datum modifikace se mohou lišit) pro něj může být použita třída \"katalogizační záznam\"."@cs , "Questa classe descrive il dataset dal punto di vista concettuale. Possono essere disponibili una o più rappresentazioni, con diversi layout e formati schematici o serializzazioni."@it , "This class describes the conceptual dataset. One or more representations might be available, with differing schematic layouts and formats or serializations."@en , "このクラスは、データセットの公開者が公開する実際のデータセットを表わします。カタログ内の実際のデータセットとそのエントリーとの区別が必要な場合（修正日と維持者などのメタデータが異なるかもしれないので）は、後者にcatalog recordというクラスを使用できます。"@ja , "The notion of dataset in DCAT is broad and inclusive, with the intention of accommodating resource types arising from all communities. Data comes in many forms including numbers, text, pixels, imagery, sound and other multi-media, and potentially other types, any of which might be collected into a dataset."@en , "Denne klasse beskriver det konceptuelle datasæt. En eller flere repræsentationer kan være tilgængelige med forskellige skematiske opsætninger, formater eller serialiseringer."@da , "Denne klasse repræsenterer det konkrete datasæt som det udgives af datasætleverandøren. I de tilfælde hvor det er nødvendigt at skelne mellem det konkrete datasæt og dets registrering i kataloget (fordi metadata såsom ændringsdato og vedligeholder er forskellige), så kan klassen katalogpost anvendes. "@da .
+
+dcterms:description  rdf:type  rdf:Property ;
+                     rdfs:comment         "An account of the resource."@en ;
+                     rdfs:isDefinedBy     dcterms: ;
+                     rdfs:label           "Description"@en ;
+                     rdfs:subPropertyOf   dc:description ;
+                     dcterms:description  "Description may include but is not limited to: an abstract, a table of contents, a graphical representation, or a free-text account of the resource."@en ;
+                     dcterms:issued       "2008-01-14"^^xsd:date .
+
+vcard:Contact  rdf:type   owl:Class ;
+               rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+               rdfs:label        "Contact"@en ;
+               rdfs:subClassOf   vcard:RelatedType .
+
+dcterms:issued  rdf:type     rdf:Property ;
+                rdfs:comment         "Date of formal issuance of the resource."@en ;
+                rdfs:isDefinedBy     dcterms: ;
+                rdfs:label           "Date Issued"@en ;
+                rdfs:range           rdfs:Literal ;
+                rdfs:subPropertyOf   dc:date , dcterms:date ;
+                dcterms:description  "Recommended practice is to describe the date, date/time, or period of time as recommended for the property Date, of which this is a subproperty."@en ;
+                dcterms:issued       "2000-07-11"^^xsd:date .
+
+[ rdf:type               owl:Axiom ;
+  owl:annotatedProperty  rdfs:domain ;
+  owl:annotatedSource    prov:wasInfluencedBy ;
+  owl:annotatedTarget    [ rdf:type     owl:Class ;
+                           owl:unionOf  ( prov:Activity prov:Agent prov:Entity )
+                         ] ;
+  prov:definition        "influencee: an identifier (o2) for an entity, activity, or agent; " ;
+  prov:dm                "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence"
+] .
+
+skos:mappingRelation  rdf:type  owl:ObjectProperty , rdf:Property ;
+                      rdfs:comment        "These concept mapping relations mirror semantic relations, and the data model defined below is similar (with the exception of skos:exactMatch) to the data model defined for semantic relations. A distinct vocabulary is provided for concept mapping relations, to provide a convenient way to differentiate links within a concept scheme from links between concept schemes. However, this pattern of usage is not a formal requirement of the SKOS data model, and relies on informal definitions of best practice."@en ;
+                      rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+                      rdfs:label          "is in mapping relation with"@en ;
+                      rdfs:subPropertyOf  skos:semanticRelation ;
+                      skos:definition     "Relates two concepts coming, by convention, from different schemes, and that have comparable meanings"@en .
+
+vcard:title  rdf:type     owl:DatatypeProperty ;
+             rdfs:comment      "To specify the position or job of the object"@en ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "title"@en ;
+             rdfs:range        xsd:string .
+
+vcard:organization-unit
+  rdf:type            owl:DatatypeProperty ;
+  rdfs:comment        "To specify the organizational unit name associated with the object"@en ;
+  rdfs:isDefinedBy    <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label          "organizational unit name"@en ;
+  rdfs:range          xsd:string ;
+  rdfs:subPropertyOf  vcard:organization-name .
+
+vcard:hasEmail  rdf:type  owl:ObjectProperty ;
+                rdfs:comment      "To specify the electronic mail address for communication with the object"@en ;
+                rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                rdfs:label        "has email"@en ;
+                rdfs:range        vcard:Email .
+
+spdx:annotation  rdf:type  owl:ObjectProperty ;
+                 rdfs:comment    "Provide additional information about an SpdxElement."@en ;
+                 rdfs:domain     spdx:SpdxElement ;
+                 rdfs:range      spdx:Annotation ;
+                 vs:term_status  "stable" .
+
+spdx:relationshipType_dataFileOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is a data file used in SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+dcterms:RFC3066  rdf:type    rdfs:Datatype ;
+                 rdfs:comment         "The set of tags constructed according to RFC 3066 for the identification of languages."@en ;
+                 rdfs:isDefinedBy     dcterms: ;
+                 rdfs:label           "RFC 3066"@en ;
+                 rdfs:seeAlso         <http://www.ietf.org/rfc/rfc3066.txt> ;
+                 dcterms:description  "RFC 3066 has been obsoleted by RFC 4646."@en ;
+                 dcterms:issued       "2002-07-13"^^xsd:date .
+
+[ rdf:type               owl:Axiom ;
+  rdfs:comment           "hadPrimarySource property is a particular case of wasDerivedFrom (see http://www.w3.org/TR/prov-dm/#term-original-source) that aims to give credit to the source that originated some information." ;
+  owl:annotatedProperty  rdfs:subPropertyOf ;
+  owl:annotatedSource    prov:hadPrimarySource ;
+  owl:annotatedTarget    prov:wasDerivedFrom
+] .
+
+spdx:reviewer  rdf:type  owl:DatatypeProperty ;
+               rdfs:comment    "The name and, optionally, contact information of the person who performed the review. Values of this property must conform to the agent and tool syntax.  The reviewer property is deprecated in favor of Annotation with an annotationType review."@en ;
+               rdfs:domain     spdx:Review ;
+               rdfs:range      xsd:string ;
+               owl:deprecated  true ;
+               vs:term_status  "deprecated"@en .
+
+dcterms:spatial  rdf:type   rdf:Property ;
+                 rdfs:comment        "Spatial characteristics of the resource."@en ;
+                 rdfs:isDefinedBy    dcterms: ;
+                 rdfs:label          "Spatial Coverage"@en ;
+                 rdfs:subPropertyOf  dc:coverage , dcterms:coverage ;
+                 dcam:rangeIncludes  dcterms:Location ;
+                 dcterms:issued      "2000-07-11"^^xsd:date .
+
+vcard:Address  rdf:type      owl:Class ;
+               rdfs:comment         "To specify the components of the delivery address for the  object"@en ;
+               rdfs:isDefinedBy     <http://www.w3.org/2006/vcard/ns> ;
+               rdfs:label           "Address"@en ;
+               owl:equivalentClass  [ rdf:type     owl:Class ;
+                                      owl:unionOf  ( [ rdf:type            owl:Class ;
+                                                       owl:intersectionOf  ( [ rdf:type            owl:Restriction ;
+                                                                               owl:onProperty      vcard:country-name ;
+                                                                               owl:someValuesFrom  xsd:string
+                                                                             ]
+                                                                             [ rdf:type            owl:Restriction ;
+                                                                               owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                                                                               owl:onProperty      vcard:country-name
+                                                                             ]
+                                                                           )
+                                                     ]
+                                                     [ rdf:type            owl:Class ;
+                                                       owl:intersectionOf  ( [ rdf:type            owl:Restriction ;
+                                                                               owl:onProperty      vcard:locality ;
+                                                                               owl:someValuesFrom  xsd:string
+                                                                             ]
+                                                                             [ rdf:type            owl:Restriction ;
+                                                                               owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                                                                               owl:onProperty      vcard:locality
+                                                                             ]
+                                                                           )
+                                                     ]
+                                                     [ rdf:type            owl:Class ;
+                                                       owl:intersectionOf  ( [ rdf:type            owl:Restriction ;
+                                                                               owl:onProperty      vcard:postal-code ;
+                                                                               owl:someValuesFrom  xsd:string
+                                                                             ]
+                                                                             [ rdf:type            owl:Restriction ;
+                                                                               owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                                                                               owl:onProperty      vcard:postal-code
+                                                                             ]
+                                                                           )
+                                                     ]
+                                                     [ rdf:type            owl:Class ;
+                                                       owl:intersectionOf  ( [ rdf:type            owl:Restriction ;
+                                                                               owl:onProperty      vcard:region ;
+                                                                               owl:someValuesFrom  xsd:string
+                                                                             ]
+                                                                             [ rdf:type            owl:Restriction ;
+                                                                               owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                                                                               owl:onProperty      vcard:region
+                                                                             ]
+                                                                           )
+                                                     ]
+                                                     [ rdf:type            owl:Class ;
+                                                       owl:intersectionOf  ( [ rdf:type            owl:Restriction ;
+                                                                               owl:onProperty      vcard:street-address ;
+                                                                               owl:someValuesFrom  xsd:string
+                                                                             ]
+                                                                             [ rdf:type            owl:Restriction ;
+                                                                               owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                                                                               owl:onProperty      vcard:street-address
+                                                                             ]
+                                                                           )
+                                                     ]
+                                                   )
+                             ] .
+
+time:year  rdf:type   owl:DatatypeProperty ;
+           rdfs:comment  "Year position in a calendar-clock system.\n\nThe range of this property is not specified, so can be replaced by any specific representation of a calendar year from any calendar. "@en , "Posición de año en un sistema calendario-reloj.\n\nl rango de esta propiedad no está especificado, por tanto, se puede reemplazar por cualquier representación específica de un año de calendario de un calendario cualquiera."@es ;
+           rdfs:domain   time:GeneralDateTimeDescription ;
+           rdfs:label    "year"@en .
+
+dcterms:MethodOfInstruction
+  rdf:type          rdfs:Class ;
+  rdfs:comment      "A process that is used to engender knowledge, attitudes, and skills."@en ;
+  rdfs:isDefinedBy  dcterms: ;
+  rdfs:label        "Method of Instruction"@en ;
+  dcterms:issued    "2008-01-14"^^xsd:date .
+
+dcterms:PhysicalResource
+  rdf:type          rdfs:Class ;
+  rdfs:comment      "A material thing."@en ;
+  rdfs:isDefinedBy  dcterms: ;
+  rdfs:label        "Physical Resource"@en ;
+  dcterms:issued    "2008-01-14"^^xsd:date .
+
+vcard:geo  rdf:type             owl:ObjectProperty ;
+           rdfs:comment            "This object property has been mapped"@en ;
+           rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label              "geo"@en ;
+           owl:equivalentProperty  vcard:hasGeo .
+
+time:DurationDescription
+  rdf:type         owl:Class ;
+  rdfs:comment     "Description of temporal extent structured with separate values for the various elements of a calendar-clock system. The temporal reference system is fixed to Gregorian Calendar, and the range of each of the numeric properties is restricted to xsd:decimal"@en , "Descripción de extensión temporal estructurada con valores separados para los distintos elementos de un sistema de horario-calendario. El sistema de referencia temporal se fija al calendario gregoriano, y el intervalo de cada una de las propiedades numéricas se restringe a xsd:decimal."@es ;
+  rdfs:label       "descripción de duración"@es , "Duration description"@en ;
+  rdfs:subClassOf  time:GeneralDurationDescription ;
+  rdfs:subClassOf  [ rdf:type           owl:Restriction ;
+                     owl:allValuesFrom  xsd:decimal ;
+                     owl:onProperty     time:minutes
+                   ] ;
+  rdfs:subClassOf  [ rdf:type           owl:Restriction ;
+                     owl:allValuesFrom  xsd:decimal ;
+                     owl:onProperty     time:days
+                   ] ;
+  rdfs:subClassOf  [ rdf:type           owl:Restriction ;
+                     owl:allValuesFrom  xsd:decimal ;
+                     owl:onProperty     time:seconds
+                   ] ;
+  rdfs:subClassOf  [ rdf:type        owl:Restriction ;
+                     owl:hasValue    <http://www.opengis.net/def/uom/ISO-8601/0/Gregorian> ;
+                     owl:onProperty  time:hasTRS
+                   ] ;
+  rdfs:subClassOf  [ rdf:type           owl:Restriction ;
+                     owl:allValuesFrom  xsd:decimal ;
+                     owl:onProperty     time:weeks
+                   ] ;
+  rdfs:subClassOf  [ rdf:type           owl:Restriction ;
+                     owl:allValuesFrom  xsd:decimal ;
+                     owl:onProperty     time:hours
+                   ] ;
+  rdfs:subClassOf  [ rdf:type           owl:Restriction ;
+                     owl:allValuesFrom  xsd:decimal ;
+                     owl:onProperty     time:years
+                   ] ;
+  rdfs:subClassOf  [ rdf:type           owl:Restriction ;
+                     owl:allValuesFrom  xsd:decimal ;
+                     owl:onProperty     time:months
+                   ] ;
+  skos:definition  "Description of temporal extent structured with separate values for the various elements of a calendar-clock system. The temporal reference system is fixed to Gregorian Calendar, and the range of each of the numeric properties is restricted to xsd:decimal"@en , "Descripción de extensión temporal estructurada con valores separados para los distintos elementos de un sistema de horario-calendario. El sistema de referencia temporal se fija al calendario gregoriano, y el intervalo de cada una de las propiedades numéricas se restringe a xsd:decimal."@es ;
+  skos:note        "In the Gregorian calendar the length of the month is not fixed. Therefore, a value like \"2.5 months\" cannot be exactly compared with a similar duration expressed in terms of weeks or days."@en , "En el calendario gregoriano la longitud de los meses no es fija. Por lo tanto, un valor como \"2,5 meses\" no se puede comparar exactamente con una duración similar expresada en términos de semanas o días."@es .
+
+vcard:Unknown  rdf:type   owl:Class ;
+               rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+               rdfs:label        "Unknown"@en ;
+               rdfs:subClassOf   vcard:Gender .
+
+[ rdf:type               owl:Axiom ;
+  owl:annotatedProperty  rdfs:range ;
+  owl:annotatedSource    prov:wasInfluencedBy ;
+  owl:annotatedTarget    [ rdf:type     owl:Class ;
+                           owl:unionOf  ( prov:Activity prov:Agent prov:Entity )
+                         ] ;
+  prov:definition        "influencer: an identifier (o1) for an ancestor entity, activity, or agent that the former depends on;" ;
+  prov:dm                "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence"
+] .
+
+dcterms:MediaTypeOrExtent
+  rdf:type          rdfs:Class ;
+  rdfs:comment      "A media type or extent."@en ;
+  rdfs:isDefinedBy  dcterms: ;
+  rdfs:label        "Media Type or Extent"@en ;
+  dcterms:issued    "2008-01-14"^^xsd:date .
+
+skos:broaderTransitive
+  rdf:type            owl:ObjectProperty , owl:TransitiveProperty , rdf:Property ;
+  rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+  rdfs:label          "has broader transitive"@en ;
+  rdfs:subPropertyOf  skos:semanticRelation ;
+  owl:inverseOf       skos:narrowerTransitive ;
+  skos:definition     "skos:broaderTransitive is a transitive superproperty of skos:broader." ;
+  skos:scopeNote      "By convention, skos:broaderTransitive is not used to make assertions. Rather, the properties can be used to draw inferences about the transitive closure of the hierarchical relation, which is useful e.g. when implementing a simple query expansion algorithm in a search application."@en .
+
+<https://www.w3.org/ns/locn.svg>
+  rdfs:label  "Class and property diagram of the LOCN vocabulary" .
+
+dcterms:DCMIType  rdf:type  dcam:VocabularyEncodingScheme ;
+                  rdfs:comment      "The set of classes specified by the DCMI Type Vocabulary, used to categorize the nature or genre of the resource."@en ;
+                  rdfs:isDefinedBy  dcterms: ;
+                  rdfs:label        "DCMI Type Vocabulary"@en ;
+                  rdfs:seeAlso      dctype: ;
+                  dcterms:issued    "2000-07-11"^^xsd:date .
+
+time:unitWeek  rdf:type  time:TemporalUnit ;
+               rdfs:label      "Week (unit of temporal duration)"@en ;
+               skos:prefLabel  "一週間"@jp , "week"@nl , "week"@en , "settimana"@it , "semana"@es , "semana"@pt , "одна неделя"@ru , "tydzień"@pl , "일주일"@kr , "一周"@zh , "semaine"@fr , "Woche"@de , "سبوع واحد"@ar ;
+               time:days       "0"^^xsd:decimal ;
+               time:hours      "0"^^xsd:decimal ;
+               time:minutes    "0"^^xsd:decimal ;
+               time:months     "0"^^xsd:decimal ;
+               time:seconds    "0"^^xsd:decimal ;
+               time:weeks      "1"^^xsd:decimal ;
+               time:years      "0"^^xsd:decimal .
+
+prov:qualifiedInvalidation
+  rdf:type                   owl:ObjectProperty ;
+  rdfs:comment               "If this Entity prov:wasInvalidatedBy Activity :a, then it can qualify how it was invalidated using prov:qualifiedInvalidation [ a prov:Invalidation;  prov:activity :a; :foo :bar ]."@en ;
+  rdfs:domain                prov:Entity ;
+  rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label                 "qualifiedInvalidation" ;
+  rdfs:range                 prov:Invalidation ;
+  rdfs:subPropertyOf         prov:qualifiedInfluence ;
+  prov:category              "qualified" ;
+  prov:component             "entities-activities" ;
+  prov:inverse               "qualifiedInvalidationOf" ;
+  prov:sharesDefinitionWith  prov:Invalidation ;
+  prov:unqualifiedForm       prov:wasInvalidatedBy .
+
+prov:qualifiedForm  rdf:type  owl:AnnotationProperty ;
+                    rdfs:comment        "This annotation property links a subproperty of prov:wasInfluencedBy with the subclass of prov:Influence and the qualifying property that are used to qualify it. \n\nExample annotation:\n\n    prov:wasGeneratedBy prov:qualifiedForm prov:qualifiedGeneration, prov:Generation .\n\nThen this unqualified assertion:\n\n    :entity1 prov:wasGeneratedBy :activity1 .\n\ncan be qualified by adding:\n\n   :entity1 prov:qualifiedGeneration :entity1Gen .\n   :entity1Gen \n       a prov:Generation, prov:Influence;\n       prov:activity :activity1;\n       :customValue 1337 .\n\nNote how the value of the unqualified influence (prov:wasGeneratedBy :activity1) is mirrored as the value of the prov:activity (or prov:entity, or prov:agent) property on the influence class."@en ;
+                    rdfs:isDefinedBy    <http://www.w3.org/ns/prov-o#> ;
+                    rdfs:subPropertyOf  rdfs:seeAlso .
+
+[ rdf:type               owl:Axiom ;
+  rdfs:comment           "Attribution is a particular case of trace (see http://www.w3.org/TR/prov-dm/#concept-trace), in the sense that it links an entity to the agent that ascribed it." ;
+  owl:annotatedProperty  rdfs:subPropertyOf ;
+  owl:annotatedSource    prov:wasAttributedTo ;
+  owl:annotatedTarget    prov:wasInfluencedBy ;
+  prov:definition        "IF wasAttributedTo(e2,ag1,aAttr) holds, THEN wasInfluencedBy(e2,ag1) also holds. "
+] .
+
+vcard:Neighbor  rdf:type  owl:Class ;
+                rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                rdfs:label        "Neighbor"@en ;
+                rdfs:subClassOf   vcard:RelatedType .
+
+vcard:language  rdf:type  owl:DatatypeProperty ;
+                rdfs:comment      "To specify the language that may be used for contacting the object. May also be used as a property parameter."@en ;
+                rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                rdfs:label        "language"@en .
+
+prov:Delegation  rdf:type     owl:Class ;
+                 rdfs:comment          "An instance of prov:Delegation provides additional descriptions about the binary prov:actedOnBehalfOf relation from a performing prov:Agent to some prov:Agent for whom it was performed. For example, :mixing prov:wasAssociatedWith :toddler . :toddler prov:actedOnBehalfOf :mother; prov:qualifiedDelegation [ a prov:Delegation; prov:entity :mother; :foo :bar ]."@en ;
+                 rdfs:isDefinedBy      <http://www.w3.org/ns/prov-o#> ;
+                 rdfs:label            "Delegation" ;
+                 rdfs:subClassOf       prov:AgentInfluence ;
+                 prov:category         "qualified" ;
+                 prov:component        "agents-responsibility" ;
+                 prov:definition       "Delegation is the assignment of authority and responsibility to an agent (by itself or by another agent) to carry out a specific activity as a delegate or representative, while the agent it acts on behalf of retains some responsibility for the outcome of the delegated work.\n\nFor example, a student acted on behalf of his supervisor, who acted on behalf of the department chair, who acted on behalf of the university; all those agents are responsible in some way for the activity that took place but we do not say explicitly who bears responsibility and to what degree."@en ;
+                 prov:dm               "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-delegation"^^xsd:anyURI ;
+                 prov:n                "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-delegation"^^xsd:anyURI ;
+                 prov:unqualifiedForm  prov:actedOnBehalfOf .
+
+dcterms:ISO3166  rdf:type  rdfs:Datatype ;
+                 rdfs:comment      "The set of codes listed in ISO 3166-1 for the representation of names of countries."@en ;
+                 rdfs:isDefinedBy  dcterms: ;
+                 rdfs:label        "ISO 3166"@en ;
+                 rdfs:seeAlso      <https://www.iso.org/obp/ui/#search> , <http://www.iso.org/iso/en/prods-services/iso3166ma/02iso-3166-code-lists/list-en1.html> ;
+                 dcterms:issued    "2000-07-11"^^xsd:date .
+
+spdx:annotationDate  rdf:type  owl:DatatypeProperty ;
+                     rdfs:comment        "Identify when the comment was made. This is to be specified according to the combined date and time in the UTC format, as specified in the ISO 8601 standard."@en ;
+                     rdfs:domain         spdx:Annotation ;
+                     rdfs:range          xsd:dateTime ;
+                     rdfs:subPropertyOf  spdx:date ;
+                     vs:term_status      "stable" .
+
+adms:AssetRepository  rdf:type  owl:Class ;
+                      rdfs:comment      "A system or service that provides facilities for storage and maintenance of descriptions of Assets and Asset Distributions, and functionality that allows users to search and access these descriptions. An Asset Repository will typically contain descriptions of several Assets and related Asset Distributions."@en ;
+                      rdfs:isDefinedBy  <http://www.w3.org/ns/adms> ;
+                      rdfs:label        "Asset repository"@en .
+
+skos:broader  rdf:type      owl:ObjectProperty , rdf:Property ;
+              rdfs:comment        "Broader concepts are typically rendered as parents in a concept hierarchy (tree)."@en ;
+              rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+              rdfs:label          "has broader"@en ;
+              rdfs:subPropertyOf  skos:broaderTransitive ;
+              owl:inverseOf       skos:narrower ;
+              skos:definition     "Relates a concept to a concept that is more general in meaning."@en ;
+              skos:scopeNote      "By convention, skos:broader is only used to assert an immediate (i.e. direct) hierarchical link between two conceptual resources."@en .
+
+spdx:relationshipType_providedDependencyOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is a to be provided dependency of SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:exceptionTextHtml
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "HTML representation of the License Exception Text"@en ;
+  rdfs:domain     spdx:ListedLicenseException ;
+  rdfs:range      xsd:string ;
+  vs:term_status  "stable"@en .
+
+<http://data.europa.eu/r5r#Location_Shape>
+  rdf:type        sh:NodeShape ;
+  sh:name         "Location"@en ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:nodeKind  sh:Literal ;
+                    sh:path      locn:geometry ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:nodeKind  sh:Literal ;
+                    sh:path      dcat:centroid ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:nodeKind  sh:Literal ;
+                    sh:path      dcat:bbox ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:targetClass  dcterms:Location .
+
+dcat:accessURL  rdf:type        rdf:Property , owl:ObjectProperty ;
+                rdfs:comment            "A URL of a resource that gives access to a distribution of the dataset. E.g. landing page, feed, SPARQL endpoint. Use for all cases except a simple download link, in which case downloadURL is preferred."@en , "Puede ser cualquier tipo de URL que de acceso a una distribución del conjunto de datos, e.g., página de destino, descarga, URL feed, punto de acceso SPARQL. Esta propriedad se debe usar cuando su catálogo de datos no tiene información sobre donde está o cuando no se puede descargar."@es , "En URL for en ressource som giver adgang til en repræsentation af datsættet. Fx destinationsside, feed, SPARQL-endpoint. Anvendes i alle sammenhænge undtagen til angivelse af et simpelt download link hvor anvendelse af egenskaben downloadURL foretrækkes."@da , "URL zdroje, přes které je přístupná distribuce datové sady. Příkladem může být vstupní stránka, RSS kanál či SPARQL endpoint. Použijte ve všech případech kromě URL souboru ke stažení, pro které je lepší použít dcat:downloadURL."@cs , "Μπορεί να είναι οποιουδήποτε είδους URL που δίνει πρόσβαση στη διανομή ενός συνόλου δεδομένων. Π.χ. ιστοσελίδα αρχικής πρόσβασης, μεταφόρτωση, feed URL, σημείο διάθεσης SPARQL. Να χρησιμοποιείται όταν ο κατάλογος δεν περιέχει πληροφορίες εαν πρόκειται ή όχι για μεταφορτώσιμο αρχείο."@el , "Un URL di una risorsa che consente di accedere a una distribuzione del set di dati. Per esempio, pagina di destinazione, feed, endpoint SPARQL. Da utilizzare per tutti i casi, tranne  quando  si tratta di un semplice link per il download nel qual caso è preferito downloadURL."@it , "データセットの配信にアクセス権を与えるランディング・ページ、フィード、SPARQLエンドポイント、その他の種類の資源。"@ja , "Ceci peut être tout type d'URL qui donne accès à une distribution du jeu de données. Par exemple, un lien à une page HTML contenant un lien au jeu de données, un Flux RSS, un point d'accès SPARQL. Utilisez le lorsque votre catalogue ne contient pas d'information sur quoi il est ou quand ce n'est pas téléchargeable."@fr , "أي رابط يتيح الوصول إلى البيانات. إذا كان الرابط هو ربط مباشر لملف يمكن تحميله استخدم الخاصية downloadURL"@ar ;
+                rdfs:domain             dcat:Distribution ;
+                rdfs:isDefinedBy        <http://www.w3.org/TR/vocab-dcat/> ;
+                rdfs:label              "přístupová adresa"@cs , "URL d'accès"@fr , "アクセスURL"@ja , "access address"@en , "URL πρόσβασης"@el , "رابط وصول"@ar , "URL de acceso"@es , "indirizzo di accesso"@it , "adgangsadresse"@da ;
+                rdfs:range              rdfs:Resource ;
+                owl:propertyChainAxiom  ( dcat:accessService dcat:endpointURL ) ;
+                skos:altLabel           "adgangsURL"@da ;
+                skos:definition         "En URL for en ressource som giver adgang til en repræsentation af datsættet. Fx destinationsside, feed, SPARQL-endpoint. Anvendes i alle sammenhænge undtagen til angivelse af et simpelt download link hvor anvendelse af egenskaben downloadURL foretrækkes."@da , "データセットの配信にアクセス権を与えるランディング・ページ、フィード、SPARQLエンドポイント、その他の種類の資源。"@ja , "A URL of a resource that gives access to a distribution of the dataset. E.g. landing page, feed, SPARQL endpoint. Use for all cases except a simple download link, in which case downloadURL is preferred."@en , "Ceci peut être tout type d'URL qui donne accès à une distribution du jeu de données. Par exemple, un lien à une page HTML contenant un lien au jeu de données, un Flux RSS, un point d'accès SPARQL. Utilisez le lorsque votre catalogue ne contient pas d'information sur quoi il est ou quand ce n'est pas téléchargeable."@fr , "Un URL di una risorsa che consente di accedere a una distribuzione del set di dati. Per esempio, pagina di destinazione, feed, endpoint SPARQL. Da utilizzare per tutti i casi, tranne  quando  si tratta di un semplice link per il download nel qual caso è preferito downloadURL."@it , "Μπορεί να είναι οποιουδήποτε είδους URL που δίνει πρόσβαση στη διανομή ενός συνόλου δεδομένων. Π.χ. ιστοσελίδα αρχικής πρόσβασης, μεταφόρτωση, feed URL, σημείο διάθεσης SPARQL. Να χρησιμοποιείται όταν ο κατάλογος δεν περιέχει πληροφορίες εαν πρόκειται ή όχι για μεταφορτώσιμο αρχείο."@el , "Puede ser cualquier tipo de URL que de acceso a una distribución del conjunto de datos, e.g., página de destino, descarga, URL feed, punto de acceso SPARQL. Esta propriedad se debe usar cuando su catálogo de datos no tiene información sobre donde está o cuando no se puede descargar."@es , "URL zdroje, přes které je přístupná distribuce datové sady. Příkladem může být vstupní stránka, RSS kanál či SPARQL endpoint. Použijte ve všech případech kromě URL souboru ke stažení, pro které je lepší použít dcat:downloadURL."@cs , "أي رابط يتيح الوصول إلى البيانات. إذا كان الرابط هو ربط مباشر لملف يمكن تحميله استخدم الخاصية downloadURL"@ar ;
+                skos:editorialNote      "rdfs:label, rdfs:comment and skos:scopeNote have been modified. Non-english versions except for Italian must be updated."@en , "Status: English Definition text modified by DCAT revision team, updated Italian and Czech translation provided, translations for other languages pending."@en ;
+                skos:scopeNote          "Se le distribuzioni sono accessibili solo attraverso una pagina web (ad esempio, gli URL per il download diretto non sono noti), allora il link della pagina web deve essere duplicato come accessURL sulla distribuzione."@it , "Hvis en eller flere distributioner kun er tilgængelige via en destinationsside (dvs. en URL til direkte download er ikke kendt), så bør destinationssidelinket gentages som adgangsadresse for distributionen."@da , "Pokud jsou distribuce přístupné pouze přes vstupní stránku (tj. URL pro přímé stažení nejsou známa), pak by URL přístupové stránky mělo být duplikováno ve vlastnosti distribuce accessURL."@cs , "El rango es una URL. Si la distribución es accesible solamente través de una página de destino (es decir, si no se conoce una URL de descarga directa), entonces el enlance a la página de destino debe ser duplicado como accessURL en la distribución."@es , "Η τιμή είναι ένα URL. Αν η/οι διανομή/ές είναι προσβάσιμη/ες μόνο μέσω μίας ιστοσελίδας αρχικής πρόσβασης (δηλαδή αν δεν υπάρχουν γνωστές διευθύνσεις άμεσης μεταφόρτωσης), τότε ο σύνδεσμος της ιστοσελίδας αρχικής πρόσβασης πρέπει να αναπαραχθεί ως accessURL σε μία διανομή."@el , "La valeur est une URL. Si la distribution est accessible seulement au travers d'une page d'atterrissage (c-à-dire on n'ignore une URL de téléchargement direct), alors le lien à la page d'atterrissage doit être dupliqué comee accessURL sur la distribution."@fr , "確実にダウンロードでない場合や、ダウンロードかどうかが不明である場合は、downloadURLではなく、accessURLを用いてください。ランディング・ページを通じてしか配信にアクセスできない場合（つまり、直接的なダウンロードURLが不明）は、配信におけるaccessURLとしてランディング・ページのリンクをコピーすべきです（SHOULD）。"@ja , "If the distribution(s) are accessible only through a landing page (i.e. direct download URLs are not known), then the landing page link should be duplicated as accessURL on a distribution."@en .
+
+spdx:snippetFromFile  rdf:type  owl:ObjectProperty ;
+                      rdfs:comment    "File containing the SPDX element (e.g. the file contaning a snippet)."@en ;
+                      rdfs:domain     spdx:Snippet ;
+                      rdfs:range      spdx:File ;
+                      vs:term_status  "stable"@en .
+
+prov:Communication  rdf:type  owl:Class ;
+                    rdfs:comment          "An instance of prov:Communication provides additional descriptions about the binary prov:wasInformedBy relation from an informed prov:Activity to the prov:Activity that informed it. For example, :you_jumping_off_bridge prov:wasInformedBy :everyone_else_jumping_off_bridge; prov:qualifiedCommunication [ a prov:Communication; prov:activity :everyone_else_jumping_off_bridge; :foo :bar ]."@en ;
+                    rdfs:isDefinedBy      <http://www.w3.org/ns/prov-o#> ;
+                    rdfs:label            "Communication" ;
+                    rdfs:subClassOf       prov:ActivityInfluence ;
+                    prov:category         "qualified" ;
+                    prov:component        "entities-activities" ;
+                    prov:constraints      "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+                    prov:definition       "Communication is the exchange of an entity by two activities, one activity using the entity generated by the other." ;
+                    prov:dm               "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Communication"^^xsd:anyURI ;
+                    prov:n                "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-wasInformedBy"^^xsd:anyURI ;
+                    prov:unqualifiedForm  prov:wasInformedBy .
+
+vcard:email  rdf:type           owl:ObjectProperty ;
+             rdfs:comment            "This object property has been mapped"@en ;
+             rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label              "email"@en ;
+             owl:equivalentProperty  vcard:hasEmail .
+
+prov:qualifiedGeneration
+  rdf:type                   owl:ObjectProperty ;
+  rdfs:comment               "If this Activity prov:generated Entity :e, then it can qualify how it performed the Generation using prov:qualifiedGeneration [ a prov:Generation;  prov:entity :e; :foo :bar ]."@en ;
+  rdfs:domain                prov:Entity ;
+  rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label                 "qualifiedGeneration" ;
+  rdfs:range                 prov:Generation ;
+  rdfs:subPropertyOf         prov:qualifiedInfluence ;
+  prov:category              "qualified" ;
+  prov:component             "entities-activities" ;
+  prov:inverse               "qualifiedGenerationOf" ;
+  prov:sharesDefinitionWith  prov:Generation ;
+  prov:unqualifiedForm       prov:wasGeneratedBy .
+
+dcterms:BibliographicResource
+  rdf:type          rdfs:Class ;
+  rdfs:comment      "A book, article, or other documentary resource."@en ;
+  rdfs:isDefinedBy  dcterms: ;
+  rdfs:label        "Bibliographic Resource"@en ;
+  dcterms:issued    "2008-01-14"^^xsd:date .
+
+spdx:fileType_audio  rdf:type  owl:NamedIndividual , spdx:FileType ;
+                     rdfs:comment    "The file is associated with an audio file (MIME type of audio/* , ie. .mp3 ); \nIMAGE if the file is assoicated with an picture image file (MIME type of image/*,  ie. .jpg, .gif  )"@en ;
+                     vs:term_status  "stable"@en .
+
+prov:wasInformedBy  rdf:type    owl:ObjectProperty ;
+                    rdfs:comment            "An activity a2 is dependent on or informed by another activity a1, by way of some unspecified entity that is generated by a1 and used by a2."@en ;
+                    rdfs:domain             prov:Activity ;
+                    rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+                    rdfs:label              "wasInformedBy" ;
+                    rdfs:range              prov:Activity ;
+                    rdfs:subPropertyOf      prov:wasInfluencedBy ;
+                    owl:propertyChainAxiom  ( prov:qualifiedCommunication prov:activity ) ;
+                    owl:propertyChainAxiom  ( prov:qualifiedCommunication prov:activity ) ;
+                    prov:category           "starting-point" ;
+                    prov:component          "entities-activities" ;
+                    prov:inverse            "informed" ;
+                    prov:qualifiedForm      prov:qualifiedCommunication , prov:Communication .
+
+dcat:CatalogRecord  rdf:type  owl:Class , rdfs:Class ;
+                    rdfs:comment        "A record in a data catalog, describing the registration of a single dataset or data service."@en , "1つのデータセットを記述したデータ・カタログ内のレコード。"@ja , "En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste."@da , "Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu."@cs , "Un registre du catalogue ou une entrée du catalogue, décrivant un seul jeu de données."@fr , "Un registro en un catálogo de datos que describe un solo conjunto de datos o un servicio de datos."@es , "Un record in un catalogo di dati che descrive un singolo dataset o servizio di dati."@it , "Μία καταγραφή ενός καταλόγου, η οποία περιγράφει ένα συγκεκριμένο σύνολο δεδομένων."@el ;
+                    rdfs:isDefinedBy    <http://www.w3.org/TR/vocab-dcat/> ;
+                    rdfs:label          "カタログ・レコード"@ja , "Καταγραφή καταλόγου"@el , "سجل"@ar , "Registro del catálogo"@es , "Record di catalogo"@it , "Catalog Record"@en , "Katalogizační záznam"@cs , "Katalogpost"@da , "Registre du catalogue"@fr ;
+                    rdfs:subClassOf     [ rdf:type           owl:Restriction ;
+                                          owl:allValuesFrom  dcat:Resource ;
+                                          owl:onProperty     foaf:primaryTopic
+                              ] ;
+                    rdfs:subClassOf     [ rdf:type         owl:Restriction ;
+                                          owl:cardinality  "1"^^xsd:nonNegativeInteger ;
+                                          owl:onProperty   foaf:primaryTopic
+                              ] ;
+                    skos:definition     "Un record in un catalogo di dati che descrive un singolo dataset o servizio di dati."@it , "Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu."@cs , "Un registro en un catálogo de datos que describe un solo conjunto de datos o un servicio de datos."@es , "En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste."@da , "1つのデータセットを記述したデータ・カタログ内のレコード。"@ja , "A record in a data catalog, describing the registration of a single dataset or data service."@en , "Μία καταγραφή ενός καταλόγου, η οποία περιγράφει ένα συγκεκριμένο σύνολο δεδομένων."@el , "Un registre du catalogue ou une entrée du catalogue, décrivant un seul jeu de données."@fr ;
+                    skos:editorialNote  "English definition updated in this revision. Multilingual text not yet updated except the Spanish one and the Czech one and Italian one."@en ;
+                    skos:scopeNote      "このクラスはオプションで、すべてのカタログがそれを用いるとは限りません。これは、データセットに関するメタデータとカタログ内のデータセットのエントリーに関するメタデータとで区別が行われるカタログのために存在しています。例えば、データセットの公開日プロパティーは、公開機関が情報を最初に利用可能とした日付を示しますが、カタログ・レコードの公開日は、データセットがカタログに追加された日付です。両方の日付が異っていたり、後者だけが分かっている場合は、カタログ・レコードに対してのみ公開日を指定すべきです。W3CのPROVオントロジー[prov-o]を用いれば、データセットに対する特定の変更に関連するプロセスやエージェントの詳細などの、さらに詳しい来歴情報の記述が可能となることに注意してください。"@ja , "Questa classe è opzionale e non tutti i cataloghi la utilizzeranno. Esiste per cataloghi in cui si opera una distinzione tra i metadati relativi al dataset ed i metadati relativi alla gestione del dataset nel catalogo. Ad esempio, la  proprietà per indicare la data di pubblicazione del dataset rifletterà la data in cui l'informazione è stata originariamente messa a disposizione dalla casa editrice, mentre la data di pubblicazione per il record nel catalogo rifletterà la data in cui il dataset è stato aggiunto al catalogo. Nei casi dove solo quest'ultima sia nota, si utilizzerà esclusivamente la data di  pubblicazione relativa al record del catalogo. Si noti che l'Ontologia W3C PROV permette di descrivere ulteriori informazioni sulla provenienza, quali i dettagli del processo, la procedura e l'agente coinvolto in una particolare modifica di un dataset."@it , "Tato třída je volitelná a ne všechny katalogy ji využijí. Existuje pro katalogy, ve kterých se rozlišují metadata datové sady či datové služby a metadata o záznamu o datové sadě či datové službě v katalogu. Například datum publikace datové sady odráží datum, kdy byla datová sada původně zveřejněna poskytovatelem dat, zatímco datum publikace katalogizačního záznamu je datum zanesení datové sady do katalogu. V případech kdy se obě data liší, nebo je známo jen to druhé, by mělo být specifikováno jen datum publikace katalogizačního záznamu. Všimněte si, že ontologie W3C PROV umožňuje popsat další informace o původu jako například podrobnosti o procesu konkrétní změny datové sady a jeho účastnících."@cs , "Esta clase es opcional y no todos los catálogos la utilizarán. Esta clase existe para catálogos que hacen una distinción entre los metadatos acerca de un conjunto de datos o un servicio de datos y los metadatos acerca de una entrada en ese conjunto de datos en el catálogo. Por ejemplo, la propiedad sobre la fecha de la publicación de los datos refleja la fecha en que la información fue originalmente publicada, mientras que la fecha de publicación del registro del catálogo es la fecha en que los datos se agregaron al mismo. En caso en que ambas fechas fueran diferentes, o en que sólo la fecha de publicación del registro del catálogo estuviera disponible, sólo debe especificarse en el registro del catálogo. Tengan en cuenta que la ontología PROV de W3C permite describir otra información sobre la proveniencia de los datos, como por ejemplo detalles del proceso y de los agentes involucrados en algún cambio específico a los datos."@es , "This class is optional and not all catalogs will use it. It exists for catalogs where a distinction is made between metadata about a dataset or data service and metadata about the entry for the dataset or data service in the catalog. For example, the publication date property of the dataset reflects the date when the information was originally made available by the publishing agency, while the publication date of the catalog record is the date when the dataset was added to the catalog. In cases where both dates differ, or where only the latter is known, the publication date should only be specified for the catalog record. Notice that the W3C PROV Ontology allows describing further provenance information such as the details of the process and the agent involved in a particular change to a dataset."@en , "Αυτή η κλάση είναι προαιρετική και δεν χρησιμοποιείται από όλους τους καταλόγους. Υπάρχει για τις περιπτώσεις καταλόγων όπου γίνεται διαχωρισμός μεταξύ των μεταδεδομένων για το σύνολο των δεδομένων και των μεταδεδομένων για την καταγραφή του συνόλου δεδομένων εντός του καταλόγου. Για παράδειγμα, η ιδιότητα της ημερομηνίας δημοσίευσης του συνόλου δεδομένων δείχνει την ημερομηνία κατά την οποία οι πληροφορίες έγιναν διαθέσιμες από τον φορέα δημοσίευσης, ενώ η ημερομηνία δημοσίευσης της καταγραφής του καταλόγου δείχνει την ημερομηνία που το σύνολο δεδομένων προστέθηκε στον κατάλογο. Σε περιπτώσεις που οι δύο ημερομηνίες διαφέρουν, ή που μόνο η τελευταία είναι γνωστή, η ημερομηνία δημοσίευσης θα πρέπει να δίνεται για την καταγραφή του καταλόγου. Να σημειωθεί πως η οντολογία W3C PROV επιτρέπει την περιγραφή επιπλέον πληροφοριών ιστορικού όπως λεπτομέρειες για τη διαδικασία και τον δράστη που εμπλέκονται σε μία συγκεκριμένη αλλαγή εντός του συνόλου δεδομένων."@el , "C'est une classe facultative et tous les catalogues ne l'utiliseront pas. Cette classe existe pour les catalogues\tayant une distinction entre les métadonnées sur le jeu de données et les métadonnées sur une entrée du jeu de données dans le catalogue."@fr , "Denne klasse er valgfri og ikke alle kataloger vil anvende denne klasse. Den kan anvendes i de kataloger hvor der skelnes mellem metadata om datasættet eller datatjenesten og metadata om selve posten til registreringen af datasættet eller datatjenesten i kataloget. Udgivelsesdatoen for datasættet afspejler for eksempel den dato hvor informationerne oprindeligt blev gjort tilgængelige af udgiveren, hvorimod udgivelsesdatoen for katalogposten er den dato hvor datasættet blev føjet til kataloget. I de tilfælde hvor de to datoer er forskellige eller hvor blot sidstnævnte er kendt, bør udgivelsesdatoen kun angives for katalogposten. Bemærk at W3Cs PROV ontologi gør til muligt at tilføje yderligere proveniensoplysninger eksempelvis om processen eller aktøren involveret i en given ændring af datasættet."@da .
+
+spdx:isValid  rdf:type  owl:DatatypeProperty ;
+              rdfs:comment  "True if the URL is a valid well formed URL"@en ;
+              rdfs:domain   spdx:CrossRef ;
+              rdfs:range    xsd:boolean .
+
+<http://www.w3.org/2009/pointers#startPointer>
+  rdf:type        owl:ObjectProperty ;
+  rdfs:domain     <http://www.w3.org/2009/pointers#CompoundPointer> ;
+  rdfs:range      <http://www.w3.org/2009/pointers#SinglePointer> ;
+  vs:term_status  "stable"@en .
+
+skos:Collection  rdf:type  owl:Class ;
+                 rdfs:isDefinedBy  <http://www.w3.org/2004/02/skos/core> ;
+                 rdfs:label        "Collection"@en ;
+                 owl:disjointWith  skos:Concept , skos:ConceptScheme ;
+                 skos:definition   "A meaningful collection of concepts."@en ;
+                 skos:scopeNote    "Labelled collections can be used where you would like a set of concepts to be displayed under a 'node label' in the hierarchy."@en .
+
+doap:Project  rdf:type  owl:Class .
+
+dcterms:modified  rdf:type   rdf:Property ;
+                  rdfs:comment         "Date on which the resource was changed."@en ;
+                  rdfs:isDefinedBy     dcterms: ;
+                  rdfs:label           "Date Modified"@en ;
+                  rdfs:range           rdfs:Literal ;
+                  rdfs:subPropertyOf   dc:date , dcterms:date ;
+                  dcterms:description  "Recommended practice is to describe the date, date/time, or period of time as recommended for the property Date, of which this is a subproperty."@en ;
+                  dcterms:issued       "2000-07-11"^^xsd:date .
+
+adms:supportedSchema  rdf:type  owl:ObjectProperty ;
+                      rdfs:comment      "A schema according to which the Asset Repository can provide data about its content, e.g. ADMS."@en ;
+                      rdfs:domain       rdfs:Resource ;
+                      rdfs:isDefinedBy  <http://www.w3.org/ns/adms> ;
+                      rdfs:label        "supported schema"@en ;
+                      rdfs:range        adms:Asset .
+
+adms:versionNotes  rdf:type  owl:DatatypeProperty ;
+                   rdfs:comment      "A description of changes between this version and the previous version of the Asset."@en ;
+                   rdfs:domain       rdfs:Resource ;
+                   rdfs:isDefinedBy  <http://www.w3.org/ns/adms> ;
+                   rdfs:label        "version notes"@en ;
+                   rdfs:range        rdfs:Literal .
+
+spdx:purpose_install  rdf:type  owl:NamedIndividual , spdx:Purpose ;
+                      rdfs:comment    "The package is used to install software on disk."@en ;
+                      vs:term_status  "stable"@en .
+
+prov:hadActivity  rdf:type         owl:ObjectProperty ;
+                  rdfs:comment               "The _optional_ Activity of an Influence, which used, generated, invalidated, or was the responsibility of some Entity. This property is _not_ used by ActivityInfluence (use prov:activity instead)."@en , "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." ;
+                  rdfs:domain                prov:Influence ;
+                  rdfs:domain                [ rdf:type     owl:Class ;
+                                               owl:unionOf  ( prov:Delegation prov:Derivation prov:End prov:Start )
+                                   ] ;
+                  rdfs:domain                [ rdf:type     owl:Class ;
+                                               owl:unionOf  ( prov:Delegation prov:Derivation prov:End prov:Start )
+                                   ] ;
+                  rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+                  rdfs:label                 "hadActivity" ;
+                  rdfs:range                 prov:Activity ;
+                  prov:category              "qualified" ;
+                  prov:component             "derivations" ;
+                  prov:editorialNote         "The multiple rdfs:domain assertions are intended. One is simpler and works for OWL-RL, the union is more specific but is not recognized by OWL-RL."@en ;
+                  prov:inverse               "wasActivityOfInfluence" ;
+                  prov:sharesDefinitionWith  prov:Activity .
+
+vcard:hasFamilyName  rdf:type  owl:ObjectProperty ;
+                     rdfs:comment      "Used to support property parameters for the family name data property"@en ;
+                     rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                     rdfs:label        "has family name"@en .
+
+time:dayOfWeek  rdf:type  owl:ObjectProperty ;
+                rdfs:comment     "The day of week, whose value is a member of the class time:DayOfWeek"@en , "El día de la semana, cuyo valor es un miembro de la clase 'día de la semana'." ;
+                rdfs:domain      time:GeneralDateTimeDescription ;
+                rdfs:label       "day of week"@en , "día de la semana"@es ;
+                rdfs:range       time:DayOfWeek ;
+                skos:definition  "The day of week, whose value is a member of the class time:DayOfWeek"@en , "El día de la semana, cuyo valor es un miembro de la clase 'día de la semana'."@es .
+
+spdx:relationshipType_devDependencyOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is a development dependency of SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+time:intervalMeets  rdf:type  owl:ObjectProperty ;
+                    rdfs:comment     "Si un intervalo propio T1 se encuentra con otro intervalo propio T2, entonces el final de T1 coincide con el principio de T2."@es , "If a proper interval T1 is intervalMeets another proper interval T2, then the end of T1 is coincident with the beginning of T2."@en ;
+                    rdfs:domain      time:ProperInterval ;
+                    rdfs:label       "intervalo se encuentra"@es , "interval meets"@en ;
+                    rdfs:range       time:ProperInterval ;
+                    owl:inverseOf    time:intervalMetBy ;
+                    skos:definition  "If a proper interval T1 is intervalMeets another proper interval T2, then the end of T1 is coincident with the beginning of T2."@en , "Si un intervalo propio T1 se encuentra con otro intervalo propio T2, entonces el final de T1 coincide con el principio de T2."@es .
+
+time:unitSecond  rdf:type  time:TemporalUnit ;
+                 rdfs:label      "Second (unit of temporal duration)"@en ;
+                 skos:prefLabel  "segundo"@pt , "segundo"@es , "seconde"@fr , "seconde"@nl , "Sekunde"@de , "second"@en , "ثانية واحدة"@ar , "一秒"@jp , "一秒"@zh , "일초"@kr , "Sekundę"@pl , "secondo"@it ;
+                 time:days       "0"^^xsd:decimal ;
+                 time:hours      "0"^^xsd:decimal ;
+                 time:minutes    "0"^^xsd:decimal ;
+                 time:months     "0"^^xsd:decimal ;
+                 time:seconds    "1"^^xsd:decimal ;
+                 time:weeks      "0"^^xsd:decimal ;
+                 time:years      "0"^^xsd:decimal .
+
+spdx:created  rdf:type      owl:DatatypeProperty ;
+              rdfs:comment        "Identify when the SPDX document was originally created. The date is to be specified according to combined date and time in UTC format as specified in ISO 8601 standard."@en ;
+              rdfs:domain         spdx:CreationInfo ;
+              rdfs:range          xsd:dateTime ;
+              rdfs:subPropertyOf  spdx:date ;
+              vs:term_status      "stable" .
+
+dcterms:ISO639-2  rdf:type  rdfs:Datatype ;
+                  rdfs:comment      "The three-letter alphabetic codes listed in ISO639-2 for the representation of names of languages."@en ;
+                  rdfs:isDefinedBy  dcterms: ;
+                  rdfs:label        "ISO 639-2"@en ;
+                  rdfs:seeAlso      <http://lcweb.loc.gov/standards/iso639-2/langhome.html> ;
+                  dcterms:issued    "2000-07-11"^^xsd:date .
+
+skos:historyNote  rdf:type  owl:AnnotationProperty , rdf:Property ;
+                  rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+                  rdfs:label          "history note"@en ;
+                  rdfs:subPropertyOf  skos:note ;
+                  skos:definition     "A note about the past state/use/meaning of a concept."@en .
+
+<http://www.w3.org/2009/pointers#StartEndPointer>
+  rdf:type         owl:Class ;
+  rdfs:subClassOf  <http://www.w3.org/2009/pointers#CompoundPointer> ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onClass               <http://www.w3.org/2009/pointers#SinglePointer> ;
+                     owl:onProperty            <http://www.w3.org/2009/pointers#endPointer> ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onClass               <http://www.w3.org/2009/pointers#SinglePointer> ;
+                     owl:onProperty            <http://www.w3.org/2009/pointers#startPointer> ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  vs:term_status   "stable" .
+
+vcard:Name  rdf:type         owl:Class ;
+            rdfs:comment         "To specify the components of the name of the object"@en ;
+            rdfs:isDefinedBy     <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label           "Name"@en ;
+            owl:equivalentClass  [ rdf:type     owl:Class ;
+                                   owl:unionOf  ( [ rdf:type            owl:Class ;
+                                                    owl:intersectionOf  ( [ rdf:type            owl:Restriction ;
+                                                                            owl:onProperty      vcard:additional-name ;
+                                                                            owl:someValuesFrom  xsd:string
+                                                                          ]
+                                                                          [ rdf:type            owl:Restriction ;
+                                                                            owl:minCardinality  "0"^^xsd:nonNegativeInteger ;
+                                                                            owl:onProperty      vcard:additional-name
+                                                                          ]
+                                                                        )
+                                                  ]
+                                                  [ rdf:type            owl:Class ;
+                                                    owl:intersectionOf  ( [ rdf:type            owl:Restriction ;
+                                                                            owl:onProperty      vcard:family-name ;
+                                                                            owl:someValuesFrom  xsd:string
+                                                                          ]
+                                                                          [ rdf:type            owl:Restriction ;
+                                                                            owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                                                                            owl:onProperty      vcard:family-name
+                                                                          ]
+                                                                        )
+                                                  ]
+                                                  [ rdf:type            owl:Class ;
+                                                    owl:intersectionOf  ( [ rdf:type            owl:Restriction ;
+                                                                            owl:onProperty      vcard:given-name ;
+                                                                            owl:someValuesFrom  xsd:string
+                                                                          ]
+                                                                          [ rdf:type            owl:Restriction ;
+                                                                            owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                                                                            owl:onProperty      vcard:given-name
+                                                                          ]
+                                                                        )
+                                                  ]
+                                                  [ rdf:type            owl:Class ;
+                                                    owl:intersectionOf  ( [ rdf:type            owl:Restriction ;
+                                                                            owl:onProperty      vcard:honorific-prefix ;
+                                                                            owl:someValuesFrom  xsd:string
+                                                                          ]
+                                                                          [ rdf:type            owl:Restriction ;
+                                                                            owl:minCardinality  "0"^^xsd:nonNegativeInteger ;
+                                                                            owl:onProperty      vcard:honorific-prefix
+                                                                          ]
+                                                                        )
+                                                  ]
+                                                  [ rdf:type            owl:Class ;
+                                                    owl:intersectionOf  ( [ rdf:type            owl:Restriction ;
+                                                                            owl:onProperty      vcard:honorific-suffix ;
+                                                                            owl:someValuesFrom  xsd:string
+                                                                          ]
+                                                                          [ rdf:type            owl:Restriction ;
+                                                                            owl:minCardinality  "0"^^xsd:nonNegativeInteger ;
+                                                                            owl:onProperty      vcard:honorific-suffix
+                                                                          ]
+                                                                        )
+                                                  ]
+                                                )
+                             ] .
+
+<http://www.w3.org/2006/vcard/ns>
+  rdf:type         owl:Ontology ;
+  rdfs:comment     "Ontology for vCard based on RFC6350"@en ;
+  rdfs:label       "Ontology for vCard"@en ;
+  owl:versionInfo  "Final"@en .
+
+vcard:tz  rdf:type        owl:DatatypeProperty ;
+          rdfs:comment      "To indicate time zone information that is specific to the object. May also be used as a property parameter."@en ;
+          rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+          rdfs:label        "time zone"@en ;
+          rdfs:range        xsd:string .
+
+vcard:Pref  rdf:type      owl:Class ;
+            rdfs:comment      "This class is deprecated"@en ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "Pref"@en ;
+            rdfs:subClassOf   vcard:Type ;
+            owl:deprecated    true .
+
+spdx:algorithm  rdf:type  owl:ObjectProperty ;
+                rdfs:comment    "Identifies the algorithm used to produce the subject Checksum. Currently, SHA-1 is the only supported algorithm. It is anticipated that other algorithms will be supported at a later time."@en ;
+                rdfs:domain     spdx:Checksum ;
+                vs:term_status  "stable" .
+
+<http://www.w3.org/2009/pointers#Pointer>
+  rdf:type        owl:Class ;
+  vs:term_status  "stable" .
+
+spdx:ListedLicenseException
+  rdf:type         owl:Class ;
+  rdfs:comment     "License exception specific to ListedLicenses" ;
+  rdfs:subClassOf  spdx:LicenseException ;
+  rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                     owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onDataRange              xsd:string ;
+                     owl:onProperty               spdx:exceptionTextHtml
+                   ] .
+
+vcard:family-name  rdf:type  owl:DatatypeProperty ;
+                   rdfs:comment      "The family name associated with the object"@en ;
+                   rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                   rdfs:label        "family name"@en ;
+                   rdfs:range        xsd:string .
+
+spdx:standardLicenseTemplate
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "License template which describes sections of the license which can be varied. See License Template section of the specification for format information."@en ;
+  rdfs:domain     spdx:License ;
+  rdfs:range      xsd:string ;
+  vs:term_status  "stable"@en .
+
+spdx:spdxDocument  rdf:type  owl:ObjectProperty ;
+                   rdfs:comment    "A property containing an SPDX document."@en ;
+                   rdfs:domain     spdx:ExternalDocumentRef ;
+                   rdfs:range      spdx:SpdxDocument ;
+                   vs:term_status  "stable"@en .
+
+prov:Role  rdf:type       owl:Class ;
+           rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+           rdfs:label        "Role" ;
+           rdfs:seeAlso      prov:hadRole ;
+           prov:category     "qualified" ;
+           prov:component    "agents-responsibility" ;
+           prov:definition   "A role is the function of an entity or agent with respect to an activity, in the context of a usage, generation, invalidation, association, start, and end."@en ;
+           prov:dm           "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribute-role"^^xsd:anyURI ;
+           prov:n            "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-attribute"^^xsd:anyURI .
+
+spdx:SpdxItem  rdf:type  owl:Class ;
+               rdfs:comment     "An SpdxItem is a potentially copyrightable work."@en ;
+               rdfs:subClassOf  spdx:SpdxElement ;
+               rdfs:subClassOf  [ rdf:type     owl:Class ;
+                                  owl:unionOf  ( [ rdf:type        owl:Restriction ;
+                                                   owl:hasValue    spdx:noassertion ;
+                                                   owl:onProperty  spdx:licenseConcluded
+                                                 ]
+                                                 [ rdf:type        owl:Restriction ;
+                                                   owl:hasValue    spdx:none ;
+                                                   owl:onProperty  spdx:licenseConcluded
+                                                 ]
+                                                 [ rdf:type                     owl:Restriction ;
+                                                   owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                                   owl:onClass                  spdx:AnyLicenseInfo ;
+                                                   owl:onProperty               spdx:licenseConcluded
+                                                 ]
+                                               )
+                         ] ;
+               rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                  owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                                  owl:onClass                  spdx:AnyLicenseInfo ;
+                                  owl:onProperty               spdx:licenseInfoFromFiles
+                         ] ;
+               rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                  owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange              xsd:string ;
+                                  owl:onProperty               spdx:attributionText
+                         ] ;
+               rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                  owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange              xsd:string ;
+                                  owl:onProperty               spdx:copyrightText
+                         ] ;
+               rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                  owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange              xsd:string ;
+                                  owl:onProperty               spdx:licenseComments
+                         ] ;
+               vs:term_status   "stable"@en .
+
+prov:qualifiedAttribution
+  rdf:type                   owl:ObjectProperty ;
+  rdfs:comment               "If this Entity prov:wasAttributedTo Agent :ag, then it can qualify how it was influenced using prov:qualifiedAttribution [ a prov:Attribution;  prov:agent :ag; :foo :bar ]."@en ;
+  rdfs:domain                prov:Entity ;
+  rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label                 "qualifiedAttribution" ;
+  rdfs:range                 prov:Attribution ;
+  rdfs:subPropertyOf         prov:qualifiedInfluence ;
+  prov:category              "qualified" ;
+  prov:component             "agents-responsibility" ;
+  prov:inverse               "qualifiedAttributionOf" ;
+  prov:sharesDefinitionWith  prov:Attribution ;
+  prov:unqualifiedForm       prov:wasAttributedTo .
+
+adms:includedAsset  rdf:type  owl:ObjectProperty ;
+                    rdfs:comment      "An Asset that is contained in the Asset being described, e.g. when there are several vocabularies defined in a single document."@en ;
+                    rdfs:domain       adms:Asset ;
+                    rdfs:isDefinedBy  <http://www.w3.org/ns/adms> ;
+                    rdfs:label        "included asset"@en ;
+                    rdfs:range        adms:Asset .
+
+prov:definition  rdf:type  owl:AnnotationProperty ;
+                 rdfs:comment      "A definition quoted from PROV-DM or PROV-CONSTRAINTS that describes the concept expressed with this OWL term."@en ;
+                 rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> .
+
+time:week  rdf:type     owl:DatatypeProperty ;
+           rdfs:comment    "Week number within the year."@en , "Número de semana en el año."@es ;
+           rdfs:domain     time:GeneralDateTimeDescription ;
+           rdfs:label      "week"@en , "semana"@es ;
+           rdfs:range      xsd:nonNegativeInteger ;
+           skos:note       "Weeks are numbered differently depending on the calendar in use and the local language or cultural conventions (locale). ISO-8601 specifies that the first week of the year includes at least four days, and that Monday is the first day of the week. In that system, week 1 is the week that contains the first Thursday in the year."@en ;
+           skos:scopeNote  "Las semanas están numeradas de forma diferente dependiendo del calendario en uso y de las convenciones lingüísticas y culturales locales (locale en inglés). El ISO-8601 especifica que la primera semana del año incluye al menos cuatro días, y que el lunes es el primer día de la semana. En ese sistema, la semana 1 es la semana que contiene el primer jueves del año."@es .
+
+spdx:builtDate  rdf:type    owl:DatatypeProperty ;
+                rdfs:comment        "This field provides a place for recording the actual date the package was built."@en ;
+                rdfs:domain         spdx:Package ;
+                rdfs:range          xsd:dateTime ;
+                rdfs:subPropertyOf  spdx:date ;
+                vs:term_status      "stable"@en .
+
+prov:category  rdf:type   owl:AnnotationProperty ;
+               rdfs:comment      "Classify prov-o terms into three categories, including 'starting-point', 'qualifed', and 'extended'. This classification is used by the prov-o html document to gently introduce prov-o terms to its users. "@en ;
+               rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> .
+
+vcard:Acquaintance  rdf:type  owl:Class ;
+                    rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                    rdfs:label        "Acquaintance"@en ;
+                    rdfs:subClassOf   vcard:RelatedType .
+
+dcterms:FileFormat  rdf:type  rdfs:Class ;
+                    rdfs:comment      "A digital resource format."@en ;
+                    rdfs:isDefinedBy  dcterms: ;
+                    rdfs:label        "File Format"@en ;
+                    rdfs:subClassOf   dcterms:MediaType ;
+                    dcterms:issued    "2008-01-14"^^xsd:date .
+
+spdx:relationshipType_runtimeDependencyOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is a dependency required for the execution of SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+time:intervalBefore  rdf:type  owl:ObjectProperty ;
+                     rdfs:comment        "Si un intervalo propio T1 está antes que otro intervalo propio T2, entonces el final de T1 está antes que el principio de T2."@es , "If a proper interval T1 is intervalBefore another proper interval T2, then the end of T1 is before the beginning of T2."@en ;
+                     rdfs:domain         time:ProperInterval ;
+                     rdfs:label          "interval before"@en , "intervalo anterior"@es ;
+                     rdfs:range          time:ProperInterval ;
+                     rdfs:subPropertyOf  time:intervalDisjoint , time:before ;
+                     owl:inverseOf       time:intervalAfter ;
+                     skos:definition     "Si un intervalo propio T1 está antes que otro intervalo propio T2, entonces el final de T1 está antes que el principio de T2."@es , "If a proper interval T1 is intervalBefore another proper interval T2, then the end of T1 is before the beginning of T2."@en .
+
+time:intervalContains
+  rdf:type         owl:ObjectProperty ;
+  rdfs:comment     "Si un intervalo propio T1 contiene otro intervalo propio T2, entonces el principio de T1 está antes que el principio de T2, y el final de T1 está después del final de T2."@es , "If a proper interval T1 is intervalContains another proper interval T2, then the beginning of T1 is before the beginning of T2, and the end of T1 is after the end of T2."@en ;
+  rdfs:domain      time:ProperInterval ;
+  rdfs:label       "intervalo contiene"@es , "interval contains"@en ;
+  rdfs:range       time:ProperInterval ;
+  owl:inverseOf    time:intervalDuring ;
+  skos:definition  "Si un intervalo propio T1 contiene otro intervalo propio T2, entonces el principio de T1 está antes que el principio de T2, y el final de T1 está después del final de T2."@es , "If a proper interval T1 is intervalContains another proper interval T2, then the beginning of T1 is before the beginning of T2, and the end of T1 is after the end of T2."@en .
+
+time:DateTimeDescription
+  rdf:type         owl:Class ;
+  rdfs:comment     "Descripción de fecha y tiempo estructurada con valores separados para los diferentes elementos de un sistema calendario-reloj. El sistema de referencia temporal está fijado al calendario gregoriano, y el rango de las propiedades año, mes, día restringidas a los correspondientes tipos del XML Schema xsd:gYear, xsd:gMonth y xsd:gDay respectivamente."@es , "Description of date and time structured with separate values for the various elements of a calendar-clock system. The temporal reference system is fixed to Gregorian Calendar, and the range of year, month, day properties restricted to corresponding XML Schema types xsd:gYear, xsd:gMonth and xsd:gDay, respectively."@en ;
+  rdfs:label       "descripción de fecha-tiempo"@es , "Date-Time description"@en ;
+  rdfs:subClassOf  time:GeneralDateTimeDescription ;
+  rdfs:subClassOf  [ rdf:type           owl:Restriction ;
+                     owl:allValuesFrom  xsd:gMonth ;
+                     owl:onProperty     time:month
+                   ] ;
+  rdfs:subClassOf  [ rdf:type           owl:Restriction ;
+                     owl:allValuesFrom  xsd:gYear ;
+                     owl:onProperty     time:year
+                   ] ;
+  rdfs:subClassOf  [ rdf:type        owl:Restriction ;
+                     owl:hasValue    <http://www.opengis.net/def/uom/ISO-8601/0/Gregorian> ;
+                     owl:onProperty  time:hasTRS
+                   ] ;
+  rdfs:subClassOf  [ rdf:type           owl:Restriction ;
+                     owl:allValuesFrom  xsd:gDay ;
+                     owl:onProperty     time:day
+                   ] ;
+  skos:definition  "Descripción de fecha y tiempo estructurada con valores separados para los diferentes elementos de un sistema calendario-reloj. El sistema de referencia temporal está fijado al calendario gregoriano, y el rango de las propiedades año, mes, día restringidas a los correspondientes tipos del XML Schema xsd:gYear, xsd:gMonth y xsd:gDay respectivamente."@es , "Description of date and time structured with separate values for the various elements of a calendar-clock system. The temporal reference system is fixed to Gregorian Calendar, and the range of year, month, day properties restricted to corresponding XML Schema types xsd:gYear, xsd:gMonth and xsd:gDay, respectively."@en .
+
+<https://joinup.ec.europa.eu/node/55858>
+  dcterms:title  "Core Vocabularies Specification" .
+
+spdx:contextualExample
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "Example for use of the external repository identifier"@en ;
+  rdfs:domain     spdx:ReferenceType ;
+  rdfs:range      xsd:anyURI ;
+  vs:term_status  "stable"@en .
+
+locn:geographicName  rdf:type  rdf:Property ;
+                     rdfs:comment        "\nA geographic name is a proper noun applied to a spatial object. Taking the example used in the relevant INSPIRE data specification (page 18), the following are all valid geographic names for the Greek capital:\n- Αθήνα (the Greek endonym written in the Greek script)\n- Athína (the standard Romanisation of the endonym)\n- Athens (the English language exonym)\nFor INSPIRE-conformant data, provide the metadata for the geographic name using a skos:Concept as a datatype.\n"@en ;
+                     rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+                     rdfs:label          "geographic name"@en ;
+                     dcterms:identifier  "locn:geographicName" ;
+                     vs:term_status      "testing"@en ;
+                     wdsr:describedby    <https://joinup.ec.europa.eu/node/55858> .
+
+time:TimeZone  rdf:type   owl:Class ;
+               rdfs:comment      "Un huso horario especifica la cantidad en que la hora local está desplazada con respecto a UTC.\n        Un huso horario normalmente se denota geográficamente (p.ej. el horario de verano del este de Australia), con un valor constante en una región dada.\n        La región donde aplica y el desplazamiento desde UTC las especifica una autoridad gubernamental localmente reconocida."@es , "A Time Zone specifies the amount by which the local time is offset from UTC. \n\tA time zone is usually denoted geographically (e.g. Australian Eastern Daylight Time), with a constant value in a given region. \nThe region where it applies and the offset from UTC are specified by a locally recognised governing authority."@en ;
+               rdfs:label        "Time Zone"@en , "huso horario"@es ;
+               skos:definition   "Un huso horario especifica la cantidad en que la hora local está desplazada con respecto a UTC.\n    Un huso horario normalmente se denota geográficamente (p.ej. el horario de verano del este de Australia), con un valor constante en una región dada.\n    La región donde aplica y el desplazamiento desde UTC las especifica una autoridad gubernamental localmente reconocida."@es , "A Time Zone specifies the amount by which the local time is offset from UTC. \n\tA time zone is usually denoted geographically (e.g. Australian Eastern Daylight Time), with a constant value in a given region. \nThe region where it applies and the offset from UTC are specified by a locally recognised governing authority."@en ;
+               skos:historyNote  "En la versión original de OWL-Time de 2006, se definió, en un espacio de nombres diferente \"http://www.w3.org/2006/timezone#\", la clase 'huso horario', con varias propiedades específicas correspondientes a un modelo específico de huso horario.\n    En la versión actual hay una clase con el mismo nombre local en el espacio de nombres de OWL-Time, eliminando la dependencia del espacio de nombres externo.\n    Un axioma de alineación permite que los datos codificados de acuerdo con la versión anterior sean consistentes con la ontología actualizada."@es , "In the original 2006 version of OWL-Time, the TimeZone class, with several properties corresponding to a specific model of time-zones, was defined in a separate namespace \"http://www.w3.org/2006/timezone#\". \n\nIn the current version a class with same local name is put into the main OWL-Time namespace, removing the dependency on the external namespace. \n\nAn alignment axiom \n\ttzont:TimeZone rdfs:subClassOf time:TimeZone . \nallows data encoded according to the previous version to be consistent with the updated ontology. " ;
+               skos:note         "A designated timezone is associated with a geographic region. However, for a particular region the offset from UTC often varies seasonally, and the dates of the changes may vary from year to year. The timezone designation usually changes for the different seasons (e.g. Australian Eastern Standard Time vs. Australian Eastern Daylight Time). Furthermore, the offset for a timezone may change over longer timescales, though its designation might not.  \n\nDetailed guidance about working with time zones is given in http://www.w3.org/TR/timezone/ ."@en , "An ontology for time zone descriptions was described in [owl-time-20060927] and provided as RDF in a separate namespace tzont:. However, that ontology was incomplete in scope, and the example datasets were selective. Furthermore, since the use of a class from an external ontology as the range of an ObjectProperty in OWL-Time creates a dependency, reference to the time zone class has been replaced with the 'stub' class in the normative part of this version of OWL-Time."@en , "Un huso horario designado está asociado con una región geográfica. Sin embargo, para una región particular el desplazamiento desde UTC a menudo varía según las estaciones, y las fechas de los cambios pueden variar de un año a otro. La designación de huso horario  normalmente cambia de una estación a otra (por ejemplo, el horario estándar frente al horario de verano ambos del este de Australia). Además, del desplazamiento para un huso horario puede cambiar sobre escalas de tiempo mayores, aunque su designación no lo haga.\n    Se puede encontrar una guía detallada sobre el funcionamiento de husos horarios en http://www.w3.org/TR/timezone/.\"@es , \"En [owl-time-20060927] se describió una ontología para descripciones de husos horarios, y se proporcionó en un espacio de nombres separado tzont:. Sin embargo, dicha ontología estaba incompleta en su alcance, y el ejemplo de conjuntos de datos (datasets) era selectivo. Además, puesto que el uso de una clase de una ontología externa como el rango de una propiedad de objeto en OWL-Time crea una dependencia, la referencia a la clase huso horario se ha reemplazado por una clase que viene a ser un \"cajón de sastre\" en la en la parte normativa de esta versión de OWL-Time."@es ;
+               skos:scopeNote    "En esta implementación 'huso horario' no tiene definidas propiedades. Se debería pensar como una superclase \"abstracta\" de todas las implementaciones de huso horario específicas."@es , "In this implementation TimeZone has no properties defined. It should be thought of as an 'abstract' superclass of all specific timezone implementations." .
+
+vcard:latitude  rdf:type  owl:DatatypeProperty ;
+                rdfs:comment      "This data property has been deprecated. See hasGeo"@en ;
+                rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                rdfs:label        "latitude"@en ;
+                owl:deprecated    true .
+
+<http://www.w3.org/ns/prov-o#>
+  rdf:type               owl:Ontology ;
+  rdfs:comment           "This document is published by the Provenance Working Group (http://www.w3.org/2011/prov/wiki/Main_Page). \n\nIf you wish to make comments regarding this document, please send them to public-prov-comments@w3.org (subscribe public-prov-comments-request@w3.org, archives http://lists.w3.org/Archives/Public/public-prov-comments/). All feedback is welcome."@en ;
+  rdfs:label             "W3C PROVenance Interchange Ontology (PROV-O)"@en ;
+  rdfs:seeAlso           <http://www.w3.org/TR/prov-o/> , <http://www.w3.org/ns/prov> ;
+  owl:versionIRI         <http://www.w3.org/ns/prov-o-20130430> ;
+  owl:versionInfo        "Recommendation version 2013-04-30"@en ;
+  prov:specializationOf  <http://www.w3.org/ns/prov-o> ;
+  prov:wasRevisionOf     <http://www.w3.org/ns/prov-o-20130312> .
+
+spdx:FileType  rdf:type  owl:Class ;
+               rdfs:comment    "Type of file."@en ;
+               vs:term_status  "stable"@en .
+
+rdfs:comment  rdf:type    owl:AnnotationProperty , owl:DatatypeProperty ;
+              rdfs:comment      ""@en ;
+              rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+              rdfs:range        xsd:string .
+
+spdx:purpose_framework
+  rdf:type        owl:NamedIndividual , spdx:Purpose ;
+  rdfs:comment    "The package is a software framework."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:specVersion  rdf:type  owl:DatatypeProperty ;
+                  rdfs:comment  "Provide a reference number that can be used to understand how to parse and interpret the rest of the file. It will enable both future changes to the specification and to support backward compatibility. The version number consists of a major and minor version indicator. The major field will be incremented when incompatible changes between versions are made (one or more sections are created, modified or deleted). The minor field will be incremented when backwards compatible changes are made."@en ;
+                  rdfs:domain   spdx:SpdxDocument ;
+                  rdfs:range    xsd:string .
+
+dcterms:RFC5646  rdf:type    rdfs:Datatype ;
+                 rdfs:comment         "The set of tags constructed according to RFC 5646 for the identification of languages."@en ;
+                 rdfs:isDefinedBy     dcterms: ;
+                 rdfs:label           "RFC 5646"@en ;
+                 rdfs:seeAlso         <http://www.ietf.org/rfc/rfc5646.txt> ;
+                 dcterms:description  "RFC 5646 obsoletes RFC 4646."@en ;
+                 dcterms:issued       "2010-10-11"^^xsd:date .
+
+skos:narrower  rdf:type     owl:ObjectProperty , rdf:Property ;
+               rdfs:comment        "Narrower concepts are typically rendered as children in a concept hierarchy (tree)."@en ;
+               rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+               rdfs:label          "has narrower"@en ;
+               rdfs:subPropertyOf  skos:narrowerTransitive ;
+               owl:inverseOf       skos:broader ;
+               skos:definition     "Relates a concept to a concept that is more specific in meaning."@en ;
+               skos:scopeNote      "By convention, skos:broader is only used to assert an immediate (i.e. direct) hierarchical link between two conceptual resources."@en .
+
+spdx:ExternalDocumentRef
+  rdf:type         owl:Class ;
+  rdfs:comment     "Information about an external SPDX document reference including the checksum. This allows for verification of the external references."@en ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onClass               spdx:Checksum ;
+                     owl:onProperty            spdx:checksum ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onClass               spdx:SpdxDocument ;
+                     owl:onProperty            spdx:spdxDocument ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onDataRange           xsd:anyURI ;
+                     owl:onProperty            spdx:externalDocumentId ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  vs:term_status   "stable"@en .
+
+skos:memberList  rdf:type  owl:ObjectProperty , owl:FunctionalProperty , rdf:Property ;
+                 rdfs:comment      "For any resource, every item in the list given as the value of the\n      skos:memberList property is also a value of the skos:member property."@en ;
+                 rdfs:domain       skos:OrderedCollection ;
+                 rdfs:isDefinedBy  <http://www.w3.org/2004/02/skos/core> ;
+                 rdfs:label        "has member list"@en ;
+                 rdfs:range        rdf:List ;
+                 skos:definition   "Relates an ordered collection to the RDF list containing its members."@en .
+
+spdx:purpose_other  rdf:type  owl:NamedIndividual , spdx:Purpose ;
+                    rdfs:comment    "The package doesn't fit into other purpose defined terms."@en ;
+                    vs:term_status  "stable"@en .
+
+prov:atLocation  rdf:type          owl:ObjectProperty ;
+                 rdfs:comment               "The Location of any resource."@en , "This property has multiple RDFS domains to suit multiple OWL Profiles. See <a href=\"#owl-profile\">PROV-O OWL Profile</a>." ;
+                 rdfs:domain                [ rdf:type     owl:Class ;
+                                              owl:unionOf  ( prov:Activity prov:Agent prov:Entity prov:InstantaneousEvent )
+                                   ] ;
+                 rdfs:domain                [ rdf:type     owl:Class ;
+                                              owl:unionOf  ( prov:Activity prov:Agent prov:Entity prov:InstantaneousEvent )
+                                   ] ;
+                 rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+                 rdfs:label                 "atLocation" ;
+                 rdfs:range                 prov:Location ;
+                 prov:category              "expanded" ;
+                 prov:editorialNote         "This property is not functional because the many values could be at a variety of granularies (In this building, in this room, in that chair)."@en , "The naming of prov:atLocation parallels prov:atTime, and is not named prov:hadLocation to avoid conflicting with the convention that prov:had* properties are used on prov:Influence classes."@en ;
+                 prov:inverse               "locationOf" ;
+                 prov:sharesDefinitionWith  prov:Location .
+
+foaf:primaryTopic  rdf:type  owl:ObjectProperty ;
+                   rdfs:comment  "This axiom needed so that Protege loads DCAT2 without errors." .
+
+adms:last  rdf:type         owl:ObjectProperty ;
+           rdfs:comment        "A link to the current or latest version of the Asset."@en ;
+           rdfs:domain         rdfs:Resource ;
+           rdfs:isDefinedBy    <http://www.w3.org/ns/adms> ;
+           rdfs:label          "last"@en ;
+           rdfs:range          rdfs:Resource ;
+           rdfs:subPropertyOf  <http://www.w3.org/1999/xhtml/vocab#last> .
+
+dcterms:replaces  rdf:type   rdf:Property ;
+                  rdfs:comment         "A related resource that is supplanted, displaced, or superseded by the described resource."@en ;
+                  rdfs:isDefinedBy     dcterms: ;
+                  rdfs:label           "Replaces"@en ;
+                  rdfs:subPropertyOf   dc:relation , dcterms:relation ;
+                  dcterms:description  "This property is intended to be used with non-literal values. This property is an inverse property of Is Replaced By."@en ;
+                  dcterms:issued       "2000-07-11"^^xsd:date .
+
+vcard:hasSource  rdf:type  owl:ObjectProperty ;
+                 rdfs:comment      "To identify the source of directory information of the object"@en ;
+                 rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                 rdfs:label        "has source"@en .
+
+vcard:Location  rdf:type  owl:Class ;
+                rdfs:comment      "An object representing a named geographical place"@en ;
+                rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                rdfs:label        "Location"@en ;
+                rdfs:subClassOf   vcard:Kind ;
+                owl:disjointWith  vcard:Organization .
+
+spdx:ReferenceType  rdf:type  owl:Class ;
+                    rdfs:comment     "Types used to external reference identifiers."@en ;
+                    rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                       owl:onDataRange           xsd:anyURI ;
+                                       owl:onProperty            spdx:contextualExample ;
+                                       owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                              ] ;
+                    rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                       owl:onDataRange           xsd:anyURI ;
+                                       owl:onProperty            spdx:documentation ;
+                                       owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                              ] ;
+                    rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                       owl:onDataRange           xsd:anyURI ;
+                                       owl:onProperty            spdx:externalReferenceSite ;
+                                       owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                              ] ;
+                    vs:term_status   "stable"@en .
+
+spdx:artifactOf  rdf:type  owl:ObjectProperty ;
+                 rdfs:comment    "Deprecated as of version 2.1"@en , "Indicates the project in which the SpdxElement originated. Tools must preserve doap:homepage and doap:name properties and the URI (if one is known) of doap:Project resources that are values of this property. All other properties of doap:Projects are not directly supported by SPDX and may be dropped when translating to or from some SPDX formats."@en ;
+                 rdfs:domain     spdx:SpdxElement ;
+                 rdfs:range      doap:Project ;
+                 owl:deprecated  true ;
+                 vs:term_status  "deprecated"@en .
+
+spdx:licenseListVersion
+  rdf:type        owl:DatatypeProperty , owl:FunctionalProperty ;
+  rdfs:comment    "An optional field for creators of the SPDX file to provide the version of the SPDX License List used when the SPDX file was created."@en ;
+  rdfs:domain     spdx:CreationInfo ;
+  rdfs:range      xsd:string ;
+  vs:term_status  "stable"@en .
+
+spdx:copyrightText  rdf:type  owl:DatatypeProperty ;
+                    rdfs:comment    "The text of copyright declarations recited in the package, file or snippet.\n\nIf the copyrightText field is not present, it implies an equivalent meaning to NOASSERTION."@en ;
+                    rdfs:domain     spdx:SpdxItem ;
+                    rdfs:range      rdfs:Literal , xsd:string ;
+                    vs:term_status  "stable"@en .
+
+<http://www.w3.org/2009/pointers#ByteOffsetPointer>
+  rdf:type         owl:Class ;
+  rdfs:subClassOf  <http://www.w3.org/2009/pointers#OffsetPointer> ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onDataRange           xsd:positiveInteger ;
+                     owl:onProperty            <http://www.w3.org/2009/pointers#offset> ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  vs:term_status   "stable" .
+
+spdx:OrLaterOperator  rdf:type  owl:Class ;
+                      rdfs:comment     "A license with an or later operator indicating this license version or any later version of the license"@en ;
+                      rdfs:subClassOf  spdx:AnyLicenseInfo ;
+                      rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                         owl:onClass               spdx:SimpleLicensingInfo ;
+                                         owl:onProperty            spdx:member ;
+                                         owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                                ] ;
+                      vs:term_status   "stable"@en .
+
+dcterms:Policy  rdf:type  rdfs:Class ;
+                rdfs:comment      "A plan or course of action by an authority, intended to influence and determine decisions, actions, and other matters."@en ;
+                rdfs:isDefinedBy  dcterms: ;
+                rdfs:label        "Policy"@en ;
+                dcterms:issued    "2008-01-14"^^xsd:date .
+
+<http://data.europa.eu/r5r#Relationship_Shape>
+  rdf:type        sh:NodeShape ;
+  sh:name         "Relationship"@en ;
+  sh:property     [ sh:minCount  1 ;
+                    sh:path      dcat:hadRole ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:minCount  1 ;
+                    sh:path      dcterms:relation ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:targetClass  dcat:Relationship .
+
+dcat:servesDataset  rdf:type  owl:ObjectProperty ;
+                    rdfs:comment     "Una colección de datos que este Servicio de Datos puede distribuir."@es , "En samling af data som denne datatjeneste kan distribuere."@da , "Una raccolta di dati che questo DataService può distribuire."@it , "Kolekce dat, kterou je tato Datová služba schopna poskytnout."@cs , "A collection of data that this DataService can distribute."@en ;
+                    rdfs:domain      dcat:DataService ;
+                    rdfs:label       "serve set di dati"@it , "datatjeneste for datasæt"@da , "poskytuje datovou sadu"@cs , "serves dataset"@en , "provee conjunto de datos"@es ;
+                    rdfs:range       dcat:Dataset ;
+                    skos:altLabel    "udstiller"@da , "ekspederer"@da , "distribuerer"@da ;
+                    skos:changeNote  "New property in DCAT 2.0."@en , "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs , "Nuova proprietà in DCAT 2.0."@it , "Nueva propiedad agregada en DCAT 2.0."@es ;
+                    skos:definition  "En samling af data som denne datatjeneste kan distribuere."@da , "Una raccolta di dati che questo DataService può distribuire."@it , "A collection of data that this DataService can distribute."@en , "Una colección de datos que este Servicio de Datos puede distribuir."@es , "Kolekce dat, kterou je tato Datová služba schopna poskytnout."@cs .
+
+dcterms:Standard  rdf:type  rdfs:Class ;
+                  rdfs:comment      "A reference point against which other things can be evaluated or compared."@en ;
+                  rdfs:isDefinedBy  dcterms: ;
+                  rdfs:label        "Standard"@en ;
+                  dcterms:issued    "2008-01-14"^^xsd:date .
+
+time:Tuesday  rdf:type  time:DayOfWeek ;
+              rdfs:label      "Tuesday"@en ;
+              skos:prefLabel  "Dienstag"@de , "Terça-feira"@pt , "الثلاثاء"@ar , "Mardi"@fr , "Вторник"@ru , "Dinsdag"@nl , "火曜日"@ja , "Wtorek"@pl , "Tuesday"@en , "Martes"@es , "星期二"@zh , "Martedì"@it .
+
+spdx:relationshipType_optionalDependencyOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is an optional dependency of SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+time:hasDuration  rdf:type  owl:ObjectProperty ;
+                  rdfs:comment        "Duration of a temporal entity, expressed as a scaled value or nominal value"@en , "Duración de una entidad temporal, expresada como un valor escalado o un valor nominal."@es ;
+                  rdfs:label          "has duration"@en , "tiene duración"@es ;
+                  rdfs:range          time:Duration ;
+                  rdfs:subPropertyOf  time:hasTemporalDuration ;
+                  skos:definition     "Duration of a temporal entity, event or activity, or thing, expressed as a scaled value"@en , "Duración de una entidad temporal, evento o actividad, o cosa, expresada como un valor escalado."@es .
+
+dcterms:PeriodOfTime  rdf:type  rdfs:Class ;
+                      rdfs:comment      "An interval of time that is named or defined by its start and end dates."@en ;
+                      rdfs:isDefinedBy  dcterms: ;
+                      rdfs:label        "Period of Time"@en ;
+                      rdfs:subClassOf   dcterms:LocationPeriodOrJurisdiction ;
+                      dcterms:issued    "2008-01-14"^^xsd:date .
+
+spdx:WithExceptionOperator
+  rdf:type         owl:Class ;
+  rdfs:comment     "Sometimes a set of license terms apply except under special circumstances. In this case, use the binary \"WITH\" operator to construct a new license expression to represent the special exception situation. A valid <license-expression> is where the left operand is a <simple-expression> value and the right operand is a <license-exception-id> that represents the special exception terms."@en ;
+  rdfs:subClassOf  spdx:AnyLicenseInfo ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onClass               spdx:LicenseException ;
+                     owl:onProperty            spdx:licenseException ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onClass               spdx:SimpleLicensingInfo ;
+                     owl:onProperty            spdx:member ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  vs:term_status   "stable"@en .
+
+vcard:hasRegion  rdf:type  owl:ObjectProperty ;
+                 rdfs:comment      "Used to support property parameters for the region data property"@en ;
+                 rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                 rdfs:label        "has region"@en .
+
+[ rdf:type     owl:AllDisjointClasses ;
+  owl:members  ( spdx:Annotation spdx:Relationship spdx:SpdxElement )
+] .
+
+spdx:externalRef  rdf:type  owl:ObjectProperty ;
+                  rdfs:comment    "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package."@en ;
+                  rdfs:domain     spdx:Package ;
+                  rdfs:range      spdx:ExternalRef ;
+                  vs:term_status  "stable"@en .
+
+vcard:hasGeo  rdf:type    owl:ObjectProperty ;
+              rdfs:comment      "To specify information related to the global positioning of the object. May also be used as a property parameter."@en ;
+              rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+              rdfs:label        "has geo"@en .
+
+vcard:Postal  rdf:type    owl:Class ;
+              rdfs:comment      "This class is deprecated"@en ;
+              rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+              rdfs:label        "Postal"@en ;
+              rdfs:subClassOf   vcard:Type ;
+              owl:deprecated    true .
+
+time:GeneralDurationDescription
+  rdf:type         owl:Class ;
+  rdfs:comment     "Descripción de extensión temporal estructurada con valores separados para los distintos elementos de un sistema de horario-calendario."@es , "Description of temporal extent structured with separate values for the various elements of a calendar-clock system."@en ;
+  rdfs:label       "descripción de duración generalizada"@es , "Generalized duration description"@en ;
+  rdfs:subClassOf  time:TemporalDuration ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:minutes
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:weeks
+                   ] ;
+  rdfs:subClassOf  [ rdf:type         owl:Restriction ;
+                     owl:cardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty   time:hasTRS
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:hours
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:years
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:days
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:seconds
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:months
+                   ] ;
+  skos:definition  "Description of temporal extent structured with separate values for the various elements of a calendar-clock system."@en , "Descripción de extensión temporal estructurada con valores separados para los distintos elementos de un sistema de horario-calendario."@es ;
+  skos:note        "La extensión de una duración de tiempo expresada como una 'descripción de duración general' depende del Sistema de Referencia Temporal. En algunos calendarios la longitud de la semana o del mes no es constante a lo largo del año. Por tanto, un valor como \"25 meses\" puede no ser necesariamente ser comparado con un duración similar expresada en términos de semanas o días. Cuando se consideran calendarios que no están basados en el movimiento de la Tierra, se deben tomar incluso más precauciones en la comparación de duraciones."@es , "The extent of a time duration expressed as a GeneralDurationDescription depends on the Temporal Reference System. In some calendars the length of the week or month is not constant within the year. Therefore, a value like \"2.5 months\" may not necessarily be exactly compared with a similar duration expressed in terms of weeks or days. When non-earth-based calendars are considered even more care must be taken in comparing durations."@en .
+
+prov:Activity  rdf:type   owl:Class ;
+               rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+               rdfs:label        "Activity" ;
+               owl:disjointWith  prov:Entity ;
+               prov:category     "starting-point" ;
+               prov:component    "entities-activities" ;
+               prov:constraints  "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+               prov:definition   "An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities." ;
+               prov:dm           "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Activity"^^xsd:anyURI ;
+               prov:n            "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Activity"^^xsd:anyURI .
+
+time:Interval  rdf:type  owl:Class ;
+               rdfs:comment     "A temporal entity with an extent or duration"@en , "Una entidad temporal con una extensión o duración."@es ;
+               rdfs:label       "Time interval"@en , "intervalo de tiempo"@es ;
+               rdfs:subClassOf  time:TemporalEntity ;
+               skos:definition  "A temporal entity with an extent or duration"@en , "Una entidad temporal con una extensión o duración."@es .
+
+vcard:Voice  rdf:type     owl:Class ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "Voice"@en ;
+             rdfs:subClassOf   vcard:TelephoneType .
+
+vcard:hasFN  rdf:type     owl:ObjectProperty ;
+             rdfs:comment      "Used to support property parameters for the formatted name data property"@en ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "has formatted name"@en .
+
+vcard:street-address  rdf:type  owl:DatatypeProperty ;
+                      rdfs:comment      "The street address associated with the address of the object"@en ;
+                      rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                      rdfs:label        "street address"@en ;
+                      rdfs:range        xsd:string .
+
+dcterms:LCSH  rdf:type    dcam:VocabularyEncodingScheme ;
+              rdfs:comment      "The set of labeled concepts specified by the Library of Congress Subject Headings."@en ;
+              rdfs:isDefinedBy  dcterms: ;
+              rdfs:label        "LCSH"@en ;
+              dcterms:issued    "2000-07-11"^^xsd:date .
+
+time:hasDurationDescription
+  rdf:type            owl:ObjectProperty ;
+  rdfs:comment        "Duration of a temporal entity, expressed using a structured description"@en , "Duración de una entidad temporal, expresada utilizando una descripción estructurada."@es ;
+  rdfs:label          "has duration description"@en , "tiene descripción de duración"@es ;
+  rdfs:range          time:GeneralDurationDescription ;
+  rdfs:subPropertyOf  time:hasTemporalDuration ;
+  skos:definition     "Duration of a temporal entity, expressed using a structured description"@en , "Duración de una entidad temporal, expresada utilizando una descripción estructurada."@es .
+
+vcard:role  rdf:type      owl:DatatypeProperty ;
+            rdfs:comment      "To specify the function or part played in a particular situation by the object"@en ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "role"@en ;
+            rdfs:range        xsd:string .
+
+time:generalDay  rdf:type     rdfs:Datatype ;
+                 rdfs:comment          "Day of month - formulated as a text string with a pattern constraint to reproduce the same lexical form as gDay, except that values up to 99 are permitted, in order to support calendars with more than 31 days in a month. \nNote that the value-space is not defined, so a generic OWL2 processor cannot compute ordering relationships of values of this type."@en , "Día del mes - formulado como una cadena de texto con una restricción patrón para reproducir la misma forma léxica que gDay, excepto que se permiten valores hasta el 99, con el propósito de proporcionar soporte a calendarios con meses con más de 31 días.\n            Nótese que el espacio de valores no está definido, por tanto, un procesador genérico de OWL2 no puede computar relaciones de orden de valores de este tipo."@es ;
+                 rdfs:label            "Generalized day"@en , "Día generalizado"@es ;
+                 owl:onDatatype        xsd:string ;
+                 owl:withRestrictions  ( [ xsd:pattern  "---(0[1-9]|[1-9][0-9])(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?" ]
+                              ) ;
+                 skos:definition       "Day of month - formulated as a text string with a pattern constraint to reproduce the same lexical form as gDay, except that values up to 99 are permitted, in order to support calendars with more than 31 days in a month. \nNote that the value-space is not defined, so a generic OWL2 processor cannot compute ordering relationships of values of this type."@en , "Día del mes - formulado como una cadena de texto con una restricción patrón para reproducir la misma forma léxica que gDay, excepto que se permiten valores hasta el 99, con el propósito de proporcionar soporte a calendarios con meses con más de 31 días.\n            Nótese que el espacio de valores no está definido, por tanto, un procesador genérico de OWL2 no puede computar relaciones de orden de valores de este tipo."@es .
+
+spdx:isDeprecatedLicenseId
+  rdf:type     owl:DatatypeProperty ;
+  rdfs:domain  spdx:ListedLicense ;
+  rdfs:range   xsd:boolean .
+
+spdx:checksumAlgorithm_md4
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was MD4" ;
+  vs:term_status  "stable" .
+
+spdx:relationshipType_other
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "to be used for a relationship which has not been defined in the formal SPDX specification. A description of the relationship should be included in the Relationship comments field."@en ;
+  vs:term_status  "stable"@en .
+
+vcard:Me  rdf:type        owl:Class ;
+          rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+          rdfs:label        "Me"@en ;
+          rdfs:subClassOf   vcard:RelatedType .
+
+spdx:licenseExceptionId
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "Short form license exception identifier in Appendix I.2 of the SPDX specification."@en ;
+  rdfs:domain     spdx:LicenseException ;
+  rdfs:range      xsd:string ;
+  vs:term_status  "stable"@en .
+
+dcterms:bibliographicCitation
+  rdf:type             rdf:Property ;
+  rdfs:comment         "A bibliographic reference for the resource."@en ;
+  rdfs:isDefinedBy     dcterms: ;
+  rdfs:label           "Bibliographic Citation"@en ;
+  rdfs:range           rdfs:Literal ;
+  rdfs:subPropertyOf   dc:identifier , dcterms:identifier ;
+  dcterms:description  "Recommended practice is to include sufficient bibliographic detail to identify the resource as unambiguously as possible."@en ;
+  dcterms:issued       "2003-02-15"^^xsd:date .
+
+prov:generated  rdf:type           owl:ObjectProperty ;
+                rdfs:domain                prov:Activity ;
+                rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+                rdfs:label                 "generated" ;
+                rdfs:range                 prov:Entity ;
+                rdfs:subPropertyOf         prov:influenced ;
+                owl:inverseOf              prov:wasGeneratedBy ;
+                prov:category              "expanded" ;
+                prov:component             "entities-activities" ;
+                prov:editorialNote         "prov:generated is one of few inverse property defined, to allow Activity-oriented assertions in addition to Entity-oriented assertions."@en ;
+                prov:inverse               "wasGeneratedBy" ;
+                prov:sharesDefinitionWith  prov:Generation .
+
+vcard:bday  rdf:type      owl:DatatypeProperty ;
+            rdfs:comment      "To specify the birth date of the object"@en ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "birth date"@en ;
+            rdfs:range        [ rdf:type     rdfs:Datatype ;
+                                owl:unionOf  ( xsd:dateTime xsd:dateTimeStamp xsd:gYear )
+                          ] .
+
+dcterms:language  rdf:type   rdf:Property ;
+                  rdfs:comment         "A language of the resource."@en ;
+                  rdfs:isDefinedBy     dcterms: ;
+                  rdfs:label           "Language"@en ;
+                  rdfs:subPropertyOf   dc:language ;
+                  dcam:rangeIncludes   dcterms:LinguisticSystem ;
+                  dcterms:description  "Recommended practice is to use either a non-literal value representing a language from a controlled vocabulary such as ISO 639-2 or ISO 639-3, or a literal value consisting of an IETF Best Current Practice 47 [[IETF-BCP47](https://tools.ietf.org/html/bcp47)] language tag."@en ;
+                  dcterms:issued       "2008-01-14"^^xsd:date .
+
+prov:hadGeneration  rdf:type       owl:ObjectProperty ;
+                    rdfs:comment               "The _optional_ Generation involved in an Entity's Derivation."@en ;
+                    rdfs:domain                prov:Derivation ;
+                    rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+                    rdfs:label                 "hadGeneration" ;
+                    rdfs:range                 prov:Generation ;
+                    prov:category              "qualified" ;
+                    prov:component             "derivations" ;
+                    prov:inverse               "generatedAsDerivation" ;
+                    prov:sharesDefinitionWith  prov:Generation .
+
+spdx:relationshipType_copyOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "A Relationship of relationshipType_copyOf expresses that the SPDXElement is an exact copy of the relatedSDPXElement.  For example, a downstream distribution of a binary library which was copied from the upstream package."@en ;
+  vs:term_status  "stable"@en .
+
+time:intervalIn  rdf:type         owl:ObjectProperty ;
+                 rdfs:comment              "Si un intervalo propio T1 es un intervalo interior a otro intervalo propio T2, entonces el principio de T1 está después del principio de T2 o coincide con el principio de T2, y el final de T1 está antes que el final de T2, o coincide con el final de T2, excepto que el final de T1 puede no coincidir con el final de T2 si el principio de T1 coincide con el principio de T2."@es , "If a proper interval T1 is intervalIn another proper interval T2, then the beginning of T1 is after the beginning of T2 or is coincident with the beginning of T2, and the end of T1 is before the end of T2, or is coincident with the end of T2, except that end of T1 may not be coincident with the end of T2 if the beginning of T1 is coincident with the beginning of T2."@en ;
+                 rdfs:domain               time:ProperInterval ;
+                 rdfs:label                "interval in"@en , "intervalo interior"@es ;
+                 rdfs:range                time:ProperInterval ;
+                 owl:propertyDisjointWith  time:intervalEquals ;
+                 skos:definition           "If a proper interval T1 is intervalIn another proper interval T2, then the beginning of T1 is after the beginning of T2 or is coincident with the beginning of T2, and the end of T1 is before the end of T2, or is coincident with the end of T2, except that end of T1 may not be coincident with the end of T2 if the beginning of T1 is coincident with the beginning of T2."@en , "Si un intervalo propio T1 es un intervalo interior a otro intervalo propio T2, entonces el principio de T1 está después del principio de T2 o coincide con el principio de T2, y el final de T1 está antes que el final de T2, o coincide con el final de T2, excepto que el final de T1 puede no coincidir con el final de T2 si el principio de T1 coincide con el principio de T2."@es ;
+                 skos:note                 "This interval relation is not included in the 13 basic relationships defined in Allen (1984), but is referred to as 'an important relationship' in Allen and Ferguson (1997). It is the disjoint union of :intervalStarts v :intervalDuring v :intervalFinishes . However, that is outside OWL2 expressivity, so is implemented as an explicit property, with :intervalStarts , :intervalDuring , :intervalFinishes as sub-properties"@en , "Esta relación entre intervalos no estaba incluida en las 13 relaciones básicas definidas por Allen (1984), pero se hace referencia a ella como \"una relación importante\" en Allen y Ferguson (1997). Es la unión disjunta de 'intervalo empieza', 'intervalo durante' y con 'intervalo termina'. Sin embargo, esto está fuera de la expresividad de OWL2, por tanto, se implementa como una propiedad explícita, con 'intervalo empieza', 'intervalo durante' e 'intervalo termina' como sub-propiedades."@es .
+
+adms:Asset  rdf:type      owl:Class ;
+            rdfs:comment      "An abstract entity that reflects the intellectual content of the asset and represents those characteristics of the asset that are independent of its physical embodiment. This abstract entity combines the FRBR entities work (a distinct intellectual or artistic creation) and expression (the intellectual or artistic realization of a work)"@en ;
+            rdfs:isDefinedBy  <http://www.w3.org/ns/adms> ;
+            rdfs:label        "Asset"@en .
+
+vcard:Crush  rdf:type     owl:Class ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "Crush"@en ;
+             rdfs:subClassOf   vcard:RelatedType .
+
+spdx:checksumAlgorithm_adler32
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was ADLER32."@en ;
+  vs:term_status  "stable"@en .
+
+vcard:hasSound  rdf:type        owl:ObjectProperty ;
+                rdfs:comment            "To specify a digital sound content information that annotates some aspect of the object"@en ;
+                rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+                rdfs:label              "has sound"@en ;
+                owl:equivalentProperty  vcard:sound .
+
+spdx:primaryPackagePurpose
+  rdf:type        owl:ObjectProperty ;
+  rdfs:comment    "This field provides information about the primary purpose of the identified package. Package Purpose is intrinsic to how the package is being used rather than the content of the package."@en ;
+  rdfs:domain     spdx:Package ;
+  rdfs:range      spdx:Purpose ;
+  vs:term_status  "stable"@en .
+
+owl:Thing  rdf:type  owl:Class .
+
+<http://data.europa.eu/r5r#Category_Shape>
+  rdf:type        sh:NodeShape ;
+  sh:name         "Category"@en ;
+  sh:property     [ sh:minCount  1 ;
+                    sh:nodeKind  sh:Literal ;
+                    sh:path      skos:prefLabel ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:targetClass  skos:Concept .
+
+spdx:relationshipType_descendantOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "A Relationship of relationshipType_descendantOf expresses that an SPDXElement is a descendant of (same lineage but post-dates) the relatedSPDXElement.  For example, an downstream File that was modified is a descendant of an upstream File"@en ;
+  vs:term_status  "stable"@en .
+
+dcterms:license  rdf:type    rdf:Property ;
+                 rdfs:comment         "A legal document giving official permission to do something with the resource."@en ;
+                 rdfs:isDefinedBy     dcterms: ;
+                 rdfs:label           "License"@en ;
+                 rdfs:subPropertyOf   dc:rights , dcterms:rights ;
+                 dcam:rangeIncludes   dcterms:LicenseDocument ;
+                 dcterms:description  "Recommended practice is to identify the license document with a URI. If this is not possible or feasible, a literal value that identifies the license may be provided."@en ;
+                 dcterms:issued       "2004-06-14"^^xsd:date .
+
+spdx:File  rdf:type       owl:Class ;
+           rdfs:comment      "A File represents a named sequence of information that is contained in a software package."@en ;
+           rdfs:subClassOf   spdx:SpdxItem ;
+           rdfs:subClassOf   [ rdf:type                     owl:Restriction ;
+                               owl:minQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                               owl:onClass                  spdx:Checksum ;
+                               owl:onProperty               spdx:checksum
+                          ] ;
+           rdfs:subClassOf   [ rdf:type                     owl:Restriction ;
+                               owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                               owl:onClass                  doap:Project ;
+                               owl:onProperty               spdx:artifactOf
+                          ] ;
+           rdfs:subClassOf   [ rdf:type                     owl:Restriction ;
+                               owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                               owl:onDataRange              xsd:string ;
+                               owl:onProperty               spdx:fileContributor
+                          ] ;
+           rdfs:subClassOf   [ rdf:type                     owl:Restriction ;
+                               owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                               owl:onDataRange              xsd:string ;
+                               owl:onProperty               spdx:noticeText
+                          ] ;
+           rdfs:subClassOf   [ rdf:type                  owl:Restriction ;
+                               owl:onDataRange           xsd:string ;
+                               owl:onProperty            spdx:fileName ;
+                               owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                          ] ;
+           rdfs:subClassOf   [ rdf:type                     owl:Restriction ;
+                               owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                               owl:onClass                  spdx:File ;
+                               owl:onProperty               spdx:fileDependency
+                          ] ;
+           rdfs:subClassOf   [ rdf:type                     owl:Restriction ;
+                               owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                               owl:onClass                  spdx:AnyLicenseInfo ;
+                               owl:onProperty               spdx:licenseInfoInFile
+                          ] ;
+           rdfs:subClassOf   [ rdf:type                     owl:Restriction ;
+                               owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                               owl:onClass                  spdx:FileType ;
+                               owl:onProperty               spdx:fileType
+                          ] ;
+           owl:disjointWith  spdx:Snippet ;
+           vs:term_status    "stable"@en .
+
+dcatap:shacl_shapes  cc:attributionURL  <http://ec.europa.eu/> ;
+                     dcatap:availability  dcatap:stable ;
+                     dcterms:conformsTo   <https://www.w3.org/TR/shacl> ;
+                     dcterms:creator      [ rdfs:seeAlso   <http://eugeniu.costezki.ro#me> ;
+                                            org:memberOf   <http://publications.europa.eu/resource/authority/corporate-body/PUBL> ;
+                                            foaf:homepage  <http://costezki.ro> ;
+                                            foaf:name      "Eugeniu Costetchi"
+                                        ] ;
+                     dcterms:creator      [ rdfs:seeAlso   <https://www.ails.ece.ntua.gr/people/natasa> ;
+                                            org:memberOf   <https://www.ails.ece.ntua.gr/> ;
+                                            foaf:homepage  <https://www.ails.ece.ntua.gr/people/natasa> ;
+                                            foaf:name      "Natasa Sofou"
+                                        ] ;
+                     dcterms:creator      [ rdfs:seeAlso   <http://makxdekkers.com/#me> ;
+                                            org:memberOf   <http://ami-consult.com/#id> ;
+                                            foaf:homepage  <http://makxdekkers.com/> ;
+                                            foaf:name      "Makx Dekkers"
+                                        ] ;
+                     dcterms:creator      [ rdfs:seeAlso   <http://www.deri.ie/users/vassilios-peristeras/> ;
+                                            org:memberOf   <http://publications.europa.eu/resource/authority/corporate-body/COM> ;
+                                            foaf:homepage  <http://www.deri.ie/users/vassilios-peristeras/> ;
+                                            foaf:name      "Vassilios Peristeras"
+                                        ] ;
+                     dcterms:creator      [ rdfs:seeAlso   <http://nikosloutas.com/> ;
+                                            org:memberOf   <http://www.pwc.com/gx/en/eu-institutions-services> ;
+                                            foaf:homepage  <http://nikosloutas.com/> ;
+                                            foaf:name      "Nikolaos Loutas"
+                                        ] ;
+                     dcterms:creator      [ rdfs:seeAlso   <https://www.linkedin.com/in/bert-van-nuffelen-a349634/> ;
+                                            org:memberOf   <https://tenforce.com> ;
+                                            foaf:homepage  <https://www.linkedin.com/in/bert-van-nuffelen-a349634/> ;
+                                            foaf:name      "Bert Van Nuffelen"
+                                        ] ;
+                     dcterms:description  "This document specifies the constraints on properties and classes expressed by DCAT-AP in SHACL."@en ;
+                     dcterms:format       <http://publications.europa.eu/resource/authority/file-type/RDF_TURTLE> ;
+                     dcterms:license      <https://creativecommons.org/licenses/by/4.0> ;
+                     dcterms:modified     "2021-12-01"^^xsd:date ;
+                     dcterms:publisher    <http://publications.europa.eu/resource/authority/corporate-body/DIGIT> ;
+                     dcterms:relation     <https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/dcat-application-profile-data-portals-europe/release/210> ;
+                     dcterms:title        "The constraints of DCAT Application Profile for Data Portals in Europe"@en ;
+                     owl:versionInfo      "2.1.1" ;
+                     dcat:accessURL       <https://joinup.ec.europa.eu/solution/dcat-application-profile-data-portals-europe/distribution/dcat-ap-200-shacl-shapes> ;
+                     dcat:downloadURL     <https://github.com/SEMICeu/DCAT-AP/raw/cea5a96bb4a6f120c20b7a2b3fb4d86bcd725952/releases/2.0.0/Draft/dcat-ap_2.0.0_shacl_shapes.ttl> ;
+                     foaf:homepage        <https://joinup.ec.europa.eu/collection/semantic-interoperability-community-semic/solution/dcat-application-profile-data-portals-europe/release/210> ;
+                     foaf:maker           [ foaf:mbox  <mailto:contact@semic.eu> ;
+                                            foaf:name  "DCAT-AP Working Group" ;
+                                            foaf:page  <https://joinup.ec.europa.eu/node/64331> , <https://github.com/SEMICeu/DCAT-AP>
+                                        ] .
+
+prov:sharesDefinitionWith
+  rdf:type            owl:AnnotationProperty ;
+  rdfs:isDefinedBy    <http://www.w3.org/ns/prov-o#> ;
+  rdfs:subPropertyOf  rdfs:seeAlso .
+
+<http://www.w3.org/2006/time>
+  rdf:type             owl:Ontology ;
+  rdfs:label           "OWL-Time"@en , "Tiempo en OWL"@es ;
+  rdfs:seeAlso         <http://www.w3.org/TR/owl-time> , <http://dx.doi.org/10.3233/SW-150187> , <http://www.semantic-web-journal.net/content/time-ontology-extended-non-gregorian-calendar-applications> ;
+  dcterms:contributor  <https://orcid.org/0000-0001-8269-8171> , <mailto:chris.little@metoffice.gov.uk> ;
+  dcterms:created      "2006-09-27"^^xsd:date ;
+  dcterms:creator      <http://orcid.org/0000-0002-3884-3420> , <mailto:panfeng66@gmail.com> , <https://en.wikipedia.org/wiki/Jerry_Hobbs> ;
+  dcterms:isVersionOf  <http://www.w3.org/TR/owl-time> ;
+  dcterms:license      <https://creativecommons.org/licenses/by/4.0/> ;
+  dcterms:modified     "2017-04-06"^^xsd:date ;
+  dcterms:rights       "Copyright © 2006-2017 W3C, OGC. W3C and OGC liability, trademark and document use rules apply."@en ;
+  owl:priorVersion     time:2006 ;
+  owl:versionIRI       time:2016 ;
+  skos:changeNote      "2016-06-15 - initial update of OWL-Time - modified to support arbitrary temporal reference systems. " , "2016-12-20 - adjust range of time:timeZone to time:TimeZone, moved up from the tzont ontology.  " , "2017-02 - intervalIn, intervalDisjoint, monthOfYear added; TemporalUnit subclass of TemporalDuration" , "2016-12-20 - restore time:Year and time:January which were present in the 2006 version of the ontology, but now marked \"deprecated\". " , "2017-04-06 - hasTime, hasXSDDuration added; Number removed; all duration elements changed to xsd:decimal" ;
+  skos:historyNote     "Update of OWL-Time ontology, extended to support general temporal reference systems. \n\nOntology engineering by Simon J D Cox"@en .
+
+spdx:relationshipType_describedBy
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used an SPDXRef-A is described by SPDXRef-Document."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:date  rdf:type     owl:DatatypeProperty ;
+           rdfs:comment    "A date-time stamp."@en ;
+           rdfs:domain     [ rdf:type     owl:Class ;
+                             owl:unionOf  ( spdx:Annotation spdx:CreationInfo )
+                        ] ;
+           rdfs:range      xsd:dateTime ;
+           vs:term_status  "stable"@en .
+
+time:unitMinute  rdf:type  time:TemporalUnit ;
+                 rdfs:label      "Minute (unit of temporal duration)"@en ;
+                 skos:prefLabel  "دقيقة واحدة"@ar , "minuut"@nl , "одна минута"@ru , "Minute"@de , "minuto"@es , "minuto"@it , "minuto"@pt , "분"@kr , "等一下"@zh , "一分"@jp , "minute"@en , "minute"@fr , "minuta"@pl ;
+                 time:days       "0"^^xsd:decimal ;
+                 time:hours      "0"^^xsd:decimal ;
+                 time:minutes    "1"^^xsd:decimal ;
+                 time:months     "0"^^xsd:decimal ;
+                 time:seconds    "0"^^xsd:decimal ;
+                 time:weeks      "0"^^xsd:decimal ;
+                 time:years      "0"^^xsd:decimal .
+
+dcat:service  rdf:type      owl:ObjectProperty ;
+              rdfs:comment        "Umístění či přístupový bod registrovaný v katalogu."@cs , "A site or endpoint that is listed in the catalog."@en , "Un sito o endpoint elencato nel catalogo."@it , "Et websted eller et endpoint som er opført i kataloget."@da , "Un sitio o 'endpoint' que está listado en el catálogo."@es ;
+              rdfs:domain         dcat:Catalog ;
+              rdfs:label          "service"@en , "datatjeneste"@da , "servicio"@es , "servizio"@it , "služba"@cs ;
+              rdfs:range          dcat:DataService ;
+              rdfs:subPropertyOf  dcterms:hasPart , rdfs:member ;
+              skos:altLabel       "har datatjeneste"@da ;
+              skos:changeNote     "Nueva propiedad añadida en DCAT 2.0."@es , "Nuova proprietà aggiunta in DCAT 2.0."@it , "New property added in DCAT 2.0."@en , "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs ;
+              skos:definition     "Un sitio o 'endpoint' que está listado en el catálogo."@es , "Umístění či přístupový bod registrovaný v katalogu."@cs , "Et websted eller et endpoint som er opført i kataloget."@da , "A site or endpoint that is listed in the catalog."@en , "Un sito o endpoint elencato nel catalogo."@it .
+
+spdx:fileType_spdx  rdf:type  owl:NamedIndividual , spdx:FileType ;
+                    rdfs:comment    "The file is an SPDX document."@en ;
+                    vs:term_status  "stable"@en .
+
+vcard:Kind  rdf:type         owl:Class ;
+            rdfs:comment         "The parent class for all objects"@en ;
+            rdfs:isDefinedBy     <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label           "Kind"@en ;
+            owl:equivalentClass  vcard:VCard ;
+            owl:equivalentClass  [ rdf:type                     owl:Restriction ;
+                                   owl:minQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                   owl:onDataRange              xsd:string ;
+                                   owl:onProperty               vcard:fn
+                             ] .
+
+prov:used  rdf:type             owl:ObjectProperty ;
+           rdfs:comment            "A prov:Entity that was used by this prov:Activity. For example, :baking prov:used :spoon, :egg, :oven ."@en ;
+           rdfs:domain             prov:Activity ;
+           rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+           rdfs:label              "used" ;
+           rdfs:range              prov:Entity ;
+           rdfs:subPropertyOf      prov:wasInfluencedBy ;
+           owl:propertyChainAxiom  ( prov:qualifiedUsage prov:entity ) ;
+           owl:propertyChainAxiom  ( prov:qualifiedUsage prov:entity ) ;
+           prov:category           "starting-point" ;
+           prov:component          "entities-activities" ;
+           prov:inverse            "wasUsedBy" ;
+           prov:qualifiedForm      prov:Usage , prov:qualifiedUsage .
+
+spdx:hasFile  rdf:type  owl:ObjectProperty ;
+              rdfs:comment    "Indicates that a particular file belongs to a package."@en ;
+              rdfs:domain     spdx:Package ;
+              rdfs:range      spdx:File ;
+              vs:term_status  "stable"@en .
+
+vcard:Modem  rdf:type     owl:Class ;
+             rdfs:comment      "This class is deprecated"@en ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "Modem"@en ;
+             rdfs:subClassOf   vcard:TelephoneType ;
+             owl:deprecated    true .
+
+dcat:accessService  rdf:type  owl:ObjectProperty ;
+                    rdfs:comment     "A site or end-point that gives access to the distribution of the dataset."@en , "Un sito o end-point che dà accesso alla distribuzione del set di dati."@it , "Un sitio o end-point que da acceso a la distribución de un conjunto de datos."@es , "Umístění či přístupový bod zpřístupňující distribuci datové sady."@cs , "Et websted eller endpoint der giver adgang til en repræsentation af datasættet."@da ;
+                    rdfs:label       "služba pro přístup k datům"@cs , "data access service"@en , "servicio de acceso de datos"@es , "dataadgangstjeneste"@da , "servizio di accesso ai dati"@it ;
+                    rdfs:range       dcat:DataService ;
+                    skos:changeNote  "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs , "New property added in DCAT 2.0."@en , "Ny egenskab tilføjet i DCAT 2.0."@da , "Nueva propiedad agregada en DCAT 2.0."@es , "Nuova proprietà aggiunta in DCAT 2.0."@it ;
+                    skos:definition  "Umístění či přístupový bod zpřístupňující distribuci datové sady."@cs , "Un sito o end-point che dà accesso alla distribuzione del set di dati."@it , "Un sitio o end-point que da acceso a la distribución de un conjunto de datos."@es , "Et websted eller endpoint der giver adgang til en repræsentation af datasættet."@da , "A site or end-point that gives access to the distribution of the dataset."@en .
+
+time:Wednesday  rdf:type  time:DayOfWeek ;
+                rdfs:label      "Wednesday"@en ;
+                skos:prefLabel  "Mercoledì"@it , "Среда"@ru , "Woensdag"@nl , "Mercredi"@fr , "水曜日"@ja , "Quarta-feira"@pt , "Środa"@pl , "星期三"@zh , "الأربعاء"@ar , "Mittwoch"@de , "Miércoles"@es , "Wednesday"@en .
+
+time:intervalFinishes
+  rdf:type            owl:ObjectProperty ;
+  rdfs:comment        "Si un intervalo propio T1 termina otro intervalo propio T2, entonces del principio de T1 está después del principio de T2, y el final de T1 coincide con el final de T2."@es , "If a proper interval T1 is intervalFinishes another proper interval T2, then the beginning of T1 is after the beginning of T2, and the end of T1 is coincident with the end of T2."@en ;
+  rdfs:domain         time:ProperInterval ;
+  rdfs:label          "intervalo termina"@es , "interval finishes"@en ;
+  rdfs:range          time:ProperInterval ;
+  rdfs:subPropertyOf  time:intervalIn ;
+  owl:inverseOf       time:intervalFinishedBy ;
+  skos:definition     "If a proper interval T1 is intervalFinishes another proper interval T2, then the beginning of T1 is after the beginning of T2, and the end of T1 is coincident with the end of T2."@en , "Si un intervalo propio T1 termina otro intervalo propio T2, entonces del principio de T1 está después del principio de T2, y el final de T1 coincide con el final de T2."@es .
+
+skos:Concept  rdf:type    owl:Class ;
+              rdfs:isDefinedBy  <http://www.w3.org/2004/02/skos/core> ;
+              rdfs:label        "Concept"@en ;
+              skos:definition   "An idea or notion; a unit of thought."@en .
+
+time:unitDay  rdf:type  time:TemporalUnit ;
+              rdfs:label      "Day (unit of temporal duration)"@en ;
+              skos:prefLabel  "Tag"@de , "day"@en , "dag"@nl , "dia"@pt , "día"@es , "doba"@pl , "ある日"@jp , "يوماً ما"@ar , "giorno"@it , "언젠가"@kr , "jour"@fr , "一天"@zh ;
+              time:days       "1"^^xsd:decimal ;
+              time:hours      "0"^^xsd:decimal ;
+              time:minutes    "0"^^xsd:decimal ;
+              time:months     "0"^^xsd:decimal ;
+              time:seconds    "0"^^xsd:decimal ;
+              time:weeks      "0"^^xsd:decimal ;
+              time:years      "0"^^xsd:decimal .
+
+spdx:relationshipType_optionalComponentOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "To be used when SPDXRef-A is an optional component of SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:relationshipType_expandedFromArchive
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "A Relationship of relationshipType_expandedFromArchive expresses that the SPDXElement is a file which was epanded from a relatedSPDXElement file.  For example, if there is an archive file xyz.tar.gz containing a file foo.c the archive file was expanded in a directory arch/xyz, the file arch/xyz/foo.c would have a relationshipType_expandedFromArchive with the file xyz.tar.gz."@en ;
+  vs:term_status  "stable"@en .
+
+<https://joinup.ec.europa.eu/node/43160>
+  dcterms:title  "Process and Methodology for Developing Core Vocabularies" .
+
+dcterms:RFC4646  rdf:type    rdfs:Datatype ;
+                 rdfs:comment         "The set of tags constructed according to RFC 4646 for the identification of languages."@en ;
+                 rdfs:isDefinedBy     dcterms: ;
+                 rdfs:label           "RFC 4646"@en ;
+                 rdfs:seeAlso         <http://www.ietf.org/rfc/rfc4646.txt> ;
+                 dcterms:description  "RFC 4646 obsoletes RFC 3066."@en ;
+                 dcterms:issued       "2008-01-14"^^xsd:date .
+
+adms:AssetDistribution
+  rdf:type          owl:Class ;
+  rdfs:comment      "A particular physical embodiment of an Asset, which is an example of the FRBR entity manifestation (the physical embodiment of an expression of a work)."@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/ns/adms> ;
+  rdfs:label        "Asset Distribution"@en .
+
+dcterms:isReferencedBy
+  rdf:type             rdf:Property ;
+  rdfs:comment         "A related resource that references, cites, or otherwise points to the described resource."@en ;
+  rdfs:isDefinedBy     dcterms: ;
+  rdfs:label           "Is Referenced By"@en ;
+  rdfs:subPropertyOf   dc:relation , dcterms:relation ;
+  dcterms:description  "This property is intended to be used with non-literal values. This property is an inverse property of References."@en ;
+  dcterms:issued       "2000-07-11"^^xsd:date .
+
+spdx:fileType_video  rdf:type  owl:NamedIndividual , spdx:FileType ;
+                     rdfs:comment    "The file is associated with a video file type (MIME type of video/*)."@en ;
+                     vs:term_status  "stable"@en .
+
+dcterms:extent  rdf:type     rdf:Property ;
+                rdfs:comment         "The size or duration of the resource."@en ;
+                rdfs:isDefinedBy     dcterms: ;
+                rdfs:label           "Extent"@en ;
+                rdfs:subPropertyOf   dc:format , dcterms:format ;
+                dcam:rangeIncludes   dcterms:SizeOrDuration ;
+                dcterms:description  "Recommended practice is to specify the file size in megabytes and duration in ISO 8601 format."@en ;
+                dcterms:issued       "2000-07-11"^^xsd:date .
+
+locn:locatorDesignator
+  rdf:type            rdf:Property ;
+  rdfs:comment        "A number or a sequence of characters that uniquely identifies the locator within the relevant scope(s). The full identification of the locator could include one or more locator designators.\n    "@en ;
+  rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+  rdfs:label          "locator designator"@en ;
+  dcterms:identifier  "locn:locatorDesignator" ;
+  vs:term_status      "testing"@en .
+
+vcard:sound  rdf:type           owl:ObjectProperty ;
+             rdfs:comment            "This object property has been mapped"@en ;
+             rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label              "sound"@en ;
+             owl:equivalentProperty  vcard:hasSound .
+
+time:nominalPosition  rdf:type  owl:DatatypeProperty ;
+                      rdfs:comment     "The (nominal) value indicating temporal position in an ordinal reference system "@en , "El valor (nominal) que indica posición temporal en un sistema de referencia ordinal."@es ;
+                      rdfs:domain      time:TimePosition ;
+                      rdfs:label       "Name of temporal position"@en , "nombre de posición temporal"@es ;
+                      rdfs:range       xsd:string ;
+                      skos:definition  "The (nominal) value indicating temporal position in an ordinal reference system "@en , "El valor (nominal) que indica posición temporal en un sistema de referencia ordinal."@es .
+
+spdx:PackageVerificationCode
+  rdf:type         owl:Class ;
+  rdfs:comment     "A manifest based verification code (the algorithm is defined in section 4.7 of the full specification) of the SPDX Item. This allows consumers of this data and/or database to determine if an SPDX item they have in hand is identical to the SPDX item from which the data was produced. This algorithm works even if the SPDX document is included in the SPDX item."@en ;
+  rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                     owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                     owl:onDataRange              xsd:string ;
+                     owl:onProperty               spdx:packageVerificationCodeExcludedFile
+                   ] ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onDataRange           xsd:hexBinary ;
+                     owl:onProperty            spdx:packageVerificationCodeValue ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  vs:term_status   "stable"@en .
+
+dcterms:hasFormat  rdf:type  rdf:Property ;
+                   rdfs:comment         "A related resource that is substantially the same as the pre-existing described resource, but in another format."@en ;
+                   rdfs:isDefinedBy     dcterms: ;
+                   rdfs:label           "Has Format"@en ;
+                   rdfs:subPropertyOf   dc:relation , dcterms:relation ;
+                   dcterms:description  "This property is intended to be used with non-literal values. This property is an inverse property of Is Format Of."@en ;
+                   dcterms:issued       "2000-07-11"^^xsd:date .
+
+time:DayOfWeek  rdf:type  owl:Class ;
+                rdfs:comment     "The day of week"@en , "El día de la semana"@es ;
+                rdfs:label       "día de la semana"@es , "Day of week"@en ;
+                rdfs:subClassOf  owl:Thing ;
+                skos:changeNote  "Remove enumeration from definition, in order to allow other days to be used when required in other calendars. \nNOTE: existing days are still present as members of the class, but the class membership is now open. \n\nIn the original OWL-Time the following constraint appeared: \n  owl:oneOf (\n      time:Monday\n      time:Tuesday\n      time:Wednesday\n      time:Thursday\n      time:Friday\n      time:Saturday\n      time:Sunday\n    ) ;"@en ;
+                skos:definition  "The day of week"@en , "El día de la semana"@es ;
+                skos:note        "Membership of the class :DayOfWeek is open, to allow for alternative week lengths and different day names."@en , "La pertenencia a la clase 'día de la semana' está abierta, para permitir longitudes de semana alternativas y diferentes nombres de días."@es .
+
+vcard:hasMember  rdf:type  owl:ObjectProperty ;
+                 rdfs:comment      "To include a member in the group this object represents. (This property can only be used by Group individuals)"@en ;
+                 rdfs:domain       vcard:Group ;
+                 rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                 rdfs:label        "has member"@en ;
+                 rdfs:range        vcard:Kind .
+
+time:generalMonth  rdf:type   rdfs:Datatype ;
+                   rdfs:comment          "Month of year - formulated as a text string with a pattern constraint to reproduce the same lexical form as gMonth, except that values up to 20 are permitted, in order to support calendars with more than 12 months in the year. \nNote that the value-space is not defined, so a generic OWL2 processor cannot compute ordering relationships of values of this type."@en , "Mes del año - formulado como una cadena de texto con una restricción patrón para reproducir la misma forma léxica que gMonth, excepto que se permiten valores hasta el 20, con el propósito de proporcionar soporte a calendarios con años con más de 12 meses.\n            Nótese que el espacio de valores no está definido, por tanto, un procesador genérico de OWL2 no puede computar relaciones de orden de valores de este tipo."@es ;
+                   rdfs:label            "Generalized month"@en , "Mes generalizado"@es ;
+                   owl:onDatatype        xsd:string ;
+                   owl:withRestrictions  ( [ xsd:pattern  "--(0[1-9]|1[0-9]|20)(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?" ]
+                              ) ;
+                   skos:definition       "Month of year - formulated as a text string with a pattern constraint to reproduce the same lexical form as gMonth, except that values up to 20 are permitted, in order to support calendars with more than 12 months in the year. \nNote that the value-space is not defined, so a generic OWL2 processor cannot compute ordering relationships of values of this type."@en , "Mes del año - formulado como una cadena de texto con una restricción patrón para reproducir la misma forma léxica que gMonth, excepto que se permiten valores hasta el 20, con el propósito de proporcionar soporte a calendarios con años con más de 12 meses.\n            Nótese que el espacio de valores no está definido, por tanto, un procesador genérico de OWL2 no puede computar relaciones de orden de valores de este tipo."@es .
+
+spdx:checksumAlgorithm_blake2b256
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was BLAKE2b-256."@en ;
+  vs:term_status  "stable"@en .
+
+prov:value  rdf:type        owl:DatatypeProperty ;
+            rdfs:domain         prov:Entity ;
+            rdfs:isDefinedBy    <http://www.w3.org/ns/prov-o#> ;
+            rdfs:label          "value" ;
+            prov:category       "expanded" ;
+            prov:component      "entities-activities" ;
+            prov:definition     "Provides a value that is a direct representation of an entity."@en ;
+            prov:dm             "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribute-value"^^xsd:anyURI ;
+            prov:editorialNote  "This property serves the same purpose as rdf:value, but has been reintroduced to avoid some of the definitional ambiguity in the RDF specification (specifically, 'may be used in describing structured values')."@en , "The editor's definition comes from http://www.w3.org/TR/rdf-primer/#rdfvalue" .
+
+spdx:fileType_documentation
+  rdf:type        owl:NamedIndividual , spdx:FileType ;
+  rdfs:comment    "The file serves as documentation."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:relationshipType_patchFor
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "A Relationship of relationshipType_patchFor expresses that the SPDXElement is a 'patchfile' that is designed to patch (apply modifications to) the relatedSPDXElement.  For example, relationship from a .diff File to a Package it is designed to patch. "@en ;
+  vs:term_status  "stable"@en .
+
+spdx:noticeText  rdf:type  owl:DatatypeProperty ;
+                 rdfs:comment    "This field provides a place for the SPDX file creator to record potential legal notices found in the file. This may or may not include copyright statements."@en ;
+                 rdfs:domain     spdx:File ;
+                 rdfs:range      xsd:string ;
+                 vs:term_status  "stable"@en .
+
+time:ProperInterval  rdf:type  owl:Class ;
+                     rdfs:comment      "A temporal entity with non-zero extent or duration, i.e. for which the value of the beginning and end are different"@en , "Una entidad temporal con extensión o duración distinta de cero, es decir, para la cual los valores de principio y fin del intervalo son diferentes."@es ;
+                     rdfs:label        "Proper interval"@en , "intervalo propio"@es ;
+                     rdfs:subClassOf   time:Interval ;
+                     owl:disjointWith  time:Instant ;
+                     skos:definition   "A temporal entity with non-zero extent or duration, i.e. for which the value of the beginning and end are different"@en , "Una entidad temporal con extensión o duración distinta de cero, es decir, para la cual los valores de principio y fin del intervalo son diferentes."@es .
+
+rdfs:Container  rdf:type  owl:Class .
+
+spdx:creationInfo  rdf:type  owl:ObjectProperty ;
+                   rdfs:comment    "The creationInfo property relates an SpdxDocument to a set of information about the creation of the SpdxDocument."@en ;
+                   rdfs:domain     spdx:SpdxDocument ;
+                   rdfs:range      spdx:CreationInfo ;
+                   vs:term_status  "stable" .
+
+time:intervalEquals  rdf:type     owl:ObjectProperty ;
+                     rdfs:comment              "If a proper interval T1 is intervalEquals another proper interval T2, then the beginning of T1 is coincident with the beginning of T2, and the end of T1 is coincident with the end of T2."@en , "Si un intervalo propio T1 es igual a otro intervalo propio T2, entonces el principio de T1 coincide con el principio de T2, y el final de T1 coincide con el final de T2."@es ;
+                     rdfs:domain               time:ProperInterval ;
+                     rdfs:label                "intervalo igual"@es , "interval equals"@en ;
+                     rdfs:range                time:ProperInterval ;
+                     owl:propertyDisjointWith  time:intervalIn ;
+                     skos:definition           "If a proper interval T1 is intervalEquals another proper interval T2, then the beginning of T1 is coincident with the beginning of T2, and the end of T1 is coincident with the end of T2."@en , "Si un intervalo propio T1 es igual a otro intervalo propio T2, entonces el principio de T1 coincide con el principio de T2, y el final de T1 coincide con el final de T2."@es .
+
+vcard:adr  rdf:type             owl:ObjectProperty ;
+           rdfs:comment            "This object property has been mapped"@en ;
+           rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label              "address"@en ;
+           owl:equivalentProperty  vcard:hasAddress .
+
+dcterms:Agent  rdf:type   dcterms:AgentClass , rdfs:Class ;
+               rdfs:comment      "A resource that acts or has the power to act."@en ;
+               rdfs:isDefinedBy  dcterms: ;
+               rdfs:label        "Agent"@en ;
+               dcterms:issued    "2008-01-14"^^xsd:date .
+
+dcterms:RightsStatement
+  rdf:type          rdfs:Class ;
+  rdfs:comment      "A statement about the intellectual property rights (IPR) held in or over a resource, a legal document giving official permission to do something with a resource, or a statement about access rights."@en ;
+  rdfs:isDefinedBy  dcterms: ;
+  rdfs:label        "Rights Statement"@en ;
+  dcterms:issued    "2008-01-14"^^xsd:date .
+
+spdx:reviewDate  rdf:type  owl:DatatypeProperty ;
+                 rdfs:comment    "Deprecated in favor of Annotation with an annotationType_review."@en , "The date and time at which the SpdxDocument was reviewed. This value must be in UTC and have 'Z' as its timezone indicator."@en ;
+                 rdfs:domain     spdx:Review ;
+                 rdfs:range      xsd:dateTime ;
+                 owl:deprecated  true ;
+                 vs:term_status  "deprecated"@en .
+
+[ rdf:type               owl:Axiom ;
+  owl:annotatedProperty  rdfs:domain ;
+  owl:annotatedSource    prov:wasInfluencedBy ;
+  owl:annotatedTarget    [ rdf:type     owl:Class ;
+                           owl:unionOf  ( prov:Activity prov:Agent prov:Entity )
+                         ] ;
+  prov:definition        "influencee: an identifier (o2) for an entity, activity, or agent; " ;
+  prov:dm                "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence"
+] .
+
+prov:wasRevisionOf  rdf:type    owl:ObjectProperty , owl:AnnotationProperty ;
+                    rdfs:comment            "A revision is a derivation that revises an entity into a revised version."@en ;
+                    rdfs:domain             prov:Entity ;
+                    rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+                    rdfs:label              "wasRevisionOf" ;
+                    rdfs:range              prov:Entity ;
+                    rdfs:subPropertyOf      prov:wasDerivedFrom ;
+                    owl:propertyChainAxiom  ( prov:qualifiedRevision prov:entity ) ;
+                    owl:propertyChainAxiom  ( prov:qualifiedRevision prov:entity ) ;
+                    prov:category           "expanded" ;
+                    prov:component          "derivations" ;
+                    prov:inverse            "hadRevision" ;
+                    prov:qualifiedForm      prov:Revision , prov:qualifiedRevision .
+
+time:January  rdf:type    owl:Class , owl:DeprecatedClass ;
+              rdfs:label        "January" ;
+              rdfs:subClassOf   time:DateTimeDescription ;
+              rdfs:subClassOf   [ rdf:type        owl:Restriction ;
+                                  owl:hasValue    time:unitMonth ;
+                                  owl:onProperty  time:unitType
+                          ] ;
+              rdfs:subClassOf   [ rdf:type        owl:Restriction ;
+                                  owl:hasValue    "--01" ;
+                                  owl:onProperty  time:month
+                          ] ;
+              owl:deprecated    true ;
+              skos:historyNote  "This class was present in the 2006 version of OWL-Time. It was presented as an example of how DateTimeDescription could be specialized, but does not belong in the revised ontology. " .
+
+skos:note  rdf:type       owl:AnnotationProperty , rdf:Property ;
+           rdfs:isDefinedBy  <http://www.w3.org/2004/02/skos/core> ;
+           rdfs:label        "note"@en ;
+           skos:definition   "A general note, for any purpose."@en ;
+           skos:scopeNote    "This property may be used directly, or as a super-property for more specific note types."@en .
+
+vcard:Fax  rdf:type       owl:Class ;
+           rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label        "Fax"@en ;
+           rdfs:subClassOf   vcard:TelephoneType .
+
+prov:Person  rdf:type     owl:Class ;
+             rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+             rdfs:label        "Person" ;
+             rdfs:subClassOf   prov:Agent ;
+             prov:category     "expanded" ;
+             prov:component    "agents-responsibility" ;
+             prov:definition   "Person agents are people."@en ;
+             prov:dm           "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
+             prov:n            "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types"^^xsd:anyURI .
+
+vcard:hasInstantMessage
+  rdf:type          owl:ObjectProperty ;
+  rdfs:comment      "To specify the instant messaging and presence protocol communications with the object. (Was called IMPP in RFC6350)"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "has messaging"@en .
+
+vcard:hasNote  rdf:type   owl:ObjectProperty ;
+               rdfs:comment      "Used to support property parameters for the note data property"@en ;
+               rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+               rdfs:label        "has note"@en .
+
+dcat:spatialResolutionInMeters
+  rdf:type            owl:DatatypeProperty ;
+  rdfs:comment        "minimum spatial separation resolvable in a dataset, measured in metres."@en-GB , "minimum spatial separation resolvable in a dataset, measured in meters."@en-US , "mínima separacíon espacial disponible en un conjunto de datos, medida en metros."@es , "separazione spaziale minima risolvibile in un set di dati, misurata in metri."@it , "mindste geografiske afstand som kan erkendes i et datasæt, målt i meter."@da , "minimální prostorový rozestup rozeznatelný v datové sadě, měřeno v metrech."@cs ;
+  rdfs:label          "spatial resolution (metres)"@en-GB , "resolución espacial (metros)"@es , "spatial resolution (meters)"@en-US , "prostorové rozlišení (metry)"@cs , "risoluzione spaziale (metros)"@it , "geografisk opløsning (meter)"@da ;
+  rdfs:range          xsd:decimal ;
+  skos:changeNote     "Nueva propiedad añadida en DCAT 2.0."@es , "Nuova proprietà aggiunta in DCAT 2.0."@it , "New property added in DCAT 2.0."@en , "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs , "Ny genskab tilføjet i DCAT 2.0."@da ;
+  skos:definition     "minimum spatial separation resolvable in a dataset, measured in meters."@en-US , "separazione spaziale minima risolvibile in un set di dati, misurata in metri."@it , "minimální prostorový rozestup rozeznatelný v datové sadě, měřeno v metrech."@cs , "minimum spatial separation resolvable in a dataset, measured in metres."@en-GB , "mínima separacíon espacial disponible en un conjunto de datos, medida en metros."@es , "mindste geografiske afstand som kan resolveres i et datasæt, målt i meter."@da ;
+  skos:editorialNote  "Může se vyskytnout v popisu Datové sady nebo Distribuce, takže nebyl specifikován definiční obor."@cs , "Might appear in the description of a Dataset or a Distribution, so no domain is specified."@en , "Kan optræde i forbindelse med beskrivelse af datasættet eller datasætditributionen, så der er ikke angivet et domæne for egenskaben."@da ;
+  skos:scopeNote      "Pokud je datová sada obraz či mřížka, měla by tato vlastnost odpovídat rozestupu položek. Pro ostatní druhy prostorových datových sad bude tato vlastnost obvykle indikovat nejmenší vzdálenost mezi položkami této datové sady."@cs , "Hvis datasættet udgøres af et billede eller et grid, så bør dette svare til afstanden mellem elementerne. For andre typer af spatiale datasæt, vil denne egenskab typisk indikere den mindste afstand mellem elementerne i datasættet."@da , "Různá prostorová rozlišení mohou být poskytována jako různé distribuce datové sady."@cs , "Distintas distribuciones de un conjunto de datos pueden tener resoluciones espaciales diferentes."@es , "Se il set di dati è un'immagine o una griglia, questo dovrebbe corrispondere alla spaziatura degli elementi. Per altri tipi di set di dati spaziali, questa proprietà di solito indica la distanza minima tra gli elementi nel set di dati."@it , "Alternative geografiske opløsninger kan leveres som forskellige datasætdistributioner."@da , "Alternative spatial resolutions might be provided as different dataset distributions."@en , "Risoluzioni spaziali alternative possono essere fornite come diverse distribuzioni di set di dati."@it , "Si el conjunto de datos es una imágen o grilla, esta propiedad corresponde al espaciado de los elementos. Para otro tipo de conjunto de datos espaciales, esta propieda usualmente indica la menor distancia entre los elementos de dichos datos."@es , "If the dataset is an image or grid this should correspond to the spacing of items. For other kinds of spatial dataset, this property will usually indicate the smallest distance between items in the dataset."@en .
+
+time:GeneralDateTimeDescription
+  rdf:type         owl:Class ;
+  rdfs:comment     "Descripción de fecha y hora estructurada con valores separados para los distintos elementos de un sistema calendario-reloj."@es , "Description of date and time structured with separate values for the various elements of a calendar-clock system"@en ;
+  rdfs:label       "descripción de fecha-hora generalizada"@es , "Generalized date-time description"@en ;
+  rdfs:subClassOf  time:TemporalPosition ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:month
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:dayOfWeek
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:minute
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:timeZone
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:monthOfYear
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:year
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:dayOfYear
+                   ] ;
+  rdfs:subClassOf  [ rdf:type         owl:Restriction ;
+                     owl:cardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty   time:unitType
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:hour
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:day
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:second
+                   ] ;
+  rdfs:subClassOf  [ rdf:type            owl:Restriction ;
+                     owl:maxCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onProperty      time:week
+                   ] ;
+  skos:definition  "Descripción de fecha y hora estructurada con valores separados para los distintos elementos de un sistema calendario-reloj." , "Description of date and time structured with separate values for the various elements of a calendar-clock system"@en ;
+  skos:note        "Algunas combinaciones de propiedades son redundantes - por ejemplo, dentro de un 'año' especificado si se proporciona 'día del año' entonces 'día' y 'mes' se pueden computar, y viceversa. Los valores individuales deberían ser consistentes entre ellos y con el calendario, indicado a través del valor de la propiedad 'tiene TRS'."@es , "Some combinations of properties are redundant - for example, within a specified :year if :dayOfYear is provided then :day and :month can be computed, and vice versa. Individual values should be consistent with each other and the calendar, indicated through the value of the :hasTRS property." .
+
+time:numericPosition  rdf:type  owl:DatatypeProperty ;
+                      rdfs:comment     "The (numeric) value indicating position within a temporal coordinate system "@en , "El valor (numérico) que indica posición temporal en un sistema de referencia ordinal."@es ;
+                      rdfs:domain      time:TimePosition ;
+                      rdfs:label       "Numeric value of temporal position"@en , "valor numérico de posición temporal"@es ;
+                      rdfs:range       xsd:decimal ;
+                      skos:definition  "The (numeric) value indicating position within a temporal coordinate system "@en , "El valor (numérico) que indica posición temporal en un sistema de referencia ordinal."@es .
+
+dcterms:alternative  rdf:type  rdf:Property ;
+                     rdfs:comment         "An alternative name for the resource."@en ;
+                     rdfs:isDefinedBy     dcterms: ;
+                     rdfs:label           "Alternative Title"@en ;
+                     rdfs:range           rdfs:Literal ;
+                     rdfs:subPropertyOf   dc:title , dcterms:title ;
+                     dcterms:description  "The distinction between titles and alternative titles is application-specific."@en ;
+                     dcterms:issued       "2000-07-11"^^xsd:date .
+
+prov:component  rdf:type  owl:AnnotationProperty ;
+                rdfs:comment      "Classify prov-o terms into six components according to prov-dm, including 'agents-responsibility', 'alternate', 'annotations', 'collections', 'derivations', and 'entities-activities'. This classification is used so that readers of prov-o specification can find its correspondence with the prov-dm specification."@en ;
+                rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> .
+
+dcterms:  dcterms:modified  "2012-06-14"^^xsd:date ;
+          dcterms:publisher  <http://purl.org/dc/aboutdcmi#DCMI> ;
+          dcterms:title      "DCMI Metadata Terms - other"@en .
+
+time:hasDateTimeDescription
+  rdf:type         owl:ObjectProperty ;
+  rdfs:comment     "Value of DateTimeInterval expressed as a structured value. The beginning and end of the interval coincide with the limits of the shortest element in the description."@en , "Valor de intervalo de fecha-hora expresado como un valor estructurado. El principio y el final del intervalo coincide con los límites del elemento más corto en la descripción."@es ;
+  rdfs:domain      time:DateTimeInterval ;
+  rdfs:label       "has Date-Time description"@en , "tiene descripción fecha-hora"@es ;
+  rdfs:range       time:GeneralDateTimeDescription ;
+  skos:definition  "Value of DateTimeInterval expressed as a structured value. The beginning and end of the interval coincide with the limits of the shortest element in the description."@en , "Valor de intervalo de fecha-hora expresado como un valor estructurado. El principio y el final del intervalo coincide con los límites del elemento más corto en la descripción."@es .
+
+dcat:Catalog  rdf:type      rdfs:Class , owl:Class ;
+              rdfs:comment        "A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog)."@en , "Una raccolta curata di metadati sulle risorse (ad es. sui dataset e relativi servizi nel contesto di cataloghi di dati)."@it , "Řízená kolekce metadat o datových sadách a datových službách"@cs , "Una colección curada de metadatos sobre recursos (por ejemplo, conjuntos de datos y servicios de datos en el contexto de un catálogo de datos)."@es , "Une collection élaborée de métadonnées sur les jeux de données"@fr , "Μια επιμελημένη συλλογή μεταδεδομένων περί συνόλων δεδομένων"@el , "مجموعة من توصيفات قوائم البيانات"@ar , "En udvalgt og arrangeret samling af metadata om ressourcer (fx datasæt og datatjenester i kontekst af et datakatalog). "@da , "データ・カタログは、データセットに関するキュレートされたメタデータの集合です。"@ja ;
+              rdfs:isDefinedBy    <http://www.w3.org/TR/vocab-dcat/> ;
+              rdfs:label          "Κατάλογος"@el , "Katalog"@cs , "Katalog"@da , "Catalogo"@it , "فهرس قوائم البيانات"@ar , "Catálogo"@es , "カタログ"@ja , "Catalog"@en , "Catalogue"@fr ;
+              rdfs:subClassOf     dcat:Dataset ;
+              skos:definition     "データ・カタログは、データセットに関するキュレートされたメタデータの集合です。"@ja , "Řízená kolekce metadat o datových sadách a datových službách."@cs , "Una raccolta curata di metadati sulle risorse (ad es. sui dataset e relativi servizi nel contesto di cataloghi di dati)."@it , "مجموعة من توصيفات قوائم البيانات"@ar , "Una colección curada de metadatos sobre recursos (por ejemplo, conjuntos de datos y servicios de datos en el contexto de un catálogo de datos)."@es , "Μια επιμελημένη συλλογή μεταδεδομένων περί συνόλων δεδομένων."@el , "Une collection élaborée de métadonnées sur les jeux de données."@fr , "En samling af metadata om ressourcer (fx datasæt og datatjenester i kontekst af et datakatalog)."@da , "A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog)."@en ;
+              skos:editorialNote  "English, Italian, Spanish definitions updated in this revision. Multilingual text not yet updated."@en ;
+              skos:scopeNote      "Normalmente, un catálogo de datos disponible en la web se representa como una única instancia de esta clase."@es , "Et webbaseret datakatalog repræsenteres typisk ved en enkelt instans af denne klasse."@da , "Συνήθως, ένας κατάλογος δεδομένων στον Παγκόσμιο Ιστό αναπαρίσταται ως ένα στιγμιότυπο αυτής της κλάσης."@el , "Webový datový katalog je typicky reprezentován jako jedna instance této třídy."@cs , "A web-based data catalog is typically represented as a single instance of this class."@en , "Normalmente, un catalogo di dati nel web viene rappresentato come una singola istanza di questa classe."@it , "通常、ウェブ・ベースのデータ・カタログは、このクラスの1つのインスタンスとして表わされます。"@ja .
+
+prov:editorialNote  rdf:type  owl:AnnotationProperty ;
+                    rdfs:comment      "A note by the OWL development team about how this term expresses the PROV-DM concept, or how it should be used in context of semantic web or linked data."@en ;
+                    rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> .
+
+vcard:None  rdf:type      owl:Class ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "None"@en ;
+            rdfs:subClassOf   vcard:Gender .
+
+spdx:ExtractedLicensingInfo
+  rdf:type         owl:Class ;
+  rdfs:comment     "An ExtractedLicensingInfo represents a license or licensing notice that was found in a package, file or snippet. Any license text that is recognized as a license may be represented as a License rather than an ExtractedLicensingInfo."@en ;
+  rdfs:subClassOf  spdx:SimpleLicensingInfo ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onDataRange           xsd:string ;
+                     owl:onProperty            spdx:extractedText ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  vs:term_status   "stable" .
+
+[ rdf:type               owl:Axiom ;
+  rdfs:comment           "Derivation is a particular case of trace (see http://www.w3.org/TR/prov-dm/#term-trace), since it links an entity to another entity that contributed to its existence." ;
+  owl:annotatedProperty  rdfs:subPropertyOf ;
+  owl:annotatedSource    prov:wasDerivedFrom ;
+  owl:annotatedTarget    prov:wasInfluencedBy
+] .
+
+spdx:fileType_application
+  rdf:type        owl:NamedIndividual , spdx:FileType ;
+  rdfs:comment    " The file is associated with a specific application type (MIME type of application/* )"@en ;
+  vs:term_status  "stable"@en .
+
+locn:addressArea  rdf:type  rdf:Property ;
+                  rdfs:comment        "The name or names of a geographic area or locality that groups a number of addressable objects for addressing purposes, without being an administrative unit. This would typically be part of a city, a neighbourhood or village. The domain of locn:addressArea is locn:Address."@en ;
+                  rdfs:domain         locn:Address ;
+                  rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+                  rdfs:label          "address area"@en ;
+                  rdfs:range          rdfs:Literal ;
+                  dcterms:identifier  "locn:addressArea" ;
+                  vs:term_status      "testing"@en .
+
+spdx:checksumAlgorithm_sha256
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was SHA256"@en ;
+  vs:term_status  "stable"@en .
+
+spdx:relationshipType_testDependencyOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is a test dependency of SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+prov:qualifiedRevision
+  rdf:type                   owl:ObjectProperty ;
+  rdfs:comment               "If this Entity prov:wasRevisionOf Entity :e, then it can qualify how it was revised using prov:qualifiedRevision [ a prov:Revision;  prov:entity :e; :foo :bar ]."@en ;
+  rdfs:domain                prov:Entity ;
+  rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label                 "qualifiedRevision" ;
+  rdfs:range                 prov:Revision ;
+  rdfs:subPropertyOf         prov:qualifiedInfluence ;
+  prov:category              "qualified" ;
+  prov:component             "derivations" ;
+  prov:inverse               "revisedEntity" ;
+  prov:sharesDefinitionWith  prov:Revision ;
+  prov:unqualifiedForm       prov:wasRevisionOf .
+
+dcterms:Box  rdf:type     rdfs:Datatype ;
+             rdfs:comment      "The set of regions in space defined by their geographic coordinates according to the DCMI Box Encoding Scheme."@en ;
+             rdfs:isDefinedBy  dcterms: ;
+             rdfs:label        "DCMI Box"@en ;
+             rdfs:seeAlso      <https://www.dublincore.org/specifications/dublin-core/dcmi-box/> ;
+             dcterms:issued    "2000-07-11"^^xsd:date .
+
+vcard:url  rdf:type             owl:ObjectProperty ;
+           rdfs:comment            "This object property has been mapped"@en ;
+           rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label              "url"@en ;
+           owl:equivalentProperty  vcard:hasURL .
+
+spdx:Annotation  rdf:type  owl:Class ;
+                 rdfs:comment     "An Annotation is a comment on an SpdxItem by an agent." ;
+                 rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                    owl:onClass               spdx:AnnotationType ;
+                                    owl:onProperty            spdx:annotationType ;
+                                    owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                           ] ;
+                 rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                    owl:onDataRange           xsd:dateTime ;
+                                    owl:onProperty            spdx:annotationDate ;
+                                    owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                           ] ;
+                 rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                    owl:onDataRange           xsd:string ;
+                                    owl:onProperty            spdx:annotator ;
+                                    owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                           ] ;
+                 rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                    owl:onDataRange           xsd:string ;
+                                    owl:onProperty            rdfs:comment ;
+                                    owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                           ] ;
+                 vs:term_status   "stable"@en .
+
+vcard:hasTelephone  rdf:type    owl:ObjectProperty ;
+                    rdfs:comment            "To specify the telephone number for telephony communication with the object"@en ;
+                    rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+                    rdfs:label              "has telephone"@en ;
+                    owl:equivalentProperty  vcard:tel .
+
+spdx:relationshipType_dependencyOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is dependency of SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+vcard:longitude  rdf:type  owl:DatatypeProperty ;
+                 rdfs:comment      "This data property has been deprecated. See hasGeo"@en ;
+                 rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                 rdfs:label        "longitude"@en ;
+                 owl:deprecated    true .
+
+adms:schemaAgency  rdf:type  owl:DatatypeProperty ;
+                   rdfs:comment      "The name of the agency that issued the identifier."@en ;
+                   rdfs:domain       adms:Identifier ;
+                   rdfs:isDefinedBy  <http://www.w3.org/ns/adms> ;
+                   rdfs:label        "schema agency"@en ;
+                   rdfs:range        rdfs:Literal .
+
+spdx:description  rdf:type  owl:DatatypeProperty ;
+                  rdfs:comment    "Provides a detailed description of the package."@en ;
+                  rdfs:domain     spdx:Package ;
+                  rdfs:range      xsd:string ;
+                  vs:term_status  "stable"@en .
+
+time:intervalStartedBy
+  rdf:type         owl:ObjectProperty ;
+  rdfs:comment     "If a proper interval T1 is intervalStarted another proper interval T2, then the beginning of T1 is coincident with the beginning of T2, and the end of T1 is after the end of T2."@en , "Si un intervalo propio T1 es empezado por otro intervalo propio T2, entonces el principio de T1 coincide con el principio de T2, y el final de T1 es posterior al final de T2."@es ;
+  rdfs:domain      time:ProperInterval ;
+  rdfs:label       "interval started by"@en ;
+  rdfs:range       time:ProperInterval ;
+  owl:inverseOf    time:intervalStarts ;
+  skos:definition  "If a proper interval T1 is intervalStarted another proper interval T2, then the beginning of T1 is coincident with the beginning of T2, and the end of T1 is after the end of T2."@en , "Si un intervalo propio T1 es empezado por otro intervalo propio T2, entonces el principio de T1 coincide con el principio de T2, y el final de T1 es posterior al final de T2."@es .
+
+dcterms:Location  rdf:type  rdfs:Class ;
+                  rdfs:comment        "A spatial region or named place."@en , "dcterms:Location class fully represents the ISA Programme Location Core Vocabulary class of Location."@en ;
+                  rdfs:isDefinedBy    dcterms: ;
+                  rdfs:label          "Location"@en ;
+                  rdfs:subClassOf     dcterms:LocationPeriodOrJurisdiction ;
+                  dcterms:identifier  "dcterms:Location" ;
+                  dcterms:issued      "2008-01-14"^^xsd:date ;
+                  vann:usageNote      "This is the key class for the ISA Programme Location Core Vocabulary and represents any location, irrespective of size or other restriction."@en ;
+                  vs:term_status      "testing"@en .
+
+skos:notation  rdf:type   owl:DatatypeProperty , rdf:Property ;
+               rdfs:isDefinedBy  <http://www.w3.org/2004/02/skos/core> ;
+               rdfs:label        "notation"@en ;
+               skos:definition   "A notation, also known as classification code, is a string of characters such as \"T58.5\" or \"303.4833\" used to uniquely identify a concept within the scope of a given concept scheme."@en ;
+               skos:scopeNote    "By convention, skos:notation is used with a typed literal in the object position of the triple."@en .
+
+vcard:hasLogo  rdf:type         owl:ObjectProperty ;
+               rdfs:comment            "To specify a graphic image of a logo associated with the object "@en ;
+               rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+               rdfs:label              "has logo"@en ;
+               owl:equivalentProperty  vcard:logo .
+
+prov:qualifiedDelegation
+  rdf:type                   owl:ObjectProperty ;
+  rdfs:comment               "If this Agent prov:actedOnBehalfOf Agent :ag, then it can qualify how with prov:qualifiedResponsibility [ a prov:Responsibility;  prov:agent :ag; :foo :bar ]."@en ;
+  rdfs:domain                prov:Agent ;
+  rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label                 "qualifiedDelegation" ;
+  rdfs:range                 prov:Delegation ;
+  rdfs:subPropertyOf         prov:qualifiedInfluence ;
+  prov:category              "qualified" ;
+  prov:component             "agents-responsibility" ;
+  prov:inverse               "qualifiedDelegationOf" ;
+  prov:sharesDefinitionWith  prov:Delegation ;
+  prov:unqualifiedForm       prov:actedOnBehalfOf .
+
+dcterms:isVersionOf  rdf:type  rdf:Property ;
+                     rdfs:comment         "A related resource of which the described resource is a version, edition, or adaptation."@en ;
+                     rdfs:isDefinedBy     dcterms: ;
+                     rdfs:label           "Is Version Of"@en ;
+                     rdfs:subPropertyOf   dc:relation , dcterms:relation ;
+                     dcterms:description  "Changes in version imply substantive changes in content rather than differences in format. This property is intended to be used with non-literal values. This property is an inverse property of Has Version."@en ;
+                     dcterms:issued       "2000-07-11"^^xsd:date .
+
+time:inTemporalPosition
+  rdf:type         owl:ObjectProperty ;
+  rdfs:comment     "Position of a time instant"@en , "Posición de un instante de tiempo."@es ;
+  rdfs:domain      time:Instant ;
+  rdfs:label       "Temporal position"@en , "posición temporal"@es ;
+  rdfs:range       time:TemporalPosition ;
+  skos:definition  "Position of a time instant"@en , "Posición de un instante de tiempo."@es .
+
+time:second  rdf:type  owl:DatatypeProperty ;
+             rdfs:comment  "Second position in a calendar-clock system."@en , "Posición de segundo en un sistema calendario-reloj."@es ;
+             rdfs:domain   time:GeneralDateTimeDescription ;
+             rdfs:label    "second"@en , "segundo"@es ;
+             rdfs:range    xsd:decimal .
+
+dcat:Distribution  rdf:type  owl:Class , rdfs:Class ;
+                   rdfs:comment      "En specifik repræsentation af et datasæt. Et datasæt kan være tilgængelig i mange serialiseringer der kan variere på forskellige vis, herunder sprog, medietype eller format, systemorganisering, tidslig- og geografisk opløsning, detaljeringsniveau eller profiler (der kan specificere en eller flere af ovenstående)."@da , "Représente une forme spécifique d'un jeu de données. Caque jeu de données peut être disponible sous différentes formes, celles-ci pouvant représenter différents formats du jeu de données ou différents endpoint. Des exemples de distribution sont des fichirs CSV, des API ou des flux RSS."@fr , "Αναπαριστά μία συγκεκριμένη διαθέσιμη μορφή ενός συνόλου δεδομένων. Κάθε σύνολο δεδομενων μπορεί να είναι διαθέσιμο σε διαφορετικές μορφές, οι μορφές αυτές μπορεί να αναπαριστούν διαφορετικές μορφές αρχείων ή διαφορετικά σημεία διάθεσης. Παραδείγματα διανομών συμπεριλαμβάνουν ένα μεταφορτώσιμο αρχείο μορφής CSV, ένα API ή ένα RSS feed."@el , "شكل محدد لقائمة البيانات يمكن الوصول إليه. قائمة بيانات ما يمكن أن تكون متاحه باشكال و أنواع متعددة.  ملف يمكن تحميله أو واجهة برمجية يمكن من خلالها الوصول إلى البيانات هي أمثلة على ذلك."@ar , "Konkrétní reprezentace datové sady. Datová sada může být dostupná v různých serializacích, které se mohou navzájem lišit různými způsoby, mimo jiné přirozeným jazykem, media-typem či formátem, schematickou organizací, časovým a prostorovým rozlišením, úrovní detailu či profily (které mohou specifikovat některé či všechny tyto rozdíly)."@cs , "データセットの特定の利用可能な形式を表わします。各データセットは、異なる形式で利用できることがあり、これらの形式は、データセットの異なる形式や、異なるエンドポイントを表わす可能性があります。配信の例には、ダウンロード可能なCSVファイル、API、RSSフィードが含まれます。"@ja , "Rappresenta una forma disponibile e specifica del dataset. Ciascun dataset può essere disponibile in forme differenti, che possono rappresentare formati diversi o diversi punti di accesso per un dataset. Esempi di distribuzioni sono un file CSV scaricabile, una API o un RSS feed."@it , "A specific representation of a dataset. A dataset might be available in multiple serializations that may differ in various ways, including natural language, media-type or format, schematic organization, temporal and spatial resolution, level of detail or profiles (which might specify any or all of the above)."@en , "Una representación específica de los datos. Cada conjunto de datos puede estar disponible en formas diferentes, las cuáles pueden variar en distintas formas, incluyendo el idioma, 'media-type' o formato, organización esquemática, resolución temporal y espacial, nivel de detalle o perfiles (que pueden especificar cualquiera o todas las diferencias anteriores)."@es ;
+                   rdfs:isDefinedBy  <http://www.w3.org/TR/vocab-dcat/> ;
+                   rdfs:label        "التوزيع"@ar , "Διανομή"@el , "Distribuce"@cs , "Distribuzione"@it , "配信"@ja , "Distribution"@en , "Distribution"@fr , "Distribution"@da , "Distribución"@es ;
+                   skos:altLabel     "Datamanifestation"@da , "Datarepræsentation"@da , "Dataudstilling"@da , "Datadistribution"@da ;
+                   skos:definition   "Konkrétní reprezentace datové sady. Datová sada může být dostupná v různých serializacích, které se mohou navzájem lišit různými způsoby, mimo jiné přirozeným jazykem, media-typem či formátem, schematickou organizací, časovým a prostorovým rozlišením, úrovní detailu či profily (které mohou specifikovat některé či všechny tyto rozdíly)."@cs , "Rappresenta una forma disponibile e specifica del dataset. Ciascun dataset può essere disponibile in forme differenti, che possono rappresentare formati diversi o diversi punti di accesso per un dataset. Esempi di distribuzioni sono un file CSV scaricabile, una API o un RSS feed."@it , "Una representación específica de los datos. Cada conjunto de datos puede estar disponible en formas diferentes, las cuáles pueden variar en distintas formas, incluyendo el idioma, 'media-type' o formato, organización esquemática, resolución temporal y espacial, nivel de detalle o perfiles (que pueden especificar cualquiera o todas las diferencias anteriores)."@es , "Représente une forme spécifique d'un jeu de données. Caque jeu de données peut être disponible sous différentes formes, celles-ci pouvant représenter différents formats du jeu de données ou différents endpoint. Des exemples de distribution sont des fichirs CSV, des API ou des flux RSS."@fr , "A specific representation of a dataset. A dataset might be available in multiple serializations that may differ in various ways, including natural language, media-type or format, schematic organization, temporal and spatial resolution, level of detail or profiles (which might specify any or all of the above)."@en , "Αναπαριστά μία συγκεκριμένη διαθέσιμη μορφή ενός συνόλου δεδομένων. Κάθε σύνολο δεδομενων μπορεί να είναι διαθέσιμο σε διαφορετικές μορφές, οι μορφές αυτές μπορεί να αναπαριστούν διαφορετικές μορφές αρχείων ή διαφορετικά σημεία διάθεσης. Παραδείγματα διανομών συμπεριλαμβάνουν ένα μεταφορτώσιμο αρχείο μορφής CSV, ένα API ή ένα RSS feed."@el , "データセットの特定の利用可能な形式を表わします。各データセットは、異なる形式で利用できることがあり、これらの形式は、データセットの異なる形式や、異なるエンドポイントを表わす可能性があります。配信の例には、ダウンロード可能なCSVファイル、API、RSSフィードが含まれます。"@ja , "شكل محدد لقائمة البيانات يمكن الوصول إليه. قائمة بيانات ما يمكن أن تكون متاحه باشكال و أنواع متعددة.  ملف يمكن تحميله أو واجهة برمجية يمكن من خلالها الوصول إلى البيانات هي أمثلة على ذلك."@ar , "En specifik repræsentation af et datasæt. Et datasæt kan være tilgængelig i mange serialiseringer der kan variere på forskellige vis, herunder sprog, medietype eller format, systemorganisering, tidslig- og geografisk opløsning, detaljeringsniveau eller profiler (der kan specificere en eller flere af ovenstående)."@da ;
+                   skos:scopeNote    "Esta clase representa una disponibilidad general de un conjunto de datos, e implica que no existe información acerca del método de acceso real a los datos, i.e., si es un enlace de descarga directa o a través de una página Web."@es , "これは、データセットの一般的な利用可能性を表わし、データの実際のアクセス方式に関する情報（つまり、直接ダウンロードなのか、APIなのか、ウェブページを介したものなのか）を意味しません。dcat:downloadURLプロパティーの使用は、直接ダウンロード可能な配信を意味します。"@ja , "Ceci représente une disponibilité générale du jeu de données, et implique qu'il n'existe pas d'information sur la méthode d'accès réelle des données, par exple, si c'est un lien de téléchargement direct ou à travers une page Web."@fr , "Denne klasse repræsenterer datasættets overordnede tilgængelighed og giver ikke oplysninger om hvilken metode der kan anvendes til at få adgang til data, dvs. om adgang til datasættet realiseres ved direkte download, API eller via et websted. Anvendelsen af egenskaben dcat:downloadURL indikerer at distributionen kan downloades direkte."@da , "Αυτό αναπαριστά μία γενική διαθεσιμότητα ενός συνόλου δεδομένων και δεν υπονοεί τίποτα περί του πραγματικού τρόπου πρόσβασης στα δεδομένα, αν είναι άμεσα μεταφορτώσιμα, μέσω API ή μέσω μίας ιστοσελίδας. Η χρήση της ιδιότητας dcat:downloadURL δείχνει μόνο άμεσα μεταφορτώσιμες διανομές."@el , "This represents a general availability of a dataset it implies no information about the actual access method of the data, i.e. whether by direct download, API, or through a Web page. The use of dcat:downloadURL property indicates directly downloadable distributions."@en , "Toto popisuje obecnou dostupnost datové sady. Neimplikuje žádnou informaci o skutečné metodě přístupu k datům, tj. zda jsou přímo ke stažení, skrze API či přes webovou stránku. Použití vlastnosti dcat:downloadURL indikuje přímo stažitelné distribuce."@cs , "Questa classe rappresenta una disponibilità generale di un dataset e non implica alcuna informazione sul metodo di accesso effettivo ai dati, ad esempio se si tratta di un accesso a download diretto, API, o attraverso una pagina Web. L'utilizzo della proprietà dcat:downloadURL indica distribuzioni direttamente scaricabili."@it .
+
+vcard:hasAdditionalName
+  rdf:type          owl:ObjectProperty ;
+  rdfs:comment      "Used to support property parameters for the additional name data property"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "has additional name"@en .
+
+[ rdf:type               owl:Axiom ;
+  rdfs:comment           "Revision is a derivation (see http://www.w3.org/TR/prov-dm/#term-Revision). Moreover, according to \nhttp://www.w3.org/TR/2013/REC-prov-constraints-20130430/#term-Revision 23 April 2012 'wasRevisionOf is a strict sub-relation of wasDerivedFrom since two entities e2 and e1 may satisfy wasDerivedFrom(e2,e1) without being a variant of each other.'" ;
+  owl:annotatedProperty  rdfs:subPropertyOf ;
+  owl:annotatedSource    prov:wasRevisionOf ;
+  owl:annotatedTarget    prov:wasDerivedFrom
+] .
+
+locn:thoroughfare  rdf:type  rdf:Property ;
+                   rdfs:comment        "An address component that represents the name of a passage or way through from one location to another. A thoroughfare is not necessarily a road, it might be a waterway or some other feature. The domain of locn:thoroughfare is locn:Address."@en ;
+                   rdfs:domain         locn:Address ;
+                   rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+                   rdfs:label          "thoroughfare"@en ;
+                   rdfs:range          rdfs:Literal ;
+                   dcterms:identifier  "locn:thoroughfare" ;
+                   vs:term_status      "testing"@en .
+
+locn:Address  rdf:type      rdfs:Class ;
+              rdfs:comment        "An \"address representation\" as conceptually defined by the INSPIRE Address Representation data type. The locn:addressId property may be used to link this locn:Address to other representations."@en ;
+              rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+              rdfs:label          "Address"@en ;
+              dcterms:identifier  "locn:Address" ;
+              vs:term_status      "testing"@en ;
+              wdsr:describedby    <https://joinup.ec.europa.eu/node/55858> .
+
+dcat:mediaType  rdf:type    owl:ObjectProperty , rdf:Property ;
+                rdfs:comment        "Il tipo di media della distribuzione come definito da IANA"@it , "このプロパティーは、配信のメディア・タイプがIANAで定義されているときに使用すべきで（SHOULD）、そうでない場合には、dct:formatを様々な値と共に使用できます（MAY）。"@ja , "Η ιδιότητα αυτή ΘΑ ΠΡΕΠΕΙ να χρησιμοποιείται όταν ο τύπος μέσου μίας διανομής είναι ορισμένος στο IANA, αλλιώς η ιδιότητα dct:format ΔΥΝΑΤΑΙ να χρησιμοποιηθεί με διαφορετικές τιμές."@el , "Cette propriété doit être utilisée quand c'est définit le type de média de la distribution en IANA, sinon dct:format DOIT être utilisé avec différentes valeurs."@fr , "The media type of the distribution as defined by IANA"@en , "يجب استخدام هذه الخاصية إذا كان نوع الملف معرف ضمن IANA"@ar , "Medietypen for distributionen som den er defineret af IANA."@da , "Typ média distribuce definovaný v IANA."@cs , "Esta propiedad debe ser usada cuando está definido el tipo de media de la distribución en IANA, de otra manera dct:format puede ser utilizado con diferentes valores"@es ;
+                rdfs:domain         dcat:Distribution ;
+                rdfs:isDefinedBy    <http://www.w3.org/TR/vocab-dcat/> ;
+                rdfs:label          "tipo de media"@es , "media type"@en , "نوع الميديا"@ar , "typ média"@cs , "メディア・タイプ"@ja , "type de média"@fr , "τύπος μέσου"@el , "medietype"@da , "tipo di media"@it ;
+                rdfs:range          dcterms:MediaType ;
+                rdfs:subPropertyOf  dcterms:format ;
+                skos:changeNote     "Obor hodnot dcat:mediaType byl zúžen v této revizi DCAT."@cs , "Il range di dcat:mediaType è stato ristretto  come parte della revisione di DCAT."@it , "The range of dcat:mediaType has been tightened as part of the revision of DCAT."@en ;
+                skos:definition     "يجب استخدام هذه الخاصية إذا كان نوع الملف معرف ضمن IANA"@ar , "Η ιδιότητα αυτή ΘΑ ΠΡΕΠΕΙ να χρησιμοποιείται όταν ο τύπος μέσου μίας διανομής είναι ορισμένος στο IANA, αλλιώς η ιδιότητα dct:format ΔΥΝΑΤΑΙ να χρησιμοποιηθεί με διαφορετικές τιμές."@el , "Cette propriété doit être utilisée quand c'est définit le type de média de la distribution en IANA, sinon dct:format DOIT être utilisé avec différentes valeurs."@fr , "Esta propiedad debe ser usada cuando está definido el tipo de media de la distribución en IANA, de otra manera dct:format puede ser utilizado con diferentes valores."@es , "Il tipo di media della distribuzione come definito da IANA."@it , "The media type of the distribution as defined by IANA."@en , "このプロパティーは、配信のメディア・タイプがIANAで定義されているときに使用すべきで（SHOULD）、そうでない場合には、dct:formatを様々な値と共に使用できます（MAY）。"@ja , "Typ média distribuce definovaný v IANA."@cs , "Medietypen for distributionen som den er defineret af IANA."@da ;
+                skos:editorialNote  "Status: English Definition text modified by DCAT revision team, Italian and Czech translation provided, other translations pending. Note some inconsistency on def vs. usage."@en ;
+                skos:scopeNote      "Questa proprietà DEVE essere usata quando il tipo di media della distribuzione è definito nel registro dei tipi di media IANA https://www.iana.org/assignments/media-types/, altrimenti dct:format PUO 'essere usato con differenti valori."@it , "Tato vlastnost BY MĚLA být použita, je-li typ média distribuce definován v registru IANA https://www.iana.org/assignments/media-types/. V ostatních případech MŮŽE být použita vlastnost dct:format s jinými hodnotami."@cs , "Esta propiedad DEBERÍA usarse cuando el 'media type' de la distribución está definido en el registro IANA de 'media types' https://www.iana.org/assignments/media-types/, de lo contrario, dct:format PUEDE usarse con distintos valores."@es , "This property SHOULD be used when the media type of the distribution is defined in the IANA media types registry https://www.iana.org/assignments/media-types/, otherwise dct:format MAY be used with different values."@en , "Denne egenskab BØR anvendes hvis distributionens medietype optræder i 'IANA media types registry' https://www.iana.org/assignments/media-types/, ellers KAN egenskaben dct:format anvendes med et andet udfaldsrum."@da .
+
+prov:qualifiedUsage  rdf:type      owl:ObjectProperty ;
+                     rdfs:comment               "If this Activity prov:used Entity :e, then it can qualify how it used it using prov:qualifiedUsage [ a prov:Usage; prov:entity :e; :foo :bar ]."@en ;
+                     rdfs:domain                prov:Activity ;
+                     rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+                     rdfs:label                 "qualifiedUsage" ;
+                     rdfs:range                 prov:Usage ;
+                     rdfs:subPropertyOf         prov:qualifiedInfluence ;
+                     prov:category              "qualified" ;
+                     prov:component             "entities-activities" ;
+                     prov:inverse               "qualifiedUsingActivity" ;
+                     prov:sharesDefinitionWith  prov:Usage ;
+                     prov:unqualifiedForm       prov:used .
+
+dcterms:AgentClass  rdf:type  rdfs:Class ;
+                    rdfs:comment      "A group of agents."@en ;
+                    rdfs:isDefinedBy  dcterms: ;
+                    rdfs:label        "Agent Class"@en ;
+                    rdfs:subClassOf   rdfs:Class ;
+                    dcterms:issued    "2008-01-14"^^xsd:date .
+
+prov:Collection  rdf:type  owl:Class ;
+                 rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+                 rdfs:label        "Collection" ;
+                 rdfs:subClassOf   prov:Entity ;
+                 prov:category     "expanded" ;
+                 prov:component    "collections" ;
+                 prov:definition   "A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections."@en ;
+                 prov:dm           "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-collection"^^xsd:anyURI .
+
+dcterms:W3CDTF  rdf:type  rdfs:Datatype ;
+                rdfs:comment      "The set of dates and times constructed according to the W3C Date and Time Formats Specification."@en ;
+                rdfs:isDefinedBy  dcterms: ;
+                rdfs:label        "W3C-DTF"@en ;
+                rdfs:seeAlso      <http://www.w3.org/TR/NOTE-datetime> ;
+                dcterms:issued    "2000-07-11"^^xsd:date .
+
+spdx:checksumAlgorithm_sha3_384
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was SHA3-384."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:relationshipType_dynamicLink
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A dynamically links to SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:License  rdf:type   owl:Class ;
+              rdfs:comment     "A License represents a copyright license. The SPDX license list website is annotated with these properties (using RDFa) to allow license data published there to be easily processed. The license list is populated in accordance with the License List fields guidelines. These guidelines are not normative and may change over time. SPDX tooling should not rely on values in the license list conforming to the current guidelines."@en ;
+              rdfs:subClassOf  spdx:SimpleLicensingInfo ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:string ;
+                                 owl:onProperty               spdx:standardLicenseHeaderTemplate
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:string ;
+                                 owl:onProperty               spdx:standardLicenseHeader
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:boolean ;
+                                 owl:onProperty               spdx:isDeprecatedLicenseId
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:string ;
+                                 owl:onProperty               spdx:standardLicenseTemplate
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                 owl:onDataRange           xsd:boolean ;
+                                 owl:onProperty            spdx:isOsiApproved ;
+                                 owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:boolean ;
+                                 owl:onProperty               spdx:isFsfLibre
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                 owl:onDataRange           xsd:string ;
+                                 owl:onProperty            spdx:licenseText ;
+                                 owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                         ] ;
+              vs:term_status   "stable"@en .
+
+vcard:post-office-box
+  rdf:type          owl:DatatypeProperty ;
+  rdfs:comment      "This data property has been deprecated"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "post office box"@en ;
+  owl:deprecated    true .
+
+time:hasTemporalDuration
+  rdf:type         owl:ObjectProperty ;
+  rdfs:comment     "Duration of a temporal entity."@en , "Duración de una entidad temporal."@es ;
+  rdfs:domain      time:TemporalEntity ;
+  rdfs:label       "has temporal duration"@en , "tiene duración temporal"@es ;
+  rdfs:range       time:TemporalDuration ;
+  skos:definition  "Duration of a temporal entity."@en , "Duración de una entidad temporal."@es .
+
+<http://www.w3.org/ns/locn.rdf>
+  rdfs:label      "RDF/XML version of the ISA Programme Location Core Vocabulary"@en ;
+  dcterms:format  <http://www.w3.org/ns/formats/data/RDF_XML> ;
+  dcat:mediaType  "application/rdf+xml"^^dcterms:IMT .
+
+prov:Start  rdf:type          owl:Class ;
+            rdfs:comment          "An instance of prov:Start provides additional descriptions about the binary prov:wasStartedBy relation from some started prov:Activity to an prov:Entity that started it. For example, :foot_race prov:wasStartedBy :bang; prov:qualifiedStart [ a prov:Start; prov:entity :bang; :foo :bar; prov:atTime '2012-03-09T08:05:08-05:00'^^xsd:dateTime ] ."@en ;
+            rdfs:isDefinedBy      <http://www.w3.org/ns/prov-o#> ;
+            rdfs:label            "Start" ;
+            rdfs:subClassOf       prov:EntityInfluence , prov:InstantaneousEvent ;
+            prov:category         "qualified" ;
+            prov:component        "entities-activities" ;
+            prov:constraints      "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+            prov:definition       "Start is when an activity is deemed to have been started by an entity, known as trigger. The activity did not exist before its start. Any usage, generation, or invalidation involving an activity follows the activity's start. A start may refer to a trigger entity that set off the activity, or to an activity, known as starter, that generated the trigger."@en ;
+            prov:dm               "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Start"^^xsd:anyURI ;
+            prov:n                "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Start"^^xsd:anyURI ;
+            prov:unqualifiedForm  prov:wasStartedBy .
+
+spdx:extractedText  rdf:type  owl:DatatypeProperty ;
+                    rdfs:comment    "Provide a copy of the actual text of the license reference extracted from the package, file or snippet that is associated with the License Identifier to aid in future analysis."@en ;
+                    rdfs:domain     spdx:ExtractedLicensingInfo ;
+                    rdfs:range      xsd:string ;
+                    vs:term_status  "stable"@en .
+
+dcterms:tableOfContents
+  rdf:type            rdf:Property ;
+  rdfs:comment        "A list of subunits of the resource."@en ;
+  rdfs:isDefinedBy    dcterms: ;
+  rdfs:label          "Table Of Contents"@en ;
+  rdfs:subPropertyOf  dc:description , dcterms:description ;
+  dcterms:issued      "2000-07-11"^^xsd:date .
+
+spdx:range  rdf:type    owl:ObjectProperty ;
+            rdfs:comment    "This field defines the byte range in the original host file (in X.2) that the snippet information applies to"@en ;
+            rdfs:domain     spdx:Snippet ;
+            rdfs:range      <http://www.w3.org/2009/pointers#StartEndPointer> ;
+            vs:term_status  "stable"@en .
+
+time:unitHour  rdf:type  time:TemporalUnit ;
+               rdfs:label      "Hour (unit of temporal duration)"@en ;
+               skos:prefLabel  "один час\"@ru" , "一時間"@jp , "godzina"@pl , "Stunde"@de , "一小時"@zh , "한 시간"@kr , "hora"@es , "hora"@pt , "ora"@it , "hour"@en , "ساعة واحدة"@ar , "uur"@nl , "heure"@fr ;
+               time:days       "0"^^xsd:decimal ;
+               time:hours      "1"^^xsd:decimal ;
+               time:minutes    "0"^^xsd:decimal ;
+               time:months     "0"^^xsd:decimal ;
+               time:seconds    "0"^^xsd:decimal ;
+               time:weeks      "0"^^xsd:decimal ;
+               time:years      "0"^^xsd:decimal .
+
+prov:specializationOf
+  rdf:type            owl:ObjectProperty , owl:AnnotationProperty ;
+  rdfs:domain         prov:Entity ;
+  rdfs:isDefinedBy    <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label          "specializationOf" ;
+  rdfs:range          prov:Entity ;
+  rdfs:seeAlso        prov:alternateOf ;
+  rdfs:subPropertyOf  prov:alternateOf ;
+  prov:category       "expanded" ;
+  prov:component      "alternate" ;
+  prov:constraints    "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+  prov:definition     "An entity that is a specialization of another shares all aspects of the latter, and additionally presents more specific aspects of the same thing as the latter. In particular, the lifetime of the entity being specialized contains that of any specialization. Examples of aspects include a time period, an abstraction, and a context associated with the entity."@en ;
+  prov:dm             "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-specialization"^^xsd:anyURI ;
+  prov:inverse        "generalizationOf" ;
+  prov:n              "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-specialization"^^xsd:anyURI .
+
+prov:qualifiedInfluence
+  rdf:type                   owl:ObjectProperty ;
+  rdfs:comment               "Because prov:qualifiedInfluence is a broad relation, the more specific relations (qualifiedCommunication, qualifiedDelegation, qualifiedEnd, etc.) should be used when applicable."@en ;
+  rdfs:domain                [ rdf:type     owl:Class ;
+                               owl:unionOf  ( prov:Activity prov:Agent prov:Entity )
+                             ] ;
+  rdfs:domain                [ rdf:type     owl:Class ;
+                               owl:unionOf  ( prov:Activity prov:Agent prov:Entity )
+                             ] ;
+  rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label                 "qualifiedInfluence" ;
+  rdfs:range                 prov:Influence ;
+  prov:category              "qualified" ;
+  prov:component             "derivations" ;
+  prov:inverse               "qualifiedInfluenceOf" ;
+  prov:sharesDefinitionWith  prov:Influence ;
+  prov:unqualifiedForm       prov:wasInfluencedBy .
+
+vcard:country-name  rdf:type  owl:DatatypeProperty ;
+                    rdfs:comment      "The country name associated with the address of the object"@en ;
+                    rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                    rdfs:label        "country name"@en ;
+                    rdfs:range        xsd:string .
+
+vcard:Other  rdf:type     owl:Class ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "Other"@en ;
+             rdfs:subClassOf   vcard:Gender .
+
+<http://data.europa.eu/r5r#Identifier_Shape>
+  rdf:type        sh:NodeShape ;
+  sh:name         "Identifier"@en ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      skos:notation ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:targetClass  adms:Identifier .
+
+spdx:Purpose  rdf:type  owl:Class ;
+              rdfs:comment    "Package Purpose is intrinsic to how the package is being used rather than the content of the package." ;
+              vs:term_status  "stable" .
+
+spdx:isWayBackLink  rdf:type  owl:DatatypeProperty ;
+                    rdfs:comment  "True if the License SeeAlso URL points to a Wayback archive"@en ;
+                    rdfs:domain   spdx:CrossRef ;
+                    rdfs:range    xsd:boolean .
+
+time:month  rdf:type     owl:DatatypeProperty ;
+            rdfs:comment     "Month position in a calendar-clock system.\n\nThe range of this property is not specified, so can be replaced by any specific representation of a calendar month from any calendar. "@en , "Posición de mes en un sistema calendario-reloj.\n    El rango de esta propiedad no está especificado, por tanto, se puede reemplazar por cualquier representación específica de un mes de calendario de un calendario cualquiera."@es ;
+            rdfs:domain      time:GeneralDateTimeDescription ;
+            rdfs:label       "month"@en , "mes"@es ;
+            skos:definition  "Month position in a calendar-clock system.\n\nThe range of this property is not specified, so can be replaced by any specific representation of a calendar month from any calendar. "@en , "Posición de mes en un sistema calendario-reloj.\n            El rango de esta propiedad no está especificado, por tanto, se puede reemplazar por cualquier representación específica de un mes de calendario de un calendario cualquiera."@es .
+
+time:seconds  rdf:type  owl:DatatypeProperty ;
+              rdfs:comment  "length of, or element of the length of, a temporal extent expressed in seconds"@en , "Longitud de, o elemento de la longitud de, una extensión temporal expresada en segundos."@es ;
+              rdfs:domain   time:GeneralDurationDescription ;
+              rdfs:label    "seconds duration"@en , "duración en segundos"@es ;
+              rdfs:range    xsd:decimal ;
+              rdfs:seeAlso  <http://www.bipm.org/en/publications/si-brochure/second.html> .
+
+vcard:Agent  rdf:type     owl:Class ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "Agent"@en ;
+             rdfs:subClassOf   vcard:RelatedType .
+
+vcard:hasCalendarRequest
+  rdf:type          owl:ObjectProperty ;
+  rdfs:comment      "To specify the calendar user address to which a scheduling request be sent for the object. (Was called CALADRURI in RFC6350)"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "has calendar request"@en .
+
+dcterms:UDC  rdf:type     dcam:VocabularyEncodingScheme ;
+             rdfs:comment      "The set of conceptual resources specified by the Universal Decimal Classification."@en ;
+             rdfs:isDefinedBy  dcterms: ;
+             rdfs:label        "UDC"@en ;
+             rdfs:seeAlso      <http://www.udcc.org/> ;
+             dcterms:issued    "2000-07-11"^^xsd:date .
+
+locn:location  rdf:type     rdf:Property ;
+               rdfs:comment        "The location property links any resource to the Location Class. Asserting the location relationship implies only that the domain has some connection to a Location in time or space. It does not imply that the resource is necessarily at that location at the time when the assertion is made."@en ;
+               rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+               rdfs:label          "location"@en ;
+               rdfs:range          dcterms:Location ;
+               dcterms:identifier  "locn:location" ;
+               vs:term_status      "testing"@en .
+
+spdx:relationshipType_prerequisiteFor
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is a prerequisite for SPDXRef-B"@en ;
+  vs:term_status  "stable"@en .
+
+spdx:checksumAlgorithm_blake2b512
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was BLAKE2b-512."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:describesPackage
+  rdf:type        owl:ObjectProperty ;
+  rdfs:comment    "The describesPackage property relates an SpdxDocument to the package which it describes."@en ;
+  rdfs:domain     spdx:SpdxDocument ;
+  rdfs:range      spdx:Package ;
+  vs:term_status  "stable"@en .
+
+vcard:hasName  rdf:type         owl:ObjectProperty ;
+               rdfs:comment            "To specify the components of the name of the object"@en ;
+               rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+               rdfs:label              "has name"@en ;
+               rdfs:range              vcard:Name ;
+               owl:equivalentProperty  vcard:n .
+
+spdx:purpose_file  rdf:type  owl:NamedIndividual , spdx:Purpose ;
+                   rdfs:comment    "The package is a single file which can be independently distributed (configuration file, statically linked binary, Kubernetes deployment, etc)."@en ;
+                   vs:term_status  "stable"@en .
+
+time:day  rdf:type       owl:DatatypeProperty ;
+          rdfs:comment     "Day position in a calendar-clock system.\n\nThe range of this property is not specified, so can be replaced by any specific representation of a calendar day from any calendar. "@en , "Posición de día en un sistema calendario-reloj."@es ;
+          rdfs:domain      time:GeneralDateTimeDescription ;
+          rdfs:label       "day"@en , "día"@es ;
+          skos:definition  "Day position in a calendar-clock system.\n\nThe range of this property is not specified, so can be replaced by any specific representation of a calendar day from any calendar. "@en , "Posición de día en un sistema calendario-reloj.\n\nEl rango de esta propiedad no está especificado, por tanto, se puede reemplazar por una representación específica de un día de calendario de cualquier calendario."@es .
+
+dcterms:medium  rdf:type     rdf:Property ;
+                rdfs:comment         "The material or physical carrier of the resource."@en ;
+                rdfs:isDefinedBy     dcterms: ;
+                rdfs:label           "Medium"@en ;
+                rdfs:subPropertyOf   dc:format , dcterms:format ;
+                dcam:domainIncludes  dcterms:PhysicalResource ;
+                dcam:rangeIncludes   dcterms:PhysicalMedium ;
+                dcterms:issued       "2000-07-11"^^xsd:date .
+
+<http://www.w3.org/ns/locn>
+  rdf:type                       voaf:Vocabulary , owl:Ontology ;
+  rdfs:comment                   "This is a new version of the final draft published by the European Commission in May 2012, revised according to the results of the ISA Core Location Pilot (see Section Change History for the list of changes). It is currently under the control of the Locations and Addresses Community Group, but is not under active development or review. Comments and queries should be sent to that group via public-locadd@w3.org. Terms defined here may be deprecated by that or future groups but will not disappear or their definition change."@en ;
+  rdfs:label                     "ISA Programme Location Core Vocabulary"@en ;
+  cc:attributionName             "European Commission"@en ;
+  cc:attributionURL              <http://ec.europa.eu/> ;
+  dcterms:abstract               "The ISA Programme Location Core Vocabulary provides a minimum set of classes and properties for describing any place in terms of its name, address or geometry. The vocabulary is specifically designed to aid the publication of data that is interoperable with EU INSPIRE Directive. It is closely integrated with the Business and Person Core Vocabularies of the EU ISA Programme, now available in W3C space as, respectively, the Registered Organization vocabulary and ISA Person Core Vocabulary."@en ;
+  dcterms:conformsTo             <https://joinup.ec.europa.eu/node/43160> ;
+  dcterms:hasFormat              <http://www.w3.org/ns/locn.ttl> , <http://www.w3.org/ns/locn.rdf> , <http://www.w3.org/ns/locn.html> ;
+  dcterms:issued                 "2013-11-25"^^xsd:date ;
+  dcterms:license                <https://joinup.ec.europa.eu/category/licence/isa-open-metadata-licence-v11> ;
+  dcterms:mediator               [ foaf:homepage  <http://www.w3.org/community/locadd/> ;
+                                   foaf:mbox      <mailto:public-locadd@w3.org> ;
+                                   foaf:name      "Locations and Addresses Community Group"
+                                 ] ;
+  dcterms:modified               "2015-03-23"^^xsd:date ;
+  dcterms:rights                 "Copyright © European Union, 2012-2015."@en ;
+  dcterms:title                  "ISA Programme Location Core Vocabulary"@en ;
+  vann:changes                   "\n2015-03-23: Updates in the namespace document and in the RDF/XML and Turtle schemas:\n- Fixed copyright notice.\n- Added class and property diagram.\n- Updated GeoSPARQL (a) namespace URIs  and (b) datatype names in the examples of property locn:geometry, based on version 1.0 of the GeoSPARQL specification, and added a note in the examples.\n  - prefix ogc (http://www.opengis.net/rdf#) replaced with gsp (http://www.opengis.net/ont/geosparql#) and sf (http://www.opengis.net/ont/sf#)\n  - ogc:WKTLiteral → gsp:wktLiteral\n  - ogc:GMLLiteral → gsp:gmlLiteral\n- Added namespace declarations for all namespace prefixes used in LOCN namespace document, even though they are not used in class/property definitions.\n- Corrected the endonym of the Greek capital written in the Greek script in the definition of class locn:geographicName (Aθnνa → Αθήνα).\n- Fixed links and typos, minor revisions made to the textual descriptions.\n2013-12-21: (PhilA) Update in RDF/XML and Turtle schemas:\n- Updated voaf namespace.\n- Corrected links to different distributions of the schema.\n- Removed xml:base and used http://www/w3/org/ns/locn as the schema URI cf. original which used the namespace URI (with the final # character).\n2013-11-25: Changes since final draft version released by the EU ISA Programme Core Vocabularies Working Group (Location Task Force)\n- Revised usage note of class locn:Geometry. The text describing its recommended usage has been moved to usage note of property locn:geometry.\n- Dropped domain/range restriction for locn:geographicName.\n- Dropped domain/range restriction for locn:locatorDesignator. Free text definition updated accordingly.\n- Dropped domain/range restriction for locn:locatorName. Free text definition updated accordingly.\n- Corrected free text definition of property locn:geometry (its domain is \"any resource\", and not a \"location\").\n- Revised usage note of property locn:geometry to include text about recommended usage, formerly included in the usage note of class locn:Geometry.\n- Revised usage note and examples of property locn:geometry to include support to geocoded URIs (e.g., geo URIs, GeoHash URIs).\n- Added term status. All terms have been set to \"testing\", with the exception of class locn:Geometry and properties rdfs:seeAlso (geographic identifier) and locn:addressId.\n- Renamed subject in Turtle examples (ex:a → :Resource).\n- Fixed links and typos, minor revisions made to the textual descriptions.\n    "@en ;
+  vann:preferredNamespacePrefix  "locn" ;
+  vann:preferredNamespaceUri     "http://www.w3.org/ns/locn#"^^xsd:anyURI ;
+  voaf:classNumber               "3"^^xsd:nonNegativeInteger ;
+  voaf:propertyNumber            "16"^^xsd:nonNegativeInteger ;
+  voaf:reliesOn                  dcterms: , rdfs: ;
+  rec:editor                     [ rdfs:seeAlso     <http://andrea-perego.name/foaf/#me> ;
+                                   sdo:affiliation  [ foaf:homepage  <https://ec.europa.eu/jrc/> ;
+                                                      foaf:name      "European Commission - Joint Research Centre (JRC)"@en
+                                                    ] ;
+                                   foaf:homepage    <http://about.me/andrea.perego> ;
+                                   foaf:name        "Andrea Perego"
+                                 ] ;
+  rec:editor                     [ rdfs:seeAlso     <http://philarcher.org/foaf.rdf#me> ;
+                                   sdo:affiliation  [ foaf:homepage  <http://www.w3.org/> ;
+                                                      foaf:name      "W3C/ERCIM"
+                                                    ] ;
+                                   foaf:homepage    <http://philarcher.org/> ;
+                                   foaf:name        "Phil Archer"
+                                 ] ;
+  rec:editor                     [ sdo:affiliation  [ foaf:homepage  <https://ec.europa.eu/jrc/> ;
+                                                      foaf:name      "European Commission - Joint Research Centre (JRC)"@en
+                                                    ] ;
+                                   foaf:name        "Michael Lutz"
+                                 ] ;
+  owl:versionInfo                "First version in w3.org/ns space"@en ;
+  wdsr:describedby               <https://joinup.ec.europa.eu/node/55858> ;
+  foaf:depiction                 <https://www.w3.org/ns/locn.svg> ;
+  foaf:maker                     [ foaf:homepage  <https://joinup.ec.europa.eu/node/42444> ;
+                                   foaf:name      "EU ISA Programme Core Vocabularies Working Group (Location Task Force)"
+                                 ] .
+
+vcard:Met  rdf:type       owl:Class ;
+           rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label        "Met"@en ;
+           rdfs:subClassOf   vcard:RelatedType .
+
+skos:exactMatch  rdf:type   owl:ObjectProperty , owl:SymmetricProperty , owl:TransitiveProperty , rdf:Property ;
+                 rdfs:comment        "skos:exactMatch is disjoint with each of the properties skos:broadMatch and skos:relatedMatch."@en ;
+                 rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+                 rdfs:label          "has exact match"@en ;
+                 rdfs:subPropertyOf  skos:closeMatch ;
+                 skos:definition     "skos:exactMatch is used to link two concepts, indicating a high degree of confidence that the concepts can be used interchangeably across a wide range of information retrieval applications. skos:exactMatch is a transitive property, and is a sub-property of skos:closeMatch."@en .
+
+vcard:hasRelated  rdf:type  owl:ObjectProperty ;
+                  rdfs:comment      "To specify a relationship between another entity and the entity represented by this object"@en ;
+                  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                  rdfs:label        "has related"@en .
+
+vcard:Text  rdf:type      owl:Class ;
+            rdfs:comment      "Also called sms telephone"@en ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "Text"@en ;
+            rdfs:subClassOf   vcard:TelephoneType .
+
+time:intervalOverlappedBy
+  rdf:type         owl:ObjectProperty ;
+  rdfs:comment     "Si un intervalo propio T1 es 'intervalo solapado por' otro intervalo propio T2, entonces el principio de T1 es posterior al principio de T2, y el principio de T1 es anterior al final de T2, y el final de T1 es posterior al final de T2."@es , "If a proper interval T1 is intervalOverlappedBy another proper interval T2, then the beginning of T1 is after the beginning of T2, the beginning of T1 is before the end of T2, and the end of T1 is after the end of T2."@en ;
+  rdfs:domain      time:ProperInterval ;
+  rdfs:label       "intervalo solapado por"@es , "interval overlapped by"@en ;
+  rdfs:range       time:ProperInterval ;
+  owl:inverseOf    time:intervalOverlaps ;
+  skos:definition  "If a proper interval T1 is intervalOverlappedBy another proper interval T2, then the beginning of T1 is after the beginning of T2, the beginning of T1 is before the end of T2, and the end of T1 is after the end of T2."@en , "Si un intervalo propio T1 es 'intervalo solapado por' otro intervalo propio T2, entonces el principio de T1 es posterior al principio de T2, y el principio de T1 es anterior al final de T2, y el final de T1 es posterior al final de T2."@es .
+
+spdx:relationshipType_dependencyManifestOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is a manifest file that lists a set of dependencies for SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:fileType_binary  rdf:type  owl:NamedIndividual , spdx:FileType ;
+                      rdfs:comment    "Indicates the file is not a text file. spdx:filetype_archive is preferred for archive files even though they are binary."@en ;
+                      vs:term_status  "stable"@en .
+
+vcard:class  rdf:type     owl:DatatypeProperty ;
+             rdfs:comment      "This data property has been deprecated"@en ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "class"@en ;
+             owl:deprecated    true .
+
+dcterms:IMT  rdf:type     dcam:VocabularyEncodingScheme ;
+             rdfs:comment      "The set of media types specified by the Internet Assigned Numbers Authority."@en ;
+             rdfs:isDefinedBy  dcterms: ;
+             rdfs:label        "IMT"@en ;
+             rdfs:seeAlso      <http://www.iana.org/assignments/media-types/> ;
+             dcterms:issued    "2000-07-11"^^xsd:date .
+
+prov:qualifiedEnd  rdf:type        owl:ObjectProperty ;
+                   rdfs:comment               "If this Activity prov:wasEndedBy Entity :e1, then it can qualify how it was ended using prov:qualifiedEnd [ a prov:End;  prov:entity :e1; :foo :bar ]."@en ;
+                   rdfs:domain                prov:Activity ;
+                   rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+                   rdfs:label                 "qualifiedEnd" ;
+                   rdfs:range                 prov:End ;
+                   rdfs:subPropertyOf         prov:qualifiedInfluence ;
+                   prov:category              "qualified" ;
+                   prov:component             "entities-activities" ;
+                   prov:inverse               "qualifiedEndOf" ;
+                   prov:sharesDefinitionWith  prov:End ;
+                   prov:unqualifiedForm       prov:wasEndedBy .
+
+prov:alternateOf  rdf:type  owl:ObjectProperty ;
+                  rdfs:domain       prov:Entity ;
+                  rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+                  rdfs:label        "alternateOf" ;
+                  rdfs:range        prov:Entity ;
+                  rdfs:seeAlso      prov:specializationOf ;
+                  prov:category     "expanded" ;
+                  prov:component    "alternate" ;
+                  prov:constraints  "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+                  prov:definition   "Two alternate entities present aspects of the same thing. These aspects may be the same or different, and the alternate entities may or may not overlap in time."@en ;
+                  prov:dm           "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-alternate"^^xsd:anyURI ;
+                  prov:inverse      "alternateOf" ;
+                  prov:n            "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-alternate"^^xsd:anyURI .
+
+vcard:hasPostalCode  rdf:type  owl:ObjectProperty ;
+                     rdfs:comment      "Used to support property parameters for the postal code data property"@en ;
+                     rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                     rdfs:label        "has postal code"@en .
+
+dcterms:isReplacedBy  rdf:type  rdf:Property ;
+                      rdfs:comment         "A related resource that supplants, displaces, or supersedes the described resource."@en ;
+                      rdfs:isDefinedBy     dcterms: ;
+                      rdfs:label           "Is Replaced By"@en ;
+                      rdfs:subPropertyOf   dc:relation , dcterms:relation ;
+                      dcterms:description  "This property is intended to be used with non-literal values. This property is an inverse property of Replaces."@en ;
+                      dcterms:issued       "2000-07-11"^^xsd:date .
+
+vcard:Parent  rdf:type    owl:Class ;
+              rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+              rdfs:label        "Parent"@en ;
+              rdfs:subClassOf   vcard:RelatedType .
+
+spdx:deprecatedVersion
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "License list version where this license was decprecated"@en ;
+  rdfs:domain     [ rdf:type     owl:Class ;
+                    owl:unionOf  ( spdx:ListedLicense spdx:ListedLicenseException )
+                  ] ;
+  rdfs:range      xsd:string ;
+  vs:term_status  "stable"@en .
+
+vcard:hasCalendarLink
+  rdf:type          owl:ObjectProperty ;
+  rdfs:comment      "To specify the calendar associated with the object. (Was called CALURI in RFC6350)"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "has calendar link"@en .
+
+time:Friday  rdf:type   time:DayOfWeek ;
+             rdfs:label      "Friday"@en ;
+             skos:prefLabel  "Venerdì"@it , "Vendredi"@fr , "Viernes"@es , "Friday"@en , "Piątek"@pl , "Vrijdag"@nl , "Freitag"@de , "Пятница"@ru , "金曜日"@ja , "الجمعة"@ar , "星期五"@zh , "Sexta-feira"@pt .
+
+spdx:fileType  rdf:type  owl:ObjectProperty ;
+               rdfs:comment    "The type of the file."@en ;
+               rdfs:domain     spdx:File ;
+               vs:term_status  "stable" .
+
+dcterms:type  rdf:type       rdf:Property ;
+              rdfs:comment         "The nature or genre of the resource."@en ;
+              rdfs:isDefinedBy     dcterms: ;
+              rdfs:label           "Type"@en ;
+              rdfs:subPropertyOf   dc:type ;
+              dcterms:description  "Recommended practice is to use a controlled vocabulary such as the DCMI Type Vocabulary [[DCMI-TYPE](http://dublincore.org/documents/dcmi-type-vocabulary/)]. To describe the file format, physical medium, or dimensions of the resource, use the property Format."@en ;
+              dcterms:issued       "2008-01-14"^^xsd:date .
+
+prov:todo  rdf:type  owl:AnnotationProperty .
+
+prov:qualifiedQuotation
+  rdf:type                   owl:ObjectProperty ;
+  rdfs:comment               "If this Entity prov:wasQuotedFrom Entity :e, then it can qualify how using prov:qualifiedQuotation [ a prov:Quotation;  prov:entity :e; :foo :bar ]."@en ;
+  rdfs:domain                prov:Entity ;
+  rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label                 "qualifiedQuotation" ;
+  rdfs:range                 prov:Quotation ;
+  rdfs:subPropertyOf         prov:qualifiedInfluence ;
+  prov:category              "qualified" ;
+  prov:component             "derivations" ;
+  prov:inverse               "qualifiedQuotationOf" ;
+  prov:sharesDefinitionWith  prov:Quotation ;
+  prov:unqualifiedForm       prov:wasQuotedFrom .
+
+prov:n  rdf:type            owl:AnnotationProperty ;
+        rdfs:comment        "A reference to the principal section of the PROV-DM document that describes this concept."@en ;
+        rdfs:isDefinedBy    <http://www.w3.org/ns/prov-o#> ;
+        rdfs:subPropertyOf  rdfs:seeAlso .
+
+prov:wasEndedBy  rdf:type       owl:ObjectProperty ;
+                 rdfs:comment            "End is when an activity is deemed to have ended. An end may refer to an entity, known as trigger, that terminated the activity."@en ;
+                 rdfs:domain             prov:Activity ;
+                 rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+                 rdfs:label              "wasEndedBy" ;
+                 rdfs:range              prov:Entity ;
+                 rdfs:subPropertyOf      prov:wasInfluencedBy ;
+                 owl:propertyChainAxiom  ( prov:qualifiedEnd prov:entity ) ;
+                 owl:propertyChainAxiom  ( prov:qualifiedEnd prov:entity ) ;
+                 prov:category           "expanded" ;
+                 prov:component          "entities-activities" ;
+                 prov:inverse            "ended" ;
+                 prov:qualifiedForm      prov:qualifiedEnd , prov:End .
+
+spdx:relationshipType_metafileOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "To be used when SPDXRef-A is a metafile of SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+dcterms:provenance  rdf:type  rdf:Property ;
+                    rdfs:comment         "A statement of any changes in ownership and custody of the resource since its creation that are significant for its authenticity, integrity, and interpretation."@en ;
+                    rdfs:isDefinedBy     dcterms: ;
+                    rdfs:label           "Provenance"@en ;
+                    dcam:rangeIncludes   dcterms:ProvenanceStatement ;
+                    dcterms:description  "The statement may include a description of any changes successive custodians made to the resource."@en ;
+                    dcterms:issued       "2004-09-20"^^xsd:date .
+
+spdx:dataLicense  rdf:type  owl:ObjectProperty , owl:FunctionalProperty ;
+                  rdfs:comment    "Compliance with the SPDX specification includes populating the SPDX fields therein with data related to such fields (\"SPDX-Metadata\"). The SPDX specification contains numerous fields where an SPDX document creator may provide relevant explanatory text in SPDX-Metadata. Without opining on the lawfulness of \"database rights\" (in jurisdictions where applicable), such explanatory text is copyrightable subject matter in most Berne Convention countries. By using the SPDX specification, or any portion hereof, you hereby agree that any copyright rights (as determined by your jurisdiction) in any SPDX-Metadata, including without limitation explanatory text, shall be subject to the terms of the Creative Commons CC0 1.0 Universal license. For SPDX-Metadata not containing any copyright rights, you hereby agree and acknowledge that the SPDX-Metadata is provided to you \"as-is\" and without any representations or warranties of any kind concerning the SPDX-Metadata, express, implied, statutory or otherwise, including without limitation warranties of title, merchantability, fitness for a particular purpose, non-infringement, or the absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not discoverable, all to the greatest extent permissible under applicable law."@en ;
+                  rdfs:domain     spdx:SpdxDocument ;
+                  rdfs:range      [ rdf:type        owl:Restriction ;
+                                    owl:hasValue    <http://spdx.org/licenses/CC0-1.0> ;
+                                    owl:onProperty  spdx:dataLicense
+                            ] ;
+                  vs:term_status  "stable" .
+
+vcard:agent  rdf:type     owl:ObjectProperty ;
+             rdfs:comment      "This object property has been deprecated"@en ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "agent"@en ;
+             owl:deprecated    true .
+
+spdx:relationship  rdf:type  owl:ObjectProperty ;
+                   rdfs:comment    "Defines a relationship between two SPDX elements. The SPDX element may be a Package, File, or SpdxDocument."@en ;
+                   rdfs:domain     spdx:SpdxElement ;
+                   rdfs:range      spdx:Relationship ;
+                   vs:term_status  "stable"@en .
+
+spdx:checksumAlgorithm_sha512
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was SHA512"@en ;
+  vs:term_status  "stable"@en .
+
+prov:qualifiedCommunication
+  rdf:type                   owl:ObjectProperty ;
+  rdfs:comment               "If this Activity prov:wasInformedBy Activity :a, then it can qualify how it was influenced using prov:qualifiedCommunication [ a prov:Communication;  prov:activity :a; :foo :bar ]."@en ;
+  rdfs:domain                prov:Activity ;
+  rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label                 "qualifiedCommunication" ;
+  rdfs:range                 prov:Communication ;
+  rdfs:subPropertyOf         prov:qualifiedInfluence ;
+  prov:category              "qualified" ;
+  prov:component             "entities-activities" ;
+  prov:inverse               "qualifiedCommunicationOf" ;
+  prov:qualifiedForm         prov:Communication ;
+  prov:sharesDefinitionWith  prov:Communication .
+
+vcard:rev  rdf:type       owl:DatatypeProperty ;
+           rdfs:comment      "To specify revision information about the object"@en ;
+           rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label        "revision"@en ;
+           rdfs:range        xsd:dateTime .
+
+spdx:documentation  rdf:type  owl:DatatypeProperty ;
+                    rdfs:comment    "Website containing the documentation related to the repository identifier"@en ;
+                    rdfs:domain     spdx:ReferenceType ;
+                    rdfs:range      xsd:anyURI ;
+                    vs:term_status  "stable"@en .
+
+time:before  rdf:type    owl:TransitiveProperty , owl:ObjectProperty ;
+             rdfs:comment     "Asume una dirección en el tiempo. Si una entidad temporal T1 está antes que otra entidad temporal T2, entonces el final de T1 está antes que el principio de T2. Así, \"antes\" se puede considerar básica para instantes y derivada para intervalos."@es , "Gives directionality to time. If a temporal entity T1 is before another temporal entity T2, then the end of T1 is before the beginning of T2. Thus, \"before\" can be considered to be basic to instants and derived for intervals."@en ;
+             rdfs:domain      time:TemporalEntity ;
+             rdfs:label       "antes"@es , "before"@en ;
+             rdfs:range       time:TemporalEntity ;
+             owl:inverseOf    time:after ;
+             skos:definition  "Gives directionality to time. If a temporal entity T1 is before another temporal entity T2, then the end of T1 is before the beginning of T2. Thus, \"before\" can be considered to be basic to instants and derived for intervals."@en , "Asume una dirección en el tiempo. Si una entidad temporal T1 está antes que otra entidad temporal T2, entonces el final de T1 está antes que el principio de T2. Así, \"antes\" se puede considerar básica para instantes y derivada para intervalos."@es .
+
+prov:Entity  rdf:type     owl:Class ;
+             rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+             rdfs:label        "Entity" ;
+             owl:disjointWith  prov:InstantaneousEvent ;
+             prov:category     "starting-point" ;
+             prov:component    "entities-activities" ;
+             prov:constraints  "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+             prov:definition   "An entity is a physical, digital, conceptual, or other kind of thing with some fixed aspects; entities may be real or imaginary. "@en ;
+             prov:dm           "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-entity"^^xsd:anyURI ;
+             prov:n            "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Entity"^^xsd:anyURI .
+
+prov:AgentInfluence  rdf:type   owl:Class ;
+                     rdfs:comment            "AgentInfluence provides additional descriptions of an Agent's binary influence upon any other kind of resource. Instances of AgentInfluence use the prov:agent property to cite the influencing Agent."@en , "It is not recommended that the type AgentInfluence be asserted without also asserting one of its more specific subclasses."@en ;
+                     rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+                     rdfs:label              "AgentInfluence" ;
+                     rdfs:seeAlso            prov:agent ;
+                     rdfs:subClassOf         prov:Influence ;
+                     prov:category           "qualified" ;
+                     prov:editorsDefinition  "AgentInfluence is the capacity of an agent to have an effect on the character, development, or behavior of another by means of attribution, association, delegation, or other."@en .
+
+dcterms:created  rdf:type    rdf:Property ;
+                 rdfs:comment         "Date of creation of the resource."@en ;
+                 rdfs:isDefinedBy     dcterms: ;
+                 rdfs:label           "Date Created"@en ;
+                 rdfs:range           rdfs:Literal ;
+                 rdfs:subPropertyOf   dc:date , dcterms:date ;
+                 dcterms:description  "Recommended practice is to describe the date, date/time, or period of time as recommended for the property Date, of which this is a subproperty."@en ;
+                 dcterms:issued       "2000-07-11"^^xsd:date .
+
+vcard:Cell  rdf:type      owl:Class ;
+            rdfs:comment      "Also called mobile telephone"@en ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "Cell"@en ;
+            rdfs:subClassOf   vcard:TelephoneType .
+
+prov:Location  rdf:type   owl:Class ;
+               rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+               rdfs:label        "Location" ;
+               rdfs:seeAlso      prov:atLocation ;
+               prov:category     "expanded" ;
+               prov:definition   "A location can be an identifiable geographic place (ISO 19112), but it can also be a non-geographic place such as a directory, row, or column. As such, there are numerous ways in which location can be expressed, such as by a coordinate, address, landmark, and so forth."@en ;
+               prov:dm           "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribute-location"^^xsd:anyURI ;
+               prov:n            "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-attribute"^^xsd:anyURI .
+
+dcterms:temporal  rdf:type  rdf:Property ;
+                  rdfs:comment        "Temporal characteristics of the resource."@en ;
+                  rdfs:isDefinedBy    dcterms: ;
+                  rdfs:label          "Temporal Coverage"@en ;
+                  rdfs:subPropertyOf  dc:coverage , dcterms:coverage ;
+                  dcam:rangeIncludes  dcterms:PeriodOfTime ;
+                  dcterms:issued      "2000-07-11"^^xsd:date .
+
+<http://www.w3.org/2009/pointers#endPointer>
+  rdf:type        owl:ObjectProperty ;
+  rdfs:domain     <http://www.w3.org/2009/pointers#CompoundPointer> ;
+  rdfs:range      <http://www.w3.org/2009/pointers#SinglePointer> ;
+  vs:term_status  "stable"@en .
+
+dcat:endpointDescription
+  rdf:type         owl:ObjectProperty ;
+  rdfs:comment     "En beskrivelse af det pågældende tjenesteendpoint, inklusiv dets operationer, parametre etc."@da , "Una descripción del end-point del servicio, incluyendo sus operaciones, parámetros, etc."@es , "A description of the service end-point, including its operations, parameters etc."@en , "Una descrizione dell'endpoint del servizio, incluse le sue operazioni, parametri, ecc."@it , "Popis přístupového bodu služby včetně operací, parametrů apod."@cs ;
+  rdfs:domain      dcat:DataService ;
+  rdfs:label       "endpointbeskrivelse"@da , "descripción del end-point del servicio"@es , "description of service end-point"@en , "popis přístupového bodu služby"@cs , "descrizione dell'endpoint del servizio"@it ;
+  skos:changeNote  "Nuova proprietà in DCAT 2.0."@it , "Nueva propiedad agregada en DCAT 2.0."@en , "Ny egenskab i DCAT 2.0."@da , "New property in DCAT 2.0."@en , "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs ;
+  skos:definition  "A description of the service end-point, including its operations, parameters etc."@en , "Una descrizione dell'endpoint del servizio, incluse le sue operazioni, parametri, ecc."@it , "En beskrivelse af det pågældende tjenesteendpoint, inklusiv dets operationer, parametre etc."@da , "Una descripción del end-point del servicio, incluyendo sus operaciones, parámetros, etc.."@es , "Popis přístupového bodu služby včetně operací, parametrů apod."@cs ;
+  skos:scopeNote   "Una descrizione dell'endpoint può essere espressa in un formato leggibile dalla macchina, come una descrizione OpenAPI (Swagger), una risposta GetCapabilities OGC, una descrizione del servizio SPARQL, un documento OpenSearch o WSDL, una descrizione API Hydra, o con del testo o qualche altra modalità informale se una rappresentazione formale non è possibile."@it , "La descripción del endpoint brinda detalles específicos de la instancia del endpoint, mientras que dct:conformsTo se usa para indicar el estándar general o especificación que implementa el endpoint."@es , "Popis přístupového bodu dává specifické detaily jeho konkrétní instance, zatímco dct:conformsTo indikuje obecný standard či specifikaci kterou přístupový bod implementuje."@cs , "The endpoint description gives specific details of the actual endpoint instance, while dct:conformsTo is used to indicate the general standard or specification that the endpoint implements."@en , "Una descripción del endpoint del servicio puede expresarse en un formato que la máquina puede interpretar, tal como una descripción basada en OpenAPI (Swagger), una respuesta OGC GetCapabilities, una descripción de un servicio SPARQL, un documento OpenSearch o WSDL, una descripción con la Hydra API, o en texto u otro modo informal si la representación formal no es posible."@es , "La descrizione dell'endpoint fornisce dettagli specifici dell'istanza dell'endpoint reale, mentre dct:conformsTo viene utilizzato per indicare lo standard o le specifiche implementate dall'endpoint."@it , "En beskrivelse af et endpoint kan udtrykkes i et maskinlæsbart format, såsom OpenAPI (Swagger)-beskrivelser, et OGC GetCapabilities svar, en SPARQL tjenestebeskrivelse, en OpenSearch- eller et WSDL-dokument, en Hydra-API-beskrivelse, eller i tekstformat eller i et andet uformelt format, hvis en formel repræsentation ikke er mulig."@da , "Popis přístupového bodu může být vyjádřen ve strojově čitelné formě, například jako popis OpenAPI (Swagger), odpověď služby OGC getCapabilities, pomocí slovníku SPARQL Service Description, jako OpenSearch či WSDL document, jako popis API dle slovníku Hydra, a nebo textově nebo jiným neformálním způsobem, pokud není možno použít formální reprezentaci."@cs , "An endpoint description may be expressed in a machine-readable form, such as an OpenAPI (Swagger) description, an OGC GetCapabilities response, a SPARQL Service Description, an OpenSearch or WSDL document, a Hydra API description, else in text or some other informal mode if a formal representation is not possible."@en , "Endpointbeskrivelsen giver specifikke oplysninger om den konkrete endpointinstans, mens dct:conformsTo anvendes til at indikere den overordnede standard eller specifikation som endpointet er i overensstemmelse med."@da .
+
+vcard:Sibling  rdf:type   owl:Class ;
+               rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+               rdfs:label        "Sibling"@en ;
+               rdfs:subClassOf   vcard:RelatedType .
+
+skos:editorialNote  rdf:type  owl:AnnotationProperty , rdf:Property ;
+                    rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+                    rdfs:label          "editorial note"@en ;
+                    rdfs:subPropertyOf  skos:note ;
+                    skos:definition     "A note for an editor, translator or maintainer of the vocabulary."@en .
+
+[ rdf:type             owl:AllDifferent ;
+  owl:distinctMembers  ( spdx:noassertion spdx:none )
+] .
+
+spdx:licenseException
+  rdf:type        owl:ObjectProperty ;
+  rdfs:comment    "An exception to a license."@en ;
+  rdfs:domain     spdx:WithExceptionOperator ;
+  rdfs:range      spdx:LicenseException ;
+  vs:term_status  "stable"@en .
+
+[ rdf:type               owl:Axiom ;
+  rdfs:comment           "hadPrimarySource property is a particular case of wasDerivedFrom (see http://www.w3.org/TR/prov-dm/#term-original-source) that aims to give credit to the source that originated some information." ;
+  owl:annotatedProperty  rdfs:subPropertyOf ;
+  owl:annotatedSource    prov:hadPrimarySource ;
+  owl:annotatedTarget    prov:wasDerivedFrom
+] .
+
+spdx:creator  rdf:type  owl:DatatypeProperty ;
+              rdfs:comment    "Identify who (or what, in the case of a tool) created the SPDX document. If the SPDX document was created by an individual, indicate the person's name. If the SPDX document was created on behalf of a company or organization, indicate the entity name. If the SPDX document was created using a software tool, indicate the name and version for that tool. If multiple participants or tools were involved, use multiple instances of this field. Person name or organization name may be designated as “anonymous” if appropriate."@en ;
+              rdfs:domain     spdx:CreationInfo ;
+              rdfs:range      xsd:string ;
+              vs:term_status  "stable" .
+
+dcterms:rightsHolder  rdf:type  rdf:Property ;
+                      rdfs:comment         "A person or organization owning or managing rights over the resource."@en ;
+                      rdfs:isDefinedBy     dcterms: ;
+                      rdfs:label           "Rights Holder"@en ;
+                      dcam:rangeIncludes   dcterms:Agent ;
+                      dcterms:description  "Recommended practice is to refer to the rights holder with a URI. If this is not possible or feasible, a literal value that identifies the rights holder may be provided."@en ;
+                      dcterms:issued       "2004-06-14"^^xsd:date .
+
+prov:activity  rdf:type         owl:ObjectProperty ;
+               rdfs:domain             prov:ActivityInfluence ;
+               rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+               rdfs:label              "activity" ;
+               rdfs:range              prov:Activity ;
+               rdfs:subPropertyOf      prov:influencer ;
+               prov:category           "qualified" ;
+               prov:editorialNote      "This property behaves in spirit like rdf:object; it references the object of a prov:wasInfluencedBy triple."@en ;
+               prov:editorsDefinition  "The prov:activity property references an prov:Activity which influenced a resource. This property applies to an prov:ActivityInfluence, which is given by a subproperty of prov:qualifiedInfluence from the influenced prov:Entity, prov:Activity or prov:Agent." ;
+               prov:inverse            "activityOfInfluence" .
+
+spdx:Checksum  rdf:type  owl:Class ;
+               rdfs:comment     "A Checksum is value that allows the contents of a file to be authenticated. Even small changes to the content of the file will change its checksum. This class allows the results of a variety of checksum and cryptographic message digest algorithms to be represented."@en ;
+               rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                  owl:onClass               spdx:ChecksumAlgorithm ;
+                                  owl:onProperty            spdx:algorithm ;
+                                  owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                         ] ;
+               rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                  owl:onDataRange           xsd:hexBinary ;
+                                  owl:onProperty            spdx:checksumValue ;
+                                  owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                         ] ;
+               vs:term_status   "stable"@en .
+
+time:hasXSDDuration  rdf:type  owl:DatatypeProperty ;
+                     rdfs:comment        "Extensión de una entidad temporal, expresada utilizando xsd:duration."@es , "Extent of a temporal entity, expressed using xsd:duration"@en ;
+                     rdfs:domain         time:TemporalEntity ;
+                     rdfs:label          "has XSD duration"@en , "tiene duración XSD"@es ;
+                     rdfs:range          xsd:duration ;
+                     skos:definition     "Extensión de una entidad temporal, expresada utilizando xsd:duration."@es , "Extent of a temporal entity, expressed using xsd:duration"@en ;
+                     skos:editorialNote  "Característica arriesgada - añadida en la revisión de 2017, y todavía no ampliamente utilizada."@es , "Feature at risk - added in 2017 revision, and not yet widely used. "@en .
+
+prov:hadMember  rdf:type           owl:ObjectProperty ;
+                rdfs:domain                prov:Collection ;
+                rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+                rdfs:label                 "hadMember" ;
+                rdfs:range                 prov:Entity ;
+                rdfs:subPropertyOf         prov:wasInfluencedBy ;
+                prov:category              "expanded" ;
+                prov:component             "expanded" ;
+                prov:inverse               "wasMemberOf" ;
+                prov:sharesDefinitionWith  prov:Collection .
+
+spdx:relationshipType_patchApplied
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "A Relationship of relationshipType_patchApplied expresses that the SPDXElement is a 'patchfile' that was applied and produced the relatedSPDXElement. For example, a .diff File relates to a specific file where the diff was applied."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:referenceCategory_security
+  rdf:type        owl:NamedIndividual , spdx:ReferenceCategory ;
+  vs:term_status  "stable"@en .
+
+dcterms:LCC  rdf:type     dcam:VocabularyEncodingScheme ;
+             rdfs:comment      "The set of conceptual resources specified by the Library of Congress Classification."@en ;
+             rdfs:isDefinedBy  dcterms: ;
+             rdfs:label        "LCC"@en ;
+             rdfs:seeAlso      <http://lcweb.loc.gov/catdir/cpso/lcco/lcco.html> ;
+             dcterms:issued    "2000-07-11"^^xsd:date .
+
+dcterms:LicenseDocument
+  rdf:type          rdfs:Class ;
+  rdfs:comment      "A legal document giving official permission to do something with a resource."@en ;
+  rdfs:isDefinedBy  dcterms: ;
+  rdfs:label        "License Document"@en ;
+  rdfs:subClassOf   dcterms:RightsStatement ;
+  dcterms:issued    "2008-01-14"^^xsd:date .
+
+prov:Revision  rdf:type       owl:Class ;
+               rdfs:comment          "An instance of prov:Revision provides additional descriptions about the binary prov:wasRevisionOf relation from some newer prov:Entity to an earlier prov:Entity. For example, :draft_2 prov:wasRevisionOf :draft_1; prov:qualifiedRevision [ a prov:Revision; prov:entity :draft_1; :foo :bar ]."@en ;
+               rdfs:isDefinedBy      <http://www.w3.org/ns/prov-o#> ;
+               rdfs:label            "Revision" ;
+               rdfs:subClassOf       prov:Derivation ;
+               prov:category         "qualified" ;
+               prov:component        "derivations" ;
+               prov:definition       "A revision is a derivation for which the resulting entity is a revised version of some original. The implication here is that the resulting entity contains substantial content from the original. Revision is a particular case of derivation."@en ;
+               prov:dm               "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-revision"^^xsd:anyURI ;
+               prov:n                "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Revision"^^xsd:anyURI ;
+               prov:unqualifiedForm  prov:wasRevisionOf .
+
+spdx:AnnotationType  rdf:type  owl:Class ;
+                     rdfs:comment    "This type describes the type of annotation. Annotations are usually created when someone reviews the file, and if this is the case the annotation type should be REVIEW."@en ;
+                     vs:term_status  "stable"@en .
+
+spdx:checksumValue  rdf:type  owl:DatatypeProperty , owl:FunctionalProperty ;
+                    rdfs:comment    "The checksumValue property provides a lower case hexidecimal encoded digest value produced using a specific algorithm."@en ;
+                    rdfs:domain     spdx:Checksum ;
+                    rdfs:range      xsd:hexBinary ;
+                    vs:term_status  "stable" .
+
+[ rdf:type               owl:Axiom ;
+  rdfs:comment           "Derivation is a particular case of trace (see http://www.w3.org/TR/prov-dm/#term-trace), since it links an entity to another entity that contributed to its existence." ;
+  owl:annotatedProperty  rdfs:subPropertyOf ;
+  owl:annotatedSource    prov:wasDerivedFrom ;
+  owl:annotatedTarget    prov:wasInfluencedBy
+] .
+
+time:intervalFinishedBy
+  rdf:type         owl:ObjectProperty ;
+  rdfs:comment     "If a proper interval T1 is intervalFinishedBy another proper interval T2, then the beginning of T1 is before the beginning of T2, and the end of T1 is coincident with the end of T2."@en , "Si un intervalo propio T1 está terminado por otro intervalo propio T2, entonces el principio de T1 está antes que el principio de T2, y el final de T1 coincide con el final de T2."@es ;
+  rdfs:domain      time:ProperInterval ;
+  rdfs:label       "intervalo terminado por"@es , "interval finished by"@en ;
+  rdfs:range       time:ProperInterval ;
+  owl:inverseOf    time:intervalFinishes ;
+  skos:definition  "Si un intervalo propio T1 está terminado por otro intervalo propio T2, entonces el principio de T1 está antes que el principio de T2, y el final de T1 coincide con el final de T2."@es , "If a proper interval T1 is intervalFinishedBy another proper interval T2, then the beginning of T1 is before the beginning of T2, and the end of T1 is coincident with the end of T2."@en .
+
+spdx:relationshipType_testToolOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is used as a test tool for SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+prov:qualifiedStart  rdf:type      owl:ObjectProperty ;
+                     rdfs:comment               "If this Activity prov:wasStartedBy Entity :e1, then it can qualify how it was started using prov:qualifiedStart [ a prov:Start;  prov:entity :e1; :foo :bar ]."@en ;
+                     rdfs:domain                prov:Activity ;
+                     rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+                     rdfs:label                 "qualifiedStart" ;
+                     rdfs:range                 prov:Start ;
+                     rdfs:subPropertyOf         prov:qualifiedInfluence ;
+                     prov:category              "qualified" ;
+                     prov:component             "entities-activities" ;
+                     prov:inverse               "qualifiedStartOf" ;
+                     prov:sharesDefinitionWith  prov:Start ;
+                     prov:unqualifiedForm       prov:wasStartedBy .
+
+<http://data.europa.eu/r5r#Checksum_Shape>
+  rdf:type        sh:NodeShape ;
+  sh:name         "Checksum"@en ;
+  sh:property     [ sh:datatype  xsd:hexBinary ;
+                    sh:maxCount  1 ;
+                    sh:minCount  1 ;
+                    sh:path      spdx:checksumValue ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:hasValue  spdx:checksumAlgorithm_sha1 ;
+                    sh:maxCount  1 ;
+                    sh:minCount  1 ;
+                    sh:path      spdx:algorithm ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:targetClass  spdx:Checksum .
+
+prov:Influence  rdf:type      owl:Class ;
+                rdfs:comment          "An instance of prov:Influence provides additional descriptions about the binary prov:wasInfluencedBy relation from some influenced Activity, Entity, or Agent to the influencing Activity, Entity, or Agent. For example, :stomach_ache prov:wasInfluencedBy :spoon; prov:qualifiedInfluence [ a prov:Influence; prov:entity :spoon; :foo :bar ] . Because prov:Influence is a broad relation, the more specific relations (Communication, Delegation, End, etc.) should be used when applicable."@en , "Because prov:Influence is a broad relation, its most specific subclasses (e.g. prov:Communication, prov:Delegation, prov:End, prov:Revision, etc.) should be used when applicable."@en ;
+                rdfs:isDefinedBy      <http://www.w3.org/ns/prov-o#> ;
+                rdfs:label            "Influence" ;
+                prov:category         "qualified" ;
+                prov:component        "derivations" ;
+                prov:definition       "Influence is the capacity of an entity, activity, or agent to have an effect on the character, development, or behavior of another by means of usage, start, end, generation, invalidation, communication, derivation, attribution, association, or delegation."@en ;
+                prov:dm               "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-influence"^^xsd:anyURI ;
+                prov:n                "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-influence"^^xsd:anyURI ;
+                prov:unqualifiedForm  prov:wasInfluencedBy .
+
+dcterms:conformsTo  rdf:type  rdf:Property ;
+                    rdfs:comment        "An established standard to which the described resource conforms."@en ;
+                    rdfs:isDefinedBy    dcterms: ;
+                    rdfs:label          "Conforms To"@en ;
+                    rdfs:subPropertyOf  dc:relation , dcterms:relation ;
+                    dcam:rangeIncludes  dcterms:Standard ;
+                    dcterms:issued      "2001-05-21"^^xsd:date .
+
+spdx:licenseDeclared  rdf:type  owl:ObjectProperty ;
+                      rdfs:comment    "The licensing that the creators of the software in the package, or the packager, have declared. Declarations by the original software creator should be preferred, if they exist."@en ;
+                      rdfs:domain     spdx:SpdxItem ;
+                      rdfs:range      spdx:AnyLicenseInfo ;
+                      vs:term_status  "stable"@en .
+
+spdx:relationshipType_amendment
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "To be used when SPDXRef-A amends the SPDX information in SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:example  rdf:type  owl:DatatypeProperty ;
+              rdfs:comment    "Text for examples in describing an SPDX element."@en ;
+              rdfs:domain     spdx:LicenseException ;
+              rdfs:range      xsd:string ;
+              vs:term_status  "stable"@en .
+
+spdx:AnyLicenseInfo  rdf:type  owl:Class ;
+                     rdfs:comment      "The AnyLicenseInfo class includes all resources that represent licensing information." ;
+                     rdfs:isDefinedBy  "http://spdx.org/rdf/terms#AnyLicenseInfo" ;
+                     vs:term_status    "stable" .
+
+vcard:mailer  rdf:type    owl:DatatypeProperty ;
+              rdfs:comment      "This data property has been deprecated"@en ;
+              rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+              rdfs:label        "mailer"@en ;
+              owl:deprecated    true .
+
+time:generalYear  rdf:type    rdfs:Datatype ;
+                  rdfs:comment          "Year number - formulated as a text string with a pattern constraint to reproduce the same lexical form as gYear, but not restricted to values from the Gregorian calendar. \nNote that the value-space is not defined, so a generic OWL2 processor cannot compute ordering relationships of values of this type."@en , "Número de año - formulado como una cadena de texto con una restricción patrón para reproducir la misma forma léxica que gYear, aunque no está restringido a valores del calendario gregoriano.\n            Nótese que el espacio de valores no está definido, por tanto, un procesador genérico de OWL2 no puede computar relaciones de orden de valores de este tipo."@es ;
+                  rdfs:label            "Generalized year"@en , "Año generalizado"@es ;
+                  owl:onDatatype        xsd:string ;
+                  owl:withRestrictions  ( [ xsd:pattern  "-?([1-9][0-9]{3,}|0[0-9]{3})(Z|(\\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00))?" ]
+                              ) ;
+                  skos:definition       "Year number - formulated as a text string with a pattern constraint to reproduce the same lexical form as gYear, but not restricted to values from the Gregorian calendar. \nNote that the value-space is not defined, so a generic OWL2 processor cannot compute ordering relationships of values of this type."@en , "Número de año - formulado como una cadena de texto con una restricción patrón para reproducir la misma forma léxica que gYear, aunque no está restringido a valores del calendario gregoriano.\n            Nótese que el espacio de valores no está definido, por tanto, un procesador genérico de OWL2 no puede computar relaciones de orden de valores de este tipo."@es .
+
+skos:narrowerTransitive
+  rdf:type            owl:ObjectProperty , owl:TransitiveProperty , rdf:Property ;
+  rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+  rdfs:label          "has narrower transitive"@en ;
+  rdfs:subPropertyOf  skos:semanticRelation ;
+  owl:inverseOf       skos:broaderTransitive ;
+  skos:definition     "skos:narrowerTransitive is a transitive superproperty of skos:narrower." ;
+  skos:scopeNote      "By convention, skos:narrowerTransitive is not used to make assertions. Rather, the properties can be used to draw inferences about the transitive closure of the hierarchical relation, which is useful e.g. when implementing a simple query expansion algorithm in a search application."@en .
+
+locn:postName  rdf:type     rdf:Property ;
+               rdfs:comment        "The key postal division of the address, usually the city. (INSPIRE's definition is \"One or more names created and maintained for postal purposes to identify a subdivision of addresses and postal delivery points.\"). The domain of locn:postName is locn:Address."@en ;
+               rdfs:domain         locn:Address ;
+               rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+               rdfs:label          "post name"@en ;
+               rdfs:range          rdfs:Literal ;
+               dcterms:identifier  "locn:postName" ;
+               vs:term_status      "testing"@en .
+
+spdx:isOsiApproved  rdf:type  owl:DatatypeProperty ;
+                    rdfs:comment    "Indicates if the OSI has approved the license."@en ;
+                    rdfs:domain     spdx:License ;
+                    rdfs:range      xsd:boolean ;
+                    vs:term_status  "stable"@en .
+
+adms:interoperabilityLevel
+  rdf:type          owl:ObjectProperty ;
+  rdfs:comment      "The interoperability level for which the Asset is relevant."@en ;
+  rdfs:domain       adms:Asset ;
+  rdfs:isDefinedBy  <http://www.w3.org/ns/adms> ;
+  rdfs:label        "interoperability level"@en ;
+  rdfs:range        skos:Concept .
+
+time:Sunday  rdf:type   time:DayOfWeek ;
+             rdfs:label      "Sunday"@en ;
+             skos:prefLabel  "Zondag"@nl , "Sunday"@en , "Воскресенье"@ru , "Sonntag"@de , "Domingo"@es , "Domingo"@pt , "الأحد (يوم)"@ar , "Niedziela"@pl , "Dimanche"@fr , "Domenica"@it , "日曜日"@ja , "星期日"@zh .
+
+owl:qualifiedCardinality
+  rdf:type  owl:AnnotationProperty .
+
+vcard:prodid  rdf:type    owl:DatatypeProperty ;
+              rdfs:comment      "To specify the identifier for the product that created the object"@en ;
+              rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+              rdfs:label        "product id"@en ;
+              rdfs:range        xsd:string .
+
+spdx:CrossRef  rdf:type  owl:Class ;
+               rdfs:comment     "Cross reference details for the a URL reference"@en ;
+               rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                  owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange              xsd:string ;
+                                  owl:onProperty               spdx:match
+                         ] ;
+               rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                  owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange              xsd:anyURI ;
+                                  owl:onProperty               spdx:isWayBackLink
+                         ] ;
+               rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                  owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange              xsd:boolean ;
+                                  owl:onProperty               spdx:isValid
+                         ] ;
+               rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                  owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange              xsd:boolean ;
+                                  owl:onProperty               spdx:isLive
+                         ] ;
+               rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                  owl:onDataRange           xsd:anyURI ;
+                                  owl:onProperty            spdx:url ;
+                                  owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                         ] ;
+               rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                  owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange              xsd:nonNegativeInteger ;
+                                  owl:onProperty               spdx:order
+                         ] ;
+               rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                  owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                  owl:onDataRange              xsd:dateTime ;
+                                  owl:onProperty               spdx:timestamp
+                         ] ;
+               vs:term_status   "stable"@en .
+
+dcat:record  rdf:type       owl:ObjectProperty , rdf:Property ;
+             rdfs:comment        "Συνδέει έναν κατάλογο με τις καταγραφές του."@el , "Un record che descrive la registrazione di un singolo set di dati o di un servizio dati che fa parte del catalogo."@it , "Relie un catalogue à ses registres."@fr , "Propojuje katalog a jeho záznamy."@cs , "تربط الفهرس بسجل ضمنه"@ar , "Záznam popisující registraci jedné datové sady či datové služby jakožto součásti katalogu."@cs , "Describe la registración de un conjunto de datos o un servicio de datos en el catálogo."@es , "En post der beskriver registreringen af et enkelt datasæt eller en datatjeneste som er opført i kataloget."@da , "A record describing the registration of a single dataset or data service that is part of the catalog."@en , "カタログの一部であるカタログ・レコード。"@ja ;
+             rdfs:domain         dcat:Catalog ;
+             rdfs:isDefinedBy    <http://www.w3.org/TR/vocab-dcat/> ;
+             rdfs:label          "カタログ・レコード"@ja , "سجل"@ar , "registre"@fr , "záznam"@cs , "record"@en , "record"@it , "registro"@es , "καταγραφή"@el , "post"@da ;
+             rdfs:range          dcat:CatalogRecord ;
+             skos:altLabel       "har post"@da ;
+             skos:definition     "Propojuje katalog a jeho záznamy."@cs , "Relie un catalogue à ses registres."@fr , "Záznam popisující registraci jedné datové sady či datové služby jakožto součásti katalogu."@cs , "En post der beskriver registreringen af et enkelt datasæt eller en datatjeneste som er opført i kataloget."@da , "Un record che descrive la registrazione di un singolo set di dati o di un servizio dati che fa parte del catalogo."@it , "Συνδέει έναν κατάλογο με τις καταγραφές του."@el , "カタログの一部であるカタログ・レコード。"@ja , "Describe la registración de un conjunto de datos o un servicio de datos en el catálogo."@es , "تربط الفهرس بسجل ضمنه"@ar , "A record describing the registration of a single dataset or data service that is part of the catalog."@en ;
+             skos:editorialNote  "Status: English, Italian, Spanish and Czech Definitions modified by DCAT revision team, other translations pending."@en .
+
+time:unitType  rdf:type  owl:ObjectProperty ;
+               rdfs:comment  "The temporal unit which provides the precision of a date-time value or scale of a temporal extent"@en , "La unidad de tiempo que proporciona la precisión de un valor fecha-hora o la escala de una extensión temporal."@es ;
+               rdfs:domain   [ rdf:type     owl:Class ;
+                               owl:unionOf  ( time:GeneralDateTimeDescription time:Duration )
+                         ] ;
+               rdfs:label    "temporal unit type"@en , "tipo de unidad temporal"@es ;
+               rdfs:range    time:TemporalUnit .
+
+prov:generatedAtTime  rdf:type  owl:DatatypeProperty ;
+                      rdfs:comment        "The time at which an entity was completely created and is available for use."@en ;
+                      rdfs:domain         prov:Entity ;
+                      rdfs:isDefinedBy    <http://www.w3.org/ns/prov-o#> ;
+                      rdfs:label          "generatedAtTime" ;
+                      rdfs:range          xsd:dateTime ;
+                      prov:category       "expanded" ;
+                      prov:component      "entities-activities" ;
+                      prov:editorialNote  "It is the intent that the property chain holds: (prov:qualifiedGeneration o prov:atTime) rdfs:subPropertyOf prov:generatedAtTime."@en ;
+                      prov:qualifiedForm  prov:atTime , prov:Generation .
+
+spdx:supplier  rdf:type  owl:DatatypeProperty ;
+               rdfs:comment    "The name and, optionally, contact information of the person or organization who was the immediate supplier of this package to the recipient. The supplier may be different than originator when the software has been repackaged. Values of this property must conform to the agent and tool syntax."@en ;
+               rdfs:domain     spdx:Package ;
+               rdfs:range      xsd:string ;
+               vs:term_status  "stable"@en .
+
+spdx:licenseTextHtml  rdf:type  owl:DatatypeProperty ;
+                      rdfs:comment    "License text in HTML format"@en ;
+                      rdfs:domain     spdx:ListedLicense ;
+                      rdfs:range      xsd:string ;
+                      vs:term_status  "stable"@en .
+
+dcterms:NLM  rdf:type     dcam:VocabularyEncodingScheme ;
+             rdfs:comment      "The set of conceptual resources specified by the National Library of Medicine Classification."@en ;
+             rdfs:isDefinedBy  dcterms: ;
+             rdfs:label        "NLM"@en ;
+             rdfs:seeAlso      <http://wwwcf.nlm.nih.gov/class/> ;
+             dcterms:issued    "2005-06-13"^^xsd:date .
+
+dcat:contactPoint  rdf:type  rdf:Property , owl:ObjectProperty ;
+                   rdfs:comment        "Relevante kontaktoplysninger for den katalogiserede ressource. Anvendelse af vCard anbefales."@da , "Relevant contact information for the catalogued resource. Use of vCard is recommended."@en , "Información relevante de contacto para el recurso catalogado. Se recomienda el uso de vCard."@es , "Relie un jeu de données à une information de contact utile en utilisant VCard."@fr , "Informazioni di contatto rilevanti per la risorsa catalogata. Si raccomanda l'uso di vCard."@it , "データセットを、VCardを用いて提供されている適切な連絡先情報にリンクします。"@ja , "تربط قائمة البيانات بعنوان اتصال موصف  باستخدام VCard"@ar , "Συνδέει ένα σύνολο δεδομένων με ένα σχετικό σημείο επικοινωνίας, μέσω VCard."@el , "Relevantní kontaktní informace pro katalogizovaný zdroj. Doporučuje se použít slovník VCard."@cs ;
+                   rdfs:isDefinedBy    <http://www.w3.org/TR/vocab-dcat/> ;
+                   rdfs:label          "point de contact"@fr , "عنوان اتصال"@ar , "窓口"@ja , "contact point"@en , "σημείο επικοινωνίας"@el , "kontaktní bod"@cs , "punto di contatto"@it , "Punto de contacto"@es , "kontaktpunkt"@da ;
+                   rdfs:range          vcard:Kind ;
+                   skos:definition     "Relie un jeu de données à une information de contact utile en utilisant VCard."@fr , "Informazioni di contatto rilevanti per la risorsa catalogata. Si raccomanda l'uso di vCard."@it , "Συνδέει ένα σύνολο δεδομένων με ένα σχετικό σημείο επικοινωνίας, μέσω VCard."@el , "Relevant contact information for the catalogued resource. Use of vCard is recommended."@en , "Información relevante de contacto para el recurso catalogado. Se recomienda el uso de vCard."@es , "データセットを、VCardを用いて提供されている適切な連絡先情報にリンクします。"@ja , "Relevante kontaktoplysninger for den katalogiserede ressource. Anvendelse af vCard anbefales."@da , "تربط قائمة البيانات بعنوان اتصال موصف  باستخدام VCard"@ar , "Relevantní kontaktní informace pro katalogizovaný zdroj. Doporučuje se použít slovník VCard."@cs ;
+                   skos:editorialNote  "Status: English Definition text modified by DCAT revision team, Italian, Spanish and Czech translations provided, other translations pending."@en .
+
+spdx:relationshipType_buildDependencyOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is a build dependency of SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+<http://www.w3.org/ns/dcat>
+  rdf:type             owl:Ontology ;
+  rdfs:comment         "DCAT er et RDF-vokabular som har til formål at understøtte interoperabilitet mellem datakataloger udgivet på nettet. Ved at anvende DCAT til at beskrive datasæt i datakataloger, kan udgivere øge findbarhed og gøre det gøre det lettere for applikationer at anvende metadata fra forskellige kataloger. Derudover understøttes decentraliseret udstilling af kataloger og fødererede datasætsøgninger på tværs af websider. Aggregerede DCAT-metadata kan fungere som fortegnelsesfiler der kan understøtte digital bevaring. DCAT er defineret på http://www.w3.org/TR/vocab-dcat/. Enhver forskel mellem det normative dokument og dette schema er en fejl i dette schema."@da , "DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web. En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données augmentent leur découverte et permettent que les applications facilement les métadonnées de plusieurs catalogues. Il permet en plus la publication décentralisée des catalogues et facilitent la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources. DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Une quelconque version de ce document normatif et ce vocabulaire est une erreur dans ce vocabulaire."@fr , "DCAT je RDF slovník navržený pro zprostředkování interoperability mezi datovými katalogy publikovanými na Webu. Poskytovatelé dat používáním slovníku DCAT pro popis datových sad v datových katalozích zvyšují jejich dohledatelnost a umožňují aplikacím konzumovat metadata z více katalogů. Dále je umožňena decentralizovaná publikace katalogů a federované dotazování na datové sady napříč katalogy. Agregovaná DCAT metadata mohou také sloužit jako průvodka umožňující digitální uchování informace. DCAT je definován na http://www.w3.org/TR/vocab-dcat/. Jakýkoliv nesoulad mezi odkazovaným dokumentem a tímto schématem je chybou v tomto schématu."@cs , "هي أنطولوجية تسهل تبادل البيانات بين مختلف الفهارس على الوب. استخدام هذه الأنطولوجية يساعد على اكتشاف قوائم  البيانات المنشورة على الوب و يمكن التطبيقات المختلفة من الاستفادة أتوماتيكيا من البيانات المتاحة من مختلف الفهارس."@ar , "DCATは、ウェブ上で公開されたデータ・カタログ間の相互運用性の促進を目的とするRDFの語彙です。このドキュメントでは、その利用のために、スキーマを定義し、例を提供します。データ・カタログ内のデータセットを記述するためにDCATを用いると、公開者が、発見可能性を増加させ、アプリケーションが複数のカタログのメタデータを容易に利用できるようになります。さらに、カタログの分散公開を可能にし、複数のサイトにまたがるデータセットの統合検索を促進します。集約されたDCATメタデータは、ディジタル保存を促進するためのマニフェスト・ファイルとして使用できます。"@ja , "DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. By using DCAT to describe datasets in data catalogs, publishers increase discoverability and enable applications easily to consume metadata from multiple catalogs. It further enables decentralized publishing of catalogs and facilitates federated dataset search across sites. Aggregated DCAT metadata can serve as a manifest file to facilitate digital preservation. DCAT is defined at http://www.w3.org/TR/vocab-dcat/. Any variance between that normative document and this schema is an error in this schema."@en , "DCAT es un vocabulario RDF diseñado para facilitar la interoperabilidad entre catálogos de datos publicados en la Web. Utilizando DCAT para describir datos disponibles en catálogos se aumenta la posibilidad de que sean descubiertos y se permite que las aplicaciones consuman fácilmente los metadatos de varios catálogos."@es , "Το DCAT είναι ένα RDF λεξιλόγιο που σχεδιάσθηκε για να κάνει εφικτή τη διαλειτουργικότητα μεταξύ καταλόγων δεδομένων στον Παγκόσμιο Ιστό. Χρησιμοποιώντας το DCAT για την περιγραφή συνόλων δεδομένων, οι εκδότες αυτών αυξάνουν την ανακαλυψιμότητα και επιτρέπουν στις εφαρμογές την εύκολη κατανάλωση μεταδεδομένων από πολλαπλούς καταλόγους. Επιπλέον, δίνει τη δυνατότητα για αποκεντρωμένη έκδοση και διάθεση καταλόγων και επιτρέπει δυνατότητες ενοποιημένης αναζήτησης μεταξύ διαφορετικών πηγών. Συγκεντρωτικά μεταδεδομένα που έχουν περιγραφεί με το DCAT μπορούν να χρησιμοποιηθούν σαν ένα δηλωτικό αρχείο (manifest file) ώστε να διευκολύνουν την ψηφιακή συντήρηση."@el , "DCAT è un vocabolario RDF progettato per facilitare l'interoperabilità tra i cataloghi di dati pubblicati nel Web. Utilizzando DCAT per descrivere i dataset nei cataloghi di dati, i fornitori migliorano la capacità di individuazione dei dati e abilitano le  applicazioni al consumo di dati provenienti da cataloghi differenti. DCAT permette di decentralizzare la pubblicazione di cataloghi e facilita la ricerca federata dei dataset. L'aggregazione dei metadati federati può fungere da file manifesto per facilitare la conservazione digitale. DCAT è definito all'indirizzo http://www.w3.org/TR/vocab-dcat/. Qualsiasi scostamento tra tale definizione normativa e questo schema è da considerarsi un errore di questo schema."@it ;
+  rdfs:label           "Slovník pro datové katalogy"@cs , "Il vocabolario del catalogo dei dati"@it , "Le vocabulaire des jeux de données"@fr , "El vocabulario de catálogo de datos"@es , "Datakatalogvokabular"@da , "أنطولوجية فهارس قوائم البيانات"@ar , "Το λεξιλόγιο των καταλόγων δεδομένων"@el , "データ・カタログ語彙（DCAT）"@ja , "The data catalog vocabulary"@en ;
+  dcterms:contributor  [ rdfs:seeAlso     <https://orcid.org/0000-0003-3499-8262> ;
+                         sdo:affiliation  [ foaf:homepage  <http://stfc.ac.uk> ;
+                                            foaf:name      "Science and Technology Facilities Council, UK"
+                                          ] ;
+                         foaf:homepage    <https://agbeltran.github.io> ;
+                         foaf:name        "Alejandra Gonzalez-Beltran"
+                       ] ;
+  dcterms:contributor  [ rdfs:seeAlso   <https://jakub.klímek.com/#me> ;
+                         foaf:homepage  <https://jakub.klímek.com/> ;
+                         foaf:name      "Jakub Klímek"
+                       ] ;
+  dcterms:contributor  [ foaf:name  "Martin Alvarez-Espinar" ] ;
+  dcterms:contributor  [ foaf:name  "Richard Cyganiak" ] ;
+  dcterms:contributor  [ rdfs:seeAlso     <http://philarcher.org/foaf.rdf#me> ;
+                         sdo:affiliation  <http://www.w3.org/data#W3C> ;
+                         foaf:homepage    <http://www.w3.org/People/all#phila> ;
+                         foaf:name        "Phil Archer"
+                       ] ;
+  dcterms:contributor  [ rdfs:seeAlso   <http://makxdekkers.com/makxdekkers.rdf#me> ;
+                         foaf:homepage  <http://makxdekkers.com/> ;
+                         foaf:name      "Makx Dekkers"
+                       ] ;
+  dcterms:contributor  [ sdo:affiliation  [ foaf:homepage  <http://www.refinitiv.com> ;
+                                            foaf:name      "Refinitiv"
+                                          ] ;
+                         foaf:name        "David Browning"
+                       ] ;
+  dcterms:contributor  [ sdo:affiliation  [ foaf:homepage  <http://okfn.org> ;
+                                            foaf:name      "Open Knowledge Foundation"
+                                          ] ;
+                         foaf:name        "Rufus Pollock"
+                       ] ;
+  dcterms:contributor  [ rdfs:seeAlso   <https://orcid.org/0000-0001-5648-2713> ;
+                         foaf:homepage  <http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni> , <https://w3id.org/people/ralbertoni/> ;
+                         foaf:name      "Riccardo Albertoni"
+                       ] ;
+  dcterms:contributor  [ foaf:homepage  <http://www.asahi-net.or.jp/~ax2s-kmtn/> ;
+                         foaf:name      "Shuji Kamitsuna"
+                       ] ;
+  dcterms:contributor  [ rdfs:seeAlso  <http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf> ;
+                         foaf:name     "Ghislain Auguste Atemezing"
+                       ] ;
+  dcterms:contributor  [ foaf:name  "Boris Villazón-Terrazas" ] ;
+  dcterms:contributor  [ rdf:type               foaf:Person ;
+                         rdfs:seeAlso           <https://orcid.org/0000-0002-3884-3420> ;
+                         sdo:affiliation        [ foaf:homepage  <https://csiro.au> ;
+                                                  foaf:name      "Commonwealth Scientific and Industrial Research Organisation"
+                                                ] ;
+                         foaf:name              "Simon J D Cox" ;
+                         foaf:workInfoHomepage  <http://people.csiro.au/Simon-Cox>
+                       ] ;
+  dcterms:contributor  [ foaf:name  "Marios Meimaris" ] ;
+  dcterms:contributor  [ rdfs:seeAlso   <https://orcid.org/0000-0001-9300-2694> ;
+                         foaf:homepage  <http://www.andrea-perego.name/foaf/#me> ;
+                         foaf:name      "Andrea Perego"
+                       ] ;
+  dcterms:contributor  [ sdo:affiliation  [ foaf:homepage  <http://ec.europa.eu/dgs/informatics/> ;
+                                            foaf:name      "European Commission, DG DIGIT"
+                                          ] ;
+                         foaf:name        "Vassilios Peristeras"
+                       ] ;
+  dcterms:creator      [ foaf:name  "John Erickson" ] ;
+  dcterms:creator      [ rdfs:seeAlso  <http://fadmaa.me/foaf.ttl> ;
+                         foaf:name     "Fadi Maali"
+                       ] ;
+  dcterms:license      <https://creativecommons.org/licenses/by/4.0/> ;
+  dcterms:modified     "2013-09-20"^^xsd:date , "2020-11-30"^^xsd:date , "2019" , "2012-04-24"^^xsd:date , "2021-09-14"^^xsd:date , "2013-11-28"^^xsd:date , "2017-12-19"^^xsd:date ;
+  owl:imports          <http://www.w3.org/2004/02/skos/core> , <http://www.w3.org/ns/prov-o#> , dcterms: ;
+  owl:versionInfo      "Questa è una copia aggiornata del vocabolario DCAT v2.0 disponibile in https://www.w3.org/ns/dcat.ttl"@en , "This is an updated copy of v2.0 of the DCAT vocabulary, taken from https://www.w3.org/ns/dcat.ttl"@en , "Esta es una copia del vocabulario DCAT v2.0 disponible en https://www.w3.org/ns/dcat.ttl"@es , "Dette er en opdateret kopi af DCAT v. 2.0 som er tilgænglig på https://www.w3.org/ns/dcat.ttl"@da , "Toto je aktualizovaná kopie slovníku DCAT verze 2.0, převzatá z https://www.w3.org/ns/dcat.ttl"@cs ;
+  skos:editorialNote   "English language definitions updated in this revision in line with ED. Multilingual text unevenly updated."@en ;
+  foaf:maker           [ foaf:homepage  <http://www.w3.org/2011/gld/> ;
+                         foaf:name      "Government Linked Data WG"
+                       ] .
+
+dcat:qualifiedRelation
+  rdf:type            owl:ObjectProperty ;
+  rdfs:comment        "Odkaz na popis vztahu s jiným zdrojem."@cs , "Link a una descrizione di una relazione con un'altra risorsa."@it , "Link to a description of a relationship with another resource."@en , "Enlace a una descripción de la relación con otro recurso."@es , "Reference til en beskrivelse af en relation til en anden ressource."@da ;
+  rdfs:domain         dcat:Resource ;
+  rdfs:label          "qualified relation"@en , "relazione qualificata"@it , "Kvalificeret relation"@da , "relación calificada"@es , "kvalifikovaný vztah"@cs ;
+  rdfs:range          dcat:Relationship ;
+  skos:changeNote     "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs , "New property added in DCAT 2.0."@en , "Propiedad nueva añadida en DCAT 2.0."@es , "Ny egenskab tilføjet i DCAT 2.0."@da , "Nuova proprietà aggiunta in DCAT 2.0."@it ;
+  skos:definition     "Odkaz na popis vztahu s jiným zdrojem."@cs , "Reference til en beskrivelse af en relation til en anden ressource."@da , "Link a una descrizione di una relazione con un'altra risorsa."@it , "Enlace a una descripción de la relación con otro recurso."@es , "Link to a description of a relationship with another resource."@en ;
+  skos:editorialNote  "Introduced into DCAT to complement the other PROV qualified relations. "@en , "Přidáno do DCAT k doplnění jiných kvalifikovaných vztahů ze slovníku PROV."@cs , "Se incluyó en DCAT para complementar las relaciones calificadas disponibles en PROV."@es , "Introdotta in DCAT per integrare le altre relazioni qualificate di PROV."@it , "Introduceret i DCAT med henblik på at supplere de øvrige kvalificerede relationer fra PROV. "@da ;
+  skos:scopeNote      "Used to link to another resource where the nature of the relationship is known but does not match one of the standard Dublin Core properties (dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy) or PROV-O properties (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf)."@en , "Anvendes til at referere til en anden ressource hvor relationens betydning er kendt men ikke matcher en af de standardiserede egenskaber fra Dublin Core (dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy) eller PROV-O-egenskaber (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf)."@da , "Viene utilizzato per associarsi a un'altra risorsa nei casi per i quali la natura della relazione è nota ma non è alcuna delle proprietà fornite dallo standard Dublin Core (dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat , dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:require, dct:isRequiredBy) o dalle proprietà fornite da PROV-O (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom , prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf)."@it , "Použito pro odkazování na jiný zdroj, kde druh vztahu je znám, ale neodpovídá standardním vlastnostem ze slovníku Dublin Core (dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy) či slovníku PROV-O (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf)."@cs , "Se usa para asociar con otro recurso para el cuál la naturaleza de la relación es conocida pero no es ninguna de las propiedades que provee el estándar Dublin Core (dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy) or PROV-O properties (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf)."@es .
+
+time:hasTime  rdf:type      owl:ObjectProperty ;
+              rdfs:comment        "Proporciona soporte a la asociación de una entidad temporal (instante o intervalo) a cualquier cosa."@es , "Supports the association of a temporal entity (instant or interval) to any thing"@en ;
+              rdfs:label          "tiene tiempo"@es , "has time"@en ;
+              rdfs:range          time:TemporalEntity ;
+              skos:definition     "Proporciona soporte a la asociación de una entidad temporal (instante o intervalo) a cualquier cosa."@es , "Supports the association of a temporal entity (instant or interval) to any thing"@en ;
+              skos:editorialNote  "Feature at risk - added in 2017 revision, and not yet widely used. "@en , "Característica arriesgada -añadida en la revisión del 2017 que no ha sido todavía utilizada de forma amplia."@es .
+
+spdx:licenseInfoInSnippet
+  rdf:type            owl:ObjectProperty ;
+  rdfs:comment        "Licensing information that was discovered directly in the subject snippet. This is also considered a declared license for the snippet.\n\nIf the licenseInfoInSnippet field is not present for a snippet, it implies an equivalent meaning to NOASSERTION."@en ;
+  rdfs:domain         spdx:Snippet ;
+  rdfs:range          [ rdf:type     owl:Class ;
+                        owl:unionOf  ( spdx:AnyLicenseInfo
+                                       [ rdf:type        owl:Restriction ;
+                                         owl:hasValue    spdx:noassertion ;
+                                         owl:onProperty  spdx:licenseInfoInFile
+                                       ]
+                                       [ rdf:type        owl:Restriction ;
+                                         owl:hasValue    spdx:none ;
+                                         owl:onProperty  spdx:licenseInfoInFile
+                                       ]
+                                     )
+                      ] ;
+  rdfs:subPropertyOf  spdx:licenseInfoFromFiles ;
+  vs:term_status      "stable"@en .
+
+<http://data.europa.eu/r5r#DcatResource_Shape>
+  rdf:type      sh:NodeShape ;
+  rdfs:comment  "the union of Catalog, Dataset and DataService" ;
+  rdfs:label    "dcat:Resource" ;
+  sh:message    "The node is either a Catalog, Dataset or a DataService" ;
+  sh:or         ( [ sh:class  dcat:Catalog ]
+                  [ sh:class  dcat:Dataset ]
+                  [ sh:class  dcat:DataService ]
+                ) .
+
+spdx:annotationType_other
+  rdf:type        owl:NamedIndividual , spdx:AnnotationType ;
+  rdfs:comment    "Type of annotation which does not fit in any of the pre-defined annotation types."@en ;
+  vs:term_status  "stable"@en .
+
+prov:   rdf:type  owl:Ontology .
+
+vcard:note  rdf:type      owl:DatatypeProperty ;
+            rdfs:comment      "A note associated with the object"@en ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "note"@en ;
+            rdfs:range        xsd:string .
+
+skos:semanticRelation
+  rdf:type          owl:ObjectProperty , rdf:Property ;
+  rdfs:domain       skos:Concept ;
+  rdfs:isDefinedBy  <http://www.w3.org/2004/02/skos/core> ;
+  rdfs:label        "is in semantic relation with"@en ;
+  rdfs:range        skos:Concept ;
+  skos:definition   "Links a concept to a concept related by meaning."@en ;
+  skos:scopeNote    "This property should not be used directly, but as a super-property for all properties denoting a relationship of meaning between concepts."@en .
+
+<http://www.w3.org/2009/pointers#offset>
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:domain     <http://www.w3.org/2009/pointers#OffsetPointer> ;
+  rdfs:range      xsd:positiveInteger ;
+  vs:term_status  "stable"@en .
+
+prov:Quotation  rdf:type      owl:Class ;
+                rdfs:comment          "An instance of prov:Quotation provides additional descriptions about the binary prov:wasQuotedFrom relation from some taken prov:Entity from an earlier, larger prov:Entity. For example, :here_is_looking_at_you_kid prov:wasQuotedFrom :casablanca_script; prov:qualifiedQuotation [ a prov:Quotation; prov:entity :casablanca_script; :foo :bar ]."@en ;
+                rdfs:isDefinedBy      <http://www.w3.org/ns/prov-o#> ;
+                rdfs:label            "Quotation" ;
+                rdfs:subClassOf       prov:Derivation ;
+                prov:category         "qualified" ;
+                prov:component        "derivations" ;
+                prov:definition       "A quotation is the repeat of (some or all of) an entity, such as text or image, by someone who may or may not be its original author. Quotation is a particular case of derivation."@en ;
+                prov:dm               "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-quotation"^^xsd:anyURI ;
+                prov:n                "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-quotation"^^xsd:anyURI ;
+                prov:unqualifiedForm  prov:wasQuotedFrom .
+
+prov:wasGeneratedBy  rdf:type   owl:ObjectProperty ;
+                     rdfs:domain             prov:Entity ;
+                     rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+                     rdfs:label              "wasGeneratedBy" ;
+                     rdfs:range              prov:Activity ;
+                     rdfs:subPropertyOf      prov:wasInfluencedBy ;
+                     owl:propertyChainAxiom  ( prov:qualifiedGeneration prov:activity ) ;
+                     owl:propertyChainAxiom  ( prov:qualifiedGeneration prov:activity ) ;
+                     prov:category           "starting-point" ;
+                     prov:component          "entities-activities" ;
+                     prov:inverse            "generated" ;
+                     prov:qualifiedForm      prov:Generation , prov:qualifiedGeneration .
+
+dcterms:title  rdf:type     rdf:Property ;
+               rdfs:comment        "A name given to the resource."@en ;
+               rdfs:isDefinedBy    dcterms: ;
+               rdfs:label          "Title"@en ;
+               rdfs:range          rdfs:Literal ;
+               rdfs:subPropertyOf  dc:title ;
+               dcterms:issued      "2008-01-14"^^xsd:date .
+
+foaf:homepage  rdf:type  owl:ObjectProperty ;
+               rdfs:comment  "This axiom needed so that Protege loads DCAT2 without errors." .
+
+spdx:fileDependency  rdf:type  owl:ObjectProperty ;
+                     rdfs:comment    "This field is deprecated since SPDX 2.0 in favor of using Section 7 which provides more granularity about relationships."@en ;
+                     rdfs:domain     spdx:File ;
+                     rdfs:range      spdx:File ;
+                     owl:deprecated  true ;
+                     vs:term_status  "deprecated"@en .
+
+vcard:hasCalendarBusy
+  rdf:type          owl:ObjectProperty ;
+  rdfs:comment      "To specify the busy time associated with the object. (Was called FBURL in RFC6350)"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "has calendar busy"@en .
+
+spdx:purpose_source  rdf:type  owl:NamedIndividual , spdx:Purpose ;
+                     rdfs:comment    "The package is a collection of source files."@en ;
+                     vs:term_status  "stable"@en .
+
+spdx:hasExtractedLicensingInfo
+  rdf:type        owl:ObjectProperty ;
+  rdfs:comment    "Indicates that a particular ExtractedLicensingInfo was defined in the subject SpdxDocument."@en ;
+  rdfs:domain     spdx:SpdxDocument ;
+  rdfs:range      spdx:ExtractedLicensingInfo ;
+  vs:term_status  "stable"@en .
+
+spdx:purpose_application
+  rdf:type        owl:NamedIndividual , spdx:Purpose ;
+  rdfs:comment    "The package is a software application."@en ;
+  vs:term_status  "stable"@en .
+
+dcterms:coverage  rdf:type   rdf:Property ;
+                  rdfs:comment         "The spatial or temporal topic of the resource, spatial applicability of the resource, or jurisdiction under which the resource is relevant."@en ;
+                  rdfs:isDefinedBy     dcterms: ;
+                  rdfs:label           "Coverage"@en ;
+                  rdfs:subPropertyOf   dc:coverage ;
+                  dcam:rangeIncludes   dcterms:Location , dcterms:Period , dcterms:Jurisdiction ;
+                  dcterms:description  "Spatial topic and spatial applicability may be a named place or a location specified by its geographic coordinates. Temporal topic may be a named period, date, or date range. A jurisdiction may be a named administrative entity or a geographic place to which the resource applies. Recommended practice is to use a controlled vocabulary such as the Getty Thesaurus of Geographic Names [[TGN](https://www.getty.edu/research/tools/vocabulary/tgn/index.html)]. Where appropriate, named places or time periods may be used in preference to numeric identifiers such as sets of coordinates or date ranges.  Because coverage is so broadly defined, it is preferable to use the more specific subproperties Temporal Coverage and Spatial Coverage."@en ;
+                  dcterms:issued       "2008-01-14"^^xsd:date .
+
+dcterms:date  rdf:type       rdf:Property ;
+              rdfs:comment         "A point or period of time associated with an event in the lifecycle of the resource."@en ;
+              rdfs:isDefinedBy     dcterms: ;
+              rdfs:label           "Date"@en ;
+              rdfs:range           rdfs:Literal ;
+              rdfs:subPropertyOf   dc:date ;
+              dcterms:description  "Date may be used to express temporal information at any level of granularity.  Recommended practice is to express the date, date/time, or period of time according to ISO 8601-1 [[ISO 8601-1](https://www.iso.org/iso-8601-date-and-time-format.html)] or a published profile of the ISO standard, such as the W3C Note on Date and Time Formats [[W3CDTF](https://www.w3.org/TR/NOTE-datetime)] or the Extended Date/Time Format Specification [[EDTF](http://www.loc.gov/standards/datetime/)].  If the full date is unknown, month and year (YYYY-MM) or just year (YYYY) may be used. Date ranges may be specified using ISO 8601 period of time specification in which start and end dates are separated by a '/' (slash) character.  Either the start or end date may be missing."@en ;
+              dcterms:issued       "2008-01-14"^^xsd:date .
+
+time:unitYear  rdf:type  time:TemporalUnit ;
+               rdfs:label      "Year (unit of temporal duration)"@en ;
+               skos:prefLabel  "anno"@it , "سنة واحدة"@ar , "jaar"@nl , "一年"@zh , "Jahr"@de , "один год"@ru , "un año"@es , "year"@en , "an"@fr , "1 년"@kr , "1年"@jp , "ano"@pt , "rok"@pl ;
+               time:days       "0"^^xsd:decimal ;
+               time:hours      "0"^^xsd:decimal ;
+               time:minutes    "0"^^xsd:decimal ;
+               time:months     "0"^^xsd:decimal ;
+               time:seconds    "0"^^xsd:decimal ;
+               time:weeks      "0"^^xsd:decimal ;
+               time:years      "1"^^xsd:decimal .
+
+spdx:fileType_image  rdf:type  owl:NamedIndividual , spdx:FileType ;
+                     rdfs:comment    "The file is assoicated with an picture image file (MIME type of image/*,  ie. .jpg, .gif  )."@en ;
+                     vs:term_status  "stable"@en .
+
+prov:wasAttributedTo  rdf:type  owl:ObjectProperty ;
+                      rdfs:comment            "Attribution is the ascribing of an entity to an agent."@en ;
+                      rdfs:domain             prov:Entity ;
+                      rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+                      rdfs:label              "wasAttributedTo" ;
+                      rdfs:range              prov:Agent ;
+                      rdfs:subPropertyOf      prov:wasInfluencedBy ;
+                      owl:propertyChainAxiom  ( prov:qualifiedAttribution prov:agent ) ;
+                      owl:propertyChainAxiom  ( prov:qualifiedAttribution prov:agent ) ;
+                      prov:category           "starting-point" ;
+                      prov:component          "agents-responsibility" ;
+                      prov:definition         "Attribution is the ascribing of an entity to an agent."@en ;
+                      prov:inverse            "contributed" ;
+                      prov:qualifiedForm      prov:Attribution , prov:qualifiedAttribution .
+
+dcat:hadRole  rdf:type      owl:ObjectProperty ;
+              rdfs:comment        "La función de una entidad o agente con respecto a otra entidad o recurso."@es , "La funzione di un'entità o un agente rispetto ad un'altra entità o risorsa."@it , "Den funktion en entitet eller aktør har i forhold til en anden ressource."@da , "Funkce entity či agenta ve vztahu k jiné entitě či zdroji."@cs , "The function of an entity or agent with respect to another entity or resource."@en ;
+              rdfs:domain         [ rdf:type     owl:Class ;
+                                    owl:unionOf  ( prov:Attribution dcat:Relationship )
+                            ] ;
+              rdfs:label          "tiene rol"@it , "sehraná role"@cs , "hadRole"@en , "havde rolle"@da , "haRuolo"@it ;
+              rdfs:range          dcat:Role ;
+              skos:changeNote     "New property added in DCAT 2.0."@en , "Nueva propiedad agregada en DCAT 2.0."@es , "Nuova proprietà aggiunta in DCAT 2.0."@it , "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs ;
+              skos:definition     "Den funktion en entitet eller aktør har i forhold til en anden ressource."@da , "La funzione di un'entità o un agente rispetto ad un'altra entità o risorsa."@it , "The function of an entity or agent with respect to another entity or resource."@en , "La función de una entidad o agente con respecto a otra entidad o recurso."@es , "Funkce entity či agenta ve vztahu k jiné entitě či zdroji."@cs ;
+              skos:editorialNote  "Přidáno do DCAT pro doplnění vlastnosti prov:hadRole (jejíž užití je omezeno na role v kontextu aktivity, s definičním oborem prov:Association)."@cs , "Introduceret i DCAT for at supplere prov:hadRole (hvis anvendelse er begrænset til roller i forbindelse med en aktivitet med domænet prov:Association)."@da , "Introduced into DCAT to complement prov:hadRole (whose use is limited to roles in the context of an activity, with the domain of prov:Association."@en , "Introdotta in DCAT per completare prov:hadRole (il cui uso è limitato ai ruoli nel contesto di un'attività, con il dominio di prov:Association."@it , "Agregada en DCAT para complementar prov:hadRole (cuyo uso está limitado a roles en el contexto de una actividad, con dominio prov:Association."@es ;
+              skos:scopeNote      "Può essere utilizzata in una relazione qualificata per specificare il ruolo di un'entità rispetto a un'altra entità. Si raccomanda che il valore sia preso da un vocabolario controllato di ruoli di entità come ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode, IANA Registry of Link Relations https://www.iana.org/assignments/link-relation, DataCite metadata schema, o MARC relators https://id.loc.gov/vocabulary/relators."@it , "Může být použito v kvalifikovaném vztahu pro specifikaci role Entity ve vztahu k jiné Entitě. Je doporučeno použít hodnotu z řízeného slovníku rolí entit, jako například ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode, IANA Registry of Link Relations https://www.iana.org/assignments/link-relation, DataCite metadata schema, MARC relators https://id.loc.gov/vocabulary/relators."@cs , "May be used in a qualified-relation to specify the role of an Entity with respect to another Entity.  It is recommended that the value be taken from a controlled vocabulary of entity roles such as: ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode; IANA Registry of Link Relations https://www.iana.org/assignments/link-relation; DataCite metadata schema; MARC relators https://id.loc.gov/vocabulary/relators."@en , "May be used in a qualified-attribution to specify the role of an Agent with respect to an Entity. It is recommended that the value be taken from a controlled vocabulary of agent roles, such as http://registry.it.csiro.au/def/isotc211/CI_RoleCode."@en , "Může být použito v kvalifikovaném přiřazení pro specifikaci role Agenta ve vztahu k Entitě. Je doporučeno hodnotu vybrat z řízeného slovníku rolí agentů, jako například http://registry.it.csiro.au/def/isotc211/CI_RoleCode."@cs , "Può essere utilizzato in un'attribuzione qualificata per specificare il ruolo di un agente rispetto a un'entità. Si raccomanda che il valore sia preso da un vocabolario controllato di ruoli di agente, come ad esempio http://registry.it.csiro.au/def/isotc211/CI_RoleCode."@it , "Puede usarse en una atribución cualificada para especificar el rol de un Agente con respecto a una Entidad. Se recomienda que el valor sea de un vocabulario controlado de roles de agentes, como por ejemplo http://registry.it.csiro.au/def/isotc211/CI_RoleCode."@es , "Kan vendes ved kvalificerede krediteringer til at angive en aktørs rolle i forhold en entitet. Det anbefales at værdierne styres som et kontrolleret udfaldsrum med aktørroller, såsom http://registry.it.csiro.au/def/isotc211/CI_RoleCode."@da , "Puede usarse en una atribución cualificada para especificar el rol de una Entidad con respecto a otra Entidad. Se recomienda que su valor se tome de un vocabulario controlado de roles de entidades como por ejemplo: ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode; IANA Registry of Link Relations https://www.iana.org/assignments/link-relation; esquema de metadatos de DataCite; MARC relators https://id.loc.gov/vocabulary/relators."@es .
+
+xsd:dateTimeStamp  rdfs:label  "sello de tiempo"@es .
+
+spdx:noassertion  rdf:type  owl:NamedIndividual ;
+                  rdfs:comment  "Individual to indicate the creator of the SPDX document does not assert any value for the object." .
+
+spdx:purpose_container
+  rdf:type        owl:NamedIndividual , spdx:Purpose ;
+  rdfs:comment    "The package refers to a container image which can be used by a container runtime application."@en ;
+  vs:term_status  "stable"@en .
+
+prov:PrimarySource  rdf:type  owl:Class ;
+                    rdfs:comment          "An instance of prov:PrimarySource provides additional descriptions about the binary prov:hadPrimarySource relation from some secondary prov:Entity to an earlier, primary prov:Entity. For example, :blog prov:hadPrimarySource :newsArticle; prov:qualifiedPrimarySource [ a prov:PrimarySource; prov:entity :newsArticle; :foo :bar ] ."@en ;
+                    rdfs:isDefinedBy      <http://www.w3.org/ns/prov-o#> ;
+                    rdfs:label            "PrimarySource" ;
+                    rdfs:subClassOf       prov:Derivation ;
+                    prov:category         "qualified" ;
+                    prov:component        "derivations" ;
+                    prov:definition       "A primary source for a topic refers to something produced by some agent with direct experience and knowledge about the topic, at the time of the topic's study, without benefit from hindsight.\n\nBecause of the directness of primary sources, they 'speak for themselves' in ways that cannot be captured through the filter of secondary sources. As such, it is important for secondary sources to reference those primary sources from which they were derived, so that their reliability can be investigated.\n\nA primary source relation is a particular case of derivation of secondary materials from their primary sources. It is recognized that the determination of primary sources can be up to interpretation, and should be done according to conventions accepted within the application's domain."@en ;
+                    prov:dm               "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-primary-source"^^xsd:anyURI ;
+                    prov:n                "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-original-source"^^xsd:anyURI ;
+                    prov:unqualifiedForm  prov:hadPrimarySource .
+
+skos:OrderedCollection
+  rdf:type          owl:Class ;
+  rdfs:isDefinedBy  <http://www.w3.org/2004/02/skos/core> ;
+  rdfs:label        "Ordered Collection"@en ;
+  rdfs:subClassOf   skos:Collection ;
+  skos:definition   "An ordered collection of concepts, where both the grouping and the ordering are meaningful."@en ;
+  skos:scopeNote    "Ordered collections can be used where you would like a set of concepts to be displayed in a specific order, and optionally under a 'node label'."@en .
+
+prov:EntityInfluence  rdf:type  owl:Class ;
+                      rdfs:comment            "EntityInfluence provides additional descriptions of an Entity's binary influence upon any other kind of resource. Instances of EntityInfluence use the prov:entity property to cite the influencing Entity."@en , "It is not recommended that the type EntityInfluence be asserted without also asserting one of its more specific subclasses."@en ;
+                      rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+                      rdfs:label              "EntityInfluence" ;
+                      rdfs:seeAlso            prov:entity ;
+                      rdfs:subClassOf         prov:Influence ;
+                      prov:category           "qualified" ;
+                      prov:editorsDefinition  "EntityInfluence is the capacity of an entity to have an effect on the character, development, or behavior of another by means of usage, start, end, derivation, or other. "@en .
+
+spdx:relationshipType_variantOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "A Relationship of relationshipType_variantOf expresses that an SPDXElement is a variant of the relatedSPDXElement, but it is not clear which came first.  For example, if the content of two Files differs by some edit, but there is no way to tell which came first (no reliable date information), then one File is a variant of the other File."@en ;
+  vs:term_status  "stable"@en .
+
+dcterms:publisher  rdf:type  rdf:Property ;
+                   rdfs:comment        "An entity responsible for making the resource available."@en ;
+                   rdfs:isDefinedBy    dcterms: ;
+                   rdfs:label          "Publisher"@en ;
+                   rdfs:subPropertyOf  dc:publisher ;
+                   dcam:rangeIncludes  dcterms:Agent ;
+                   dcterms:issued      "2008-01-14"^^xsd:date .
+
+time:inXSDDate  rdf:type  owl:DatatypeProperty ;
+                rdfs:comment     "Position of an instant, expressed using xsd:date"@en , "Posición de un instante, expresado utilizando xsd:date."@es ;
+                rdfs:domain      time:Instant ;
+                rdfs:label       "in XSD date"@en , "en fecha XSD"@es ;
+                rdfs:range       xsd:date ;
+                skos:definition  "Position of an instant, expressed using xsd:date"@en , "Posición de un instante, expresado utilizando xsd:date."@es .
+
+dcterms:dateAccepted  rdf:type  rdf:Property ;
+                      rdfs:comment         "Date of acceptance of the resource."@en ;
+                      rdfs:isDefinedBy     dcterms: ;
+                      rdfs:label           "Date Accepted"@en ;
+                      rdfs:range           rdfs:Literal ;
+                      rdfs:subPropertyOf   dc:date , dcterms:date ;
+                      dcterms:description  "Recommended practice is to describe the date, date/time, or period of time as recommended for the property Date, of which this is a subproperty.  Examples of resources to which a date of acceptance may be relevant are a thesis (accepted by a university department) or an article (accepted by a journal)."@en ;
+                      dcterms:issued       "2002-07-13"^^xsd:date .
+
+prov:dm  rdf:type           owl:AnnotationProperty ;
+         rdfs:comment        "A reference to the principal section of the PROV-DM document that describes this concept."@en ;
+         rdfs:isDefinedBy    <http://www.w3.org/ns/prov-o#> ;
+         rdfs:subPropertyOf  rdfs:seeAlso .
+
+adms:sample  rdf:type     owl:ObjectProperty ;
+             rdfs:comment      "Links to a sample of an Asset (which is itself an Asset)."@en ;
+             rdfs:domain       rdfs:Resource ;
+             rdfs:isDefinedBy  <http://www.w3.org/ns/adms> ;
+             rdfs:label        "sample"@en ;
+             rdfs:range        rdfs:Resource .
+
+[ rdf:type               owl:Axiom ;
+  rdfs:comment           "A collection is an entity that provides a structure to some constituents, which are themselves entities. These constituents are said to be member of the collections."@en ;
+  owl:annotatedProperty  rdfs:range ;
+  owl:annotatedSource    prov:hadMember ;
+  owl:annotatedTarget    prov:Entity ;
+  prov:dm                "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-collection"
+] .
+
+prov:endedAtTime  rdf:type  owl:DatatypeProperty ;
+                  rdfs:comment        "The time at which an activity ended. See also prov:startedAtTime."@en ;
+                  rdfs:domain         prov:Activity ;
+                  rdfs:isDefinedBy    <http://www.w3.org/ns/prov-o#> ;
+                  rdfs:label          "endedAtTime" ;
+                  rdfs:range          xsd:dateTime ;
+                  prov:category       "starting-point" ;
+                  prov:component      "entities-activities" ;
+                  prov:editorialNote  "It is the intent that the property chain holds: (prov:qualifiedEnd o prov:atTime) rdfs:subPropertyOf prov:endedAtTime."@en ;
+                  prov:qualifiedForm  prov:End , prov:atTime .
+
+time:Instant  rdf:type   owl:Class ;
+              rdfs:comment     "A temporal entity with zero extent or duration"@en , "Una entidad temporal con una extensión o duración cero."@es ;
+              rdfs:label       "Time instant"@en , "instante de tiempo."@es ;
+              rdfs:subClassOf  time:TemporalEntity ;
+              skos:definition  "A temporal entity with zero extent or duration"@en , "Una entidad temporal con una extensión o duración cero."@es .
+
+adms:identifier  rdf:type  owl:ObjectProperty ;
+                 rdfs:comment      "Links a resource to an adms:Identifier class."@en ;
+                 rdfs:domain       rdfs:Resource ;
+                 rdfs:isDefinedBy  <http://www.w3.org/ns/adms> ;
+                 rdfs:label        "identifier"@en ;
+                 rdfs:range        adms:Identifier .
+
+prov:qualifiedDerivation
+  rdf:type                   owl:ObjectProperty ;
+  rdfs:comment               "If this Entity prov:wasDerivedFrom Entity :e, then it can qualify how it was derived using prov:qualifiedDerivation [ a prov:Derivation;  prov:entity :e; :foo :bar ]."@en ;
+  rdfs:domain                prov:Entity ;
+  rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label                 "qualifiedDerivation" ;
+  rdfs:range                 prov:Derivation ;
+  rdfs:subPropertyOf         prov:qualifiedInfluence ;
+  prov:category              "qualified" ;
+  prov:component             "derivations" ;
+  prov:inverse               "qualifiedDerivationOf" ;
+  prov:sharesDefinitionWith  prov:Derivation ;
+  prov:unqualifiedForm       prov:wasDerivedFrom .
+
+dcat:endpointURL  rdf:type  owl:ObjectProperty ;
+                  rdfs:comment     "La posición raíz o end-point principal del servicio (una IRI web)."@es , "La locazione principale o l'endpoint primario del servizio (un IRI risolvibile via web)."@it , "The root location or primary endpoint of the service (a web-resolvable IRI)."@en , "Kořenové umístění nebo hlavní přístupový bod služby (IRI přístupné přes Web)."@cs , "Rodplaceringen eller det primære endpoint for en tjeneste (en web-resolverbar IRI)."@da ;
+                  rdfs:domain      dcat:DataService ;
+                  rdfs:label       "end-point del servizio"@it , "service end-point"@en , "end-point del servicio"@es , "přístupový bod služby"@cs , "tjenesteendpoint"@da ;
+                  rdfs:range       rdfs:Resource ;
+                  skos:changeNote  "Nueva propiedad agregada en DCAT 2.0."@es , "Nuova proprietà in DCAT 2.0."@it , "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs , "New property in DCAT 2.0."@en ;
+                  skos:definition  "Rodplaceringen eller det primære endpoint for en tjeneste (en web-resolverbar IRI)."@da , "The root location or primary endpoint of the service (a web-resolvable IRI)."@en , "La locazione principale o l'endpoint primario del servizio (un IRI risolvibile via web)."@it , "Kořenové umístění nebo hlavní přístupový bod služby (IRI přístupné přes Web)."@cs , "La posición raíz o end-point principal del servicio (una IRI web)."@es .
+
+skos:inScheme  rdf:type   owl:ObjectProperty , rdf:Property ;
+               rdfs:isDefinedBy  <http://www.w3.org/2004/02/skos/core> ;
+               rdfs:label        "is in scheme"@en ;
+               rdfs:range        skos:ConceptScheme ;
+               skos:definition   "Relates a resource (for example a concept) to a concept scheme in which it is included."@en ;
+               skos:scopeNote    "A concept may be a member of more than one concept scheme."@en .
+
+time:minutes  rdf:type   owl:DatatypeProperty ;
+              rdfs:comment     "length, or element of, a temporal extent expressed in minutes"@en , "Longitud de, o elemento de la longitud de, una extensión temporal expresada en minutos."@es ;
+              rdfs:domain      time:GeneralDurationDescription ;
+              rdfs:label       "minutes"@en , "minutos"@es ;
+              rdfs:range       xsd:decimal ;
+              skos:definition  "length, or element of, a temporal extent expressed in minutes"@en , "Longitud de, o elemento de la longitud de, una extensión temporal expresada en minutos."@es .
+
+prov:Association  rdf:type    owl:Class ;
+                  rdfs:comment          "An instance of prov:Association provides additional descriptions about the binary prov:wasAssociatedWith relation from an prov:Activity to some prov:Agent that had some responsiblity for it. For example, :baking prov:wasAssociatedWith :baker; prov:qualifiedAssociation [ a prov:Association; prov:agent :baker; :foo :bar ]."@en ;
+                  rdfs:isDefinedBy      <http://www.w3.org/ns/prov-o#> ;
+                  rdfs:label            "Association" ;
+                  rdfs:subClassOf       prov:AgentInfluence ;
+                  prov:category         "qualified" ;
+                  prov:component        "agents-responsibility" ;
+                  prov:definition       "An activity association is an assignment of responsibility to an agent for an activity, indicating that the agent had a role in the activity. It further allows for a plan to be specified, which is the plan intended by the agent to achieve some goals in the context of this activity."@en ;
+                  prov:dm               "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Association"^^xsd:anyURI ;
+                  prov:n                "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-Association"^^xsd:anyURI ;
+                  prov:unqualifiedForm  prov:wasAssociatedWith .
+
+prov:SoftwareAgent  rdf:type  owl:Class ;
+                    rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+                    rdfs:label        "SoftwareAgent" ;
+                    rdfs:subClassOf   prov:Agent ;
+                    prov:category     "expanded" ;
+                    prov:component    "agents-responsibility" ;
+                    prov:definition   "A software agent is running software."@en ;
+                    prov:dm           "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
+                    prov:n            "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types"^^xsd:anyURI .
+
+<http://www.w3.org/ns/locn.ttl>
+  rdfs:label      "Turtle version of the ISA Programme Location Core Vocabulary"@en ;
+  dcterms:format  <http://www.w3.org/ns/formats/data/Turtle> ;
+  dcat:mediaType  "text/turtle"^^dcterms:IMT .
+
+vcard:hasTitle  rdf:type  owl:ObjectProperty ;
+                rdfs:comment      "Used to support property parameters for the title data property"@en ;
+                rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                rdfs:label        "has title"@en .
+
+skos:broadMatch  rdf:type   owl:ObjectProperty , rdf:Property ;
+                 rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+                 rdfs:label          "has broader match"@en ;
+                 rdfs:subPropertyOf  skos:mappingRelation , skos:broader ;
+                 owl:inverseOf       skos:narrowMatch ;
+                 skos:definition     "skos:broadMatch is used to state a hierarchical mapping link between two conceptual resources in different concept schemes."@en .
+
+dcat:distribution  rdf:type  rdf:Property , owl:ObjectProperty ;
+                   rdfs:comment        "Connecte un jeu de données à des distributions disponibles."@fr , "Una distribución disponible del conjunto de datos."@es , "An available distribution of the dataset."@en , "En tilgængelig repræsentation af datasættet."@da , "Una distribuzione disponibile per il set di dati."@it , "تربط قائمة البيانات بطريقة أو بشكل يسمح  الوصول الى البيانات"@ar , "データセットを、その利用可能な配信に接続します。"@ja , "Συνδέει ένα σύνολο δεδομένων με μία από τις διαθέσιμες διανομές του."@el , "Dostupná distribuce datové sady."@cs ;
+                   rdfs:domain         dcat:Dataset ;
+                   rdfs:isDefinedBy    <http://www.w3.org/TR/vocab-dcat/> ;
+                   rdfs:label          "データセット配信"@ja , "distribution"@en , "distribution"@fr , "distribution"@da , "distribuzione"@it , "διανομή"@el , "توزيع"@ar , "distribución"@es , "distribuce"@cs ;
+                   rdfs:range          dcat:Distribution ;
+                   rdfs:subPropertyOf  dcterms:relation ;
+                   skos:altLabel       "har distribution"@da ;
+                   skos:definition     "Συνδέει ένα σύνολο δεδομένων με μία από τις διαθέσιμες διανομές του."@el , "Connecte un jeu de données à des distributions disponibles."@fr , "Una distribución disponible del conjunto de datos."@es , "データセットを、その利用可能な配信に接続します。"@ja , "تربط قائمة البيانات بطريقة أو بشكل يسمح  الوصول الى البيانات"@ar , "En tilgængelig repræsentation af datasættet."@da , "An available distribution of the dataset."@en , "Una distribuzione disponibile per il set di dati."@it , "Dostupná distribuce datové sady."@cs ;
+                   skos:editorialNote  "Status: English Definition text modified by DCAT revision team, translations pending (except for Italian, Spanish and Czech)."@en .
+
+rdfs:label  rdf:type      owl:AnnotationProperty ;
+            rdfs:comment      ""@en ;
+            rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> .
+
+dcat:packageFormat  rdf:type  owl:ObjectProperty , rdf:Property ;
+                    rdfs:comment        "The package format of the distribution in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together."@en , "Balíčkový formát souboru, ve kterém je jeden či více souborů seskupeno dohromady, např. aby bylo možné stáhnout sadu souvisejících souborů naráz."@cs , "Il formato di impacchettamento della distribuzione in cui uno o più file di dati sono raggruppati insieme, ad es. per abilitare un insieme di file correlati da scaricare insieme."@it , "El formato del archivo en que se agrupan uno o más archivos de datos, e.g. para permitir que un conjunto de archivos relacionados se bajen juntos."@es , "Format til pakning af data med henblik på distribution af en eller flere relaterede datafiler der samles til en enhed med henblik på samlet distribution. "@da ;
+                    rdfs:domain         dcat:Distribution ;
+                    rdfs:isDefinedBy    <https://www.w3.org/TR/vocab-dcat-2/> ;
+                    rdfs:label          "formát balíčku"@cs , "packaging format"@en , "formato di impacchettamento"@it , "pakkeformat"@da , "formato de empaquetado"@es ;
+                    rdfs:range          dcterms:MediaType ;
+                    rdfs:subPropertyOf  dcterms:format ;
+                    skos:changeNote     "Ny egenskab tilføjet i DCAT 2.0."@da , "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs , "New property added in DCAT 2.0."@en , "Nueva propiedad agregada en DCAT 2.0."@es , "Nuova proprietà aggiunta in DCAT 2.0."@it ;
+                    skos:definition     "Il formato di impacchettamento della distribuzione in cui uno o più file di dati sono raggruppati insieme, ad es. per abilitare un insieme di file correlati da scaricare insieme."@it , "The package format of the distribution in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together."@en , "El formato del archivo en que se agrupan uno o más archivos de datos, e.g. para permitir que un conjunto de archivos relacionados se bajen juntos."@es , "Balíčkový formát souboru, ve kterém je jeden či více souborů seskupeno dohromady, např. aby bylo možné stáhnout sadu souvisejících souborů naráz."@cs ;
+                    skos:scopeNote      "Questa proprietà deve essere utilizzata quando i file nella distribuzione sono impacchettati, ad esempio in un file TAR, Frictionless Data Package o Bagit. Il formato DOVREBBE essere espresso utilizzando un tipo di supporto come definito dal registro dei tipi di media IANA https://www.iana.org/assignments/media-types/, se disponibili."@it , "Esta propiedad se debe usar cuando los archivos de la distribución están empaquetados, por ejemplo en un archivo TAR, Frictionless Data Package o Bagit. El formato DEBERÍA expresarse usando un 'media type', tales como los definidos en el registro IANA de 'media types' https://www.iana.org/assignments/media-types/, si está disponibles."@es , "Denne egenskab kan anvendes hvis filerne i en distribution er pakket, fx i en TAR-fil, en Frictionless Data Package eller en Bagit-fil. Formatet BØR udtrykkes ved en medietype som defineret i 'IANA media types registry', hvis der optræder en relevant medietype dér: https://www.iana.org/assignments/media-types/."@da , "This property to be used when the files in the distribution are packaged, e.g. in a TAR file, a Frictionless Data Package or a Bagit file. The format SHOULD be expressed using a media type as defined by IANA media types registry https://www.iana.org/assignments/media-types/, if available."@en , "Tato vlastnost se použije, když jsou soubory v distribuci zabaleny, např. v souboru TAR, v balíčku Frictionless Data Package nebo v souboru Bagit. Formát BY MĚL být vyjádřen pomocí typu média definovaného v registru IANA https://www.iana.org/assignments/media-types/, pokud existuje."@cs .
+
+time:inTimePosition  rdf:type  owl:ObjectProperty ;
+                     rdfs:comment        "Posición de un instante, expresada como una coordenada temporal o un valor nominal."@es , "Position of an instant, expressed as a temporal coordinate or nominal value"@en ;
+                     rdfs:domain         time:Instant ;
+                     rdfs:label          "posición de tiempo"@es , "Time position"@en ;
+                     rdfs:range          time:TimePosition ;
+                     rdfs:subPropertyOf  time:inTemporalPosition ;
+                     skos:definition     "Position of a time instant expressed as a TimePosition"@en , "Posición de un instante, expresada como una coordenada temporal o un valor nominal."@es .
+
+spdx:fileType_other  rdf:type  owl:NamedIndividual , spdx:FileType ;
+                     rdfs:comment    "Indicates the file is not a source, archive or binary file."@en ;
+                     vs:term_status  "stable"@en .
+
+time:dayOfYear  rdf:type  owl:DatatypeProperty ;
+                rdfs:comment     "The number of the day within the year"@en , "El número de día en el año."@es ;
+                rdfs:domain      time:GeneralDateTimeDescription ;
+                rdfs:label       "day of year"@en , "día del año"@es ;
+                rdfs:range       xsd:nonNegativeInteger ;
+                skos:definition  "The number of the day within the year"@en , "El número de día en el año."@es .
+
+dcterms:audience  rdf:type   rdf:Property ;
+                  rdfs:comment         "A class of agents for whom the resource is intended or useful."@en ;
+                  rdfs:isDefinedBy     dcterms: ;
+                  rdfs:label           "Audience"@en ;
+                  dcam:rangeIncludes   dcterms:AgentClass ;
+                  dcterms:description  "Recommended practice is to use this property with non-literal values from a vocabulary of audience types."@en ;
+                  dcterms:issued       "2001-05-21"^^xsd:date .
+
+<http://spdx.org/licenses/CC0-1.0>
+  rdf:type  owl:NamedIndividual .
+
+spdx:purpose_firmware
+  rdf:type        owl:NamedIndividual , spdx:Purpose ;
+  rdfs:comment    "The package provides low level control over a device's hardware."@en ;
+  vs:term_status  "stable"@en .
+
+time:hasBeginning  rdf:type  owl:ObjectProperty ;
+                   rdfs:comment        "Beginning of a temporal entity"@en , "Comienzo de una entidad temporal."@es ;
+                   rdfs:domain         time:TemporalEntity ;
+                   rdfs:label          "has beginning"@en , "tiene principio"@es ;
+                   rdfs:range          time:Instant ;
+                   rdfs:subPropertyOf  time:hasTime ;
+                   skos:definition     "Beginning of a temporal entity."@en , "Comienzo de una entidad temporal."@es .
+
+spdx:licenseText  rdf:type  owl:DatatypeProperty ;
+                  rdfs:comment    "Full text of the license."@en ;
+                  rdfs:domain     spdx:License ;
+                  rdfs:range      xsd:string ;
+                  vs:term_status  "stable"@en .
+
+time:Saturday  rdf:type  time:DayOfWeek ;
+               rdfs:label      "Saturday"@en ;
+               skos:prefLabel  "السبت"@ar , "Sabato"@it , "土曜日"@ja , "Sábado"@es , "Sábado"@pt , "Zaterdag"@nl , "Суббота"@ru , "Sobota"@pl , "星期六"@zh , "Samedi"@fr , "Saturday"@en , "Samstag"@de .
+
+skos:topConceptOf  rdf:type  owl:ObjectProperty , rdf:Property ;
+                   rdfs:domain         skos:Concept ;
+                   rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+                   rdfs:label          "is top concept in scheme"@en ;
+                   rdfs:range          skos:ConceptScheme ;
+                   rdfs:subPropertyOf  skos:inScheme ;
+                   owl:inverseOf       skos:hasTopConcept ;
+                   skos:definition     "Relates a concept to the concept scheme that it is a top level concept of."@en .
+
+vcard:Male  rdf:type      owl:Class ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "Male"@en ;
+            rdfs:subClassOf   vcard:Gender .
+
+vcard:Colleague  rdf:type  owl:Class ;
+                 rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                 rdfs:label        "Colleague"@en ;
+                 rdfs:subClassOf   vcard:RelatedType .
+
+spdx:ExternalRef  rdf:type  owl:Class ;
+                  rdfs:comment     "An External Reference allows a Package to reference an external source of additional information, metadata, enumerations, asset identifiers, or downloadable content believed to be relevant to the Package."@en ;
+                  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                     owl:onClass               spdx:ReferenceCategory ;
+                                     owl:onProperty            spdx:referenceCategory ;
+                                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                            ] ;
+                  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                     owl:onClass               spdx:ReferenceType ;
+                                     owl:onProperty            spdx:referenceType ;
+                                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                            ] ;
+                  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                     owl:onDataRange           xsd:anyURI ;
+                                     owl:onProperty            spdx:referenceLocator ;
+                                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                            ] ;
+                  rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                     owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                     owl:onDataRange              xsd:string ;
+                                     owl:onProperty               rdfs:comment
+                            ] ;
+                  vs:term_status   "stable"@en .
+
+vcard:hasNickname  rdf:type  owl:ObjectProperty ;
+                   rdfs:comment      "Used to support property parameters for the nickname data property"@en ;
+                   rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                   rdfs:label        "has nickname"@en ;
+                   rdfs:seeAlso      vcard:nickname .
+
+spdx:url  rdf:type    owl:DatatypeProperty ;
+          rdfs:comment  "URL Reference"@en ;
+          rdfs:domain   spdx:CrossRef ;
+          rdfs:range    xsd:anyURI .
+
+prov:order  rdf:type      owl:AnnotationProperty ;
+            rdfs:comment      "The position that this OWL term should be listed within documentation. The scope of the documentation (e.g., among all terms, among terms within a prov:category, among properties applying to a particular class, etc.) is unspecified."@en ;
+            rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> .
+
+spdx:relationshipType_staticLink
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A statically links to SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:purpose_operatingSystem
+  rdf:type        owl:NamedIndividual , spdx:Purpose ;
+  rdfs:comment    "The package refers to an operating system."@en ;
+  vs:term_status  "stable"@en .
+
+time:Year  rdf:type       owl:DeprecatedClass , owl:Class ;
+           rdfs:comment      "Year duration" ;
+           rdfs:label        "Year"@en ;
+           rdfs:subClassOf   time:DurationDescription ;
+           rdfs:subClassOf   [ rdf:type         owl:Restriction ;
+                               owl:cardinality  1 ;
+                               owl:onProperty   time:years
+                          ] ;
+           rdfs:subClassOf   [ rdf:type         owl:Restriction ;
+                               owl:cardinality  0 ;
+                               owl:onProperty   time:hours
+                          ] ;
+           rdfs:subClassOf   [ rdf:type         owl:Restriction ;
+                               owl:cardinality  0 ;
+                               owl:onProperty   time:weeks
+                          ] ;
+           rdfs:subClassOf   [ rdf:type         owl:Restriction ;
+                               owl:cardinality  0 ;
+                               owl:onProperty   time:months
+                          ] ;
+           rdfs:subClassOf   [ rdf:type         owl:Restriction ;
+                               owl:cardinality  0 ;
+                               owl:onProperty   time:minutes
+                          ] ;
+           rdfs:subClassOf   [ rdf:type         owl:Restriction ;
+                               owl:cardinality  0 ;
+                               owl:onProperty   time:seconds
+                          ] ;
+           rdfs:subClassOf   [ rdf:type         owl:Restriction ;
+                               owl:cardinality  0 ;
+                               owl:onProperty   time:days
+                          ] ;
+           owl:deprecated    true ;
+           skos:definition   "Year duration" ;
+           skos:historyNote  "Year was proposed in the 2006 version of OWL-Time as an example of how DurationDescription could be specialized to allow for a duration to be restricted to a number of years. \n\nIt is deprecated in this edition of OWL-Time. " ;
+           skos:prefLabel    "Anno"@it , "سنة"@ar , "Rok"@pl , "Jaar"@nl , "Año"@es , "Jahr"@de , "Année (calendrier)"@fr , "Year"@en , "Год"@ru , "年"@ja , "年"@zh , "Ano"@pt .
+
+<http://www.w3.org/2009/pointers#CompoundPointer>
+  rdf:type         owl:Class ;
+  rdfs:subClassOf  <http://www.w3.org/2009/pointers#Pointer> ;
+  vs:term_status   "stable" .
+
+spdx:fileType_text  rdf:type  owl:NamedIndividual , spdx:FileType ;
+                    rdfs:comment    "The file is human readable text file (MIME type of text/*)."@en ;
+                    vs:term_status  "stable"@en .
+
+spdx:match  rdf:type  owl:DatatypeProperty ;
+            rdfs:comment  "Status of a License List SeeAlso URL reference if it refers to a website that matches the license text." ;
+            rdfs:domain   spdx:CrossRef ;
+            rdfs:range    xsd:string .
+
+<http://data.europa.eu/r5r#DateOrDateTimeDataType_Shape>
+  rdf:type      sh:NodeShape ;
+  rdfs:comment  "Date time date disjunction shape checks that a datatype property receives a temporal value: date, dateTime, gYear or gYearMonth literal" ;
+  rdfs:label    "Date time date disjunction" ;
+  sh:message    "The values must be data typed as either xsd:date, xsd:dateTime, xsd:gYear or xsd:gYearMonth" ;
+  sh:or         ( [ sh:datatype  xsd:date ]
+                  [ sh:datatype  xsd:dateTime ]
+                  [ sh:datatype  xsd:gYear ]
+                  [ sh:datatype  xsd:gYearMonth ]
+                ) .
+
+dcterms:accrualMethod
+  rdf:type             rdf:Property ;
+  rdfs:comment         "The method by which items are added to a collection."@en ;
+  rdfs:domain          dctype:Collection ;
+  rdfs:isDefinedBy     dcterms: ;
+  rdfs:label           "Accrual Method"@en ;
+  dcam:rangeIncludes   dcterms:MethodOfAccrual ;
+  dcterms:description  "Recommended practice is to use a value from the Collection Description Accrual Method Vocabulary [[DCMI-ACCRUALMETHOD](https://dublincore.org/groups/collections/accrual-method/)]."@en ;
+  dcterms:issued       "2005-06-13"^^xsd:date .
+
+vcard:Kin  rdf:type       owl:Class ;
+           rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label        "Kin"@en ;
+           rdfs:subClassOf   vcard:RelatedType .
+
+dcat:byteSize  rdf:type   owl:DatatypeProperty , rdf:Property ;
+               rdfs:comment      "الحجم بالبايتات "@ar , "Το μέγεθος μιας διανομής σε bytes."@el , "The size of a distribution in bytes."@en , "Velikost distribuce v bajtech."@cs , "バイトによる配信のサイズ。"@ja , "La taille de la distribution en octects"@fr , "Størrelsen af en distributionen angivet i bytes."@da , "La dimensione di una distribuzione in byte."@it , "El tamaño de una distribución en bytes."@es ;
+               rdfs:domain       dcat:Distribution ;
+               rdfs:isDefinedBy  <http://www.w3.org/TR/vocab-dcat/> ;
+               rdfs:label        "μέγεθος σε bytes"@el , "velikost v bajtech"@cs , "byte size"@en , "tamaño en bytes"@es , "dimensione in byte"@it , "الحجم بالبايت"@ar , "バイト・サイズ"@ja , "taille en octects"@fr , "bytestørrelse"@da ;
+               rdfs:range        rdfs:Literal ;
+               skos:definition   "Το μέγεθος μιας διανομής σε bytes."@el , "Størrelsen af en distribution angivet i bytes."@da , "الحجم بالبايتات "@ar , "El tamaño de una distribución en bytes."@es , "Velikost distribuce v bajtech."@cs , "La dimensione di una distribuzione in byte."@it , "The size of a distribution in bytes."@en , "La taille de la distribution en octects."@fr , "バイトによる配信のサイズ。"@ja ;
+               skos:scopeNote    "Το μέγεθος σε bytes μπορεί να προσεγγιστεί όταν η ακριβής τιμή δεν είναι γνωστή. Η τιμή της dcat:byteSize θα πρέπει να δίνεται με τύπο δεδομένων xsd:decimal."@el , "الحجم يمكن أن يكون تقريبي إذا كان الحجم الدقيق غير معروف"@ar , "Bytestørrelsen kan approximeres hvis den præcise størrelse ikke er kendt. Værdien af dcat:byteSize bør angives som xsd:decimal."@da , "Velikost v bajtech může být přibližná, pokud její přesná hodnota není známa. Literál s hodnotou dcat:byteSize by měl mít datový typ xsd:decimal."@cs , "El tamaño en bytes puede ser aproximado cuando se desconoce el tamaño exacto. El valor literal de dcat:byteSize debe tener tipo 'xsd:decimal'."@es , "正確なサイズが不明である場合、サイズは、バイトによる近似値を示すことができます。"@ja , "La taille en octects peut être approximative lorsque l'on ignore la taille réelle. La valeur littérale de dcat:byteSize doit être de type xsd:decimal."@fr , "The size in bytes can be approximated when the precise size is not known. The literal value of dcat:byteSize should by typed as xsd:decimal."@en , "La dimensione in byte può essere approssimata quando non si conosce la dimensione precisa. Il valore di dcat:byteSize dovrebbe essere espresso come un xsd:decimal."@it .
+
+locn:fullAddress  rdf:type  rdf:Property ;
+                  rdfs:comment        "The complete address written as a string, with or without formatting. The domain of locn:fullAddress is locn:Address."@en ;
+                  rdfs:domain         locn:Address ;
+                  rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+                  rdfs:label          "full address"@en ;
+                  rdfs:range          rdfs:Literal ;
+                  dcterms:identifier  "locn:fullAddress" ;
+                  vs:term_status      "testing"@en .
+
+time:xsdDateTime  rdf:type  owl:DeprecatedProperty , owl:DatatypeProperty ;
+                  rdfs:comment    "Valor de 'intervalo de fecha-hora' expresado como un valor compacto."@es , "Value of DateTimeInterval expressed as a compact value."@en ;
+                  rdfs:domain     time:DateTimeInterval ;
+                  rdfs:label      "has XSD date-time"@en , "tiene fecha-hora XSD"@es ;
+                  rdfs:range      xsd:dateTime ;
+                  owl:deprecated  true ;
+                  skos:note       "Utilizando xsd:dateTime en este lugar significa que la duración del intervalo está implícita: se corresponde con la longitud del elemento más pequeño distinto de cero del literal fecha-hora. Sin embargo, esta regla no se puede utilizar para intervalos cuya duración es mayor que un rango más pequeño que el tiempo de comienzo - p.ej. el primer minuto o segundo del día, la primera hora del mes, o el primer día del año. En estos casos el intervalo deseado no se puede distinguir del intervalo correspondiente al próximo rango más alto. Debido a esta ambigüedad esencial, no se recomienda el uso de esta propiedad y está desaprobada." , "Using xsd:dateTime in this place means that the duration of the interval is implicit: it corresponds to the length of the smallest non-zero element of the date-time literal. However, this rule cannot be used for intervals whose duration is more than one rank smaller than the starting time - e.g. the first minute or second of a day, the first hour of a month, or the first day of a year. In these cases the desired interval cannot be distinguished from the interval corresponding to the next rank up. Because of this essential ambiguity, use of this property is not recommended and it is deprecated."@en .
+
+vcard:hasGivenName  rdf:type  owl:ObjectProperty ;
+                    rdfs:comment      "Used to support property parameters for the given name data property"@en ;
+                    rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                    rdfs:label        "has given name"@en .
+
+spdx:relationshipType_dependsOn
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A depends on SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+dcat:theme  rdf:type        rdf:Property , owl:ObjectProperty ;
+            rdfs:comment        "La categoria principale della risorsa. Una risorsa può avere più temi."@it , "Hlavní téma zdroje. Zdroj může mít více témat."@cs , "La categoría principal del recurso. Un recurso puede tener varios temas."@es , "A main category of the resource. A resource can have multiple themes."@en , "التصنيف الرئيسي لقائمة البيانات. قائمة البيانات يمكن أن تملك أكثر من تصنيف رئيسي واحد."@ar , "Et centralt emne for ressourcen. En ressource kan have flere centrale emner."@da , "La catégorie principale de la ressource. Une ressource peut avoir plusieurs thèmes."@fr , "データセットの主要カテゴリー。データセットは複数のテーマを持つことができます。"@ja , "Η κύρια κατηγορία του συνόλου δεδομένων. Ένα σύνολο δεδομένων δύναται να έχει πολλαπλά θέματα."@el ;
+            rdfs:isDefinedBy    <http://www.w3.org/TR/vocab-dcat/> ;
+            rdfs:label          "emne"@da , "Θέμα"@el , "theme"@en , "tema"@es , "tema"@it , "テーマ/カテゴリー"@ja , "téma"@cs , "التصنيف"@ar , "thème"@fr ;
+            rdfs:range          skos:Concept ;
+            rdfs:subPropertyOf  dcterms:subject ;
+            skos:altLabel       "tema"@da ;
+            skos:definition     "Hlavní téma zdroje. Zdroj může mít více témat."@cs , "La catégorie principale de la ressource. Une ressource peut avoir plusieurs thèmes."@fr , "La categoría principal del recurso. Un recurso puede tener varios temas."@es , "Η κύρια κατηγορία του συνόλου δεδομένων. Ένα σύνολο δεδομένων δύναται να έχει πολλαπλά θέματα."@el , "La categoria principale della risorsa. Una risorsa può avere più temi."@it , "データセットの主要カテゴリー。データセットは複数のテーマを持つことができます。"@ja , "A main category of the resource. A resource can have multiple themes."@en , "Et centralt emne for ressourcen. En ressource kan have flere centrale emner."@da , "التصنيف الرئيسي لقائمة البيانات. قائمة البيانات يمكن أن تملك أكثر من تصنيف رئيسي واحد."@ar ;
+            skos:editorialNote  "Status: English Definition text modified by DCAT revision team, all except for Italian and Czech translations are pending."@en ;
+            skos:scopeNote      "El conjunto de skos:Concepts utilizados para categorizar los recursos están organizados en un skos:ConceptScheme que describe todas las categorías y sus relaciones en el catálogo."@es , "データセットを分類するために用いられるskos:Conceptの集合は、カタログのすべてのカテゴリーとそれらの関係を記述しているskos:ConceptSchemeで組織化されます。"@ja , "Sada instancí třídy skos:Concept použitá pro kategorizaci zdrojů je organizována do schématu konceptů skos:ConceptScheme, které popisuje všechny kategorie v katalogu a jejich vztahy."@cs , "Il set di concetti skos usati per categorizzare le risorse sono organizzati in skos:ConceptScheme che descrive tutte le categorie e le loro relazioni nel catalogo."@it , "Samlingen af begreber (skos:Concept) der anvendes til at emneinddele ressourcer organiseres i et begrebssystem (skos:ConceptScheme) som beskriver alle emnerne og deres relationer i kataloget."@da , "Un ensemble de skos:Concepts utilisés pour catégoriser les ressources sont organisés en un skos:ConceptScheme décrivant toutes les catégories et ses relations dans le catalogue."@fr , "The set of skos:Concepts used to categorize the resources are organized in a skos:ConceptScheme describing all the categories and their relations in the catalog."@en , "Το σετ των skos:Concepts που χρησιμοποιείται για να κατηγοριοποιήσει τα σύνολα δεδομένων είναι οργανωμένο εντός ενός skos:ConceptScheme που περιγράφει όλες τις κατηγορίες και τις σχέσεις αυτών στον κατάλογο."@el .
+
+time:TemporalUnit  rdf:type  owl:Class ;
+                   rdfs:comment     "A standard duration, which provides a scale factor for a time extent, or the granularity or precision for a time position."@en , "Una duración estándar, que proporciona un factor de escala para una extensión de tiempo, o la granularidad o precisión para una posición de tiempo."@es ;
+                   rdfs:label       "unidad de tiempo"@es , "Temporal unit"@en ;
+                   rdfs:subClassOf  time:TemporalDuration ;
+                   skos:changeNote  "Remove enumeration from definition, in order to allow other units to be used when required in other coordinate systems. \nNOTE: existing units are still present as members of the class, but the class membership is now open. \n\nIn the original OWL-Time the following constraint appeared: \n  owl:oneOf (\n      time:unitSecond\n      time:unitMinute\n      time:unitHour\n      time:unitDay\n      time:unitWeek\n      time:unitMonth\n      time:unitYear\n    ) ;"@en ;
+                   skos:definition  "Una duración estándar, que proporciona un factor de escala para una extensión de tiempo, o la granularidad o precisión para una posición de tiempo."@es , "A standard duration, which provides a scale factor for a time extent, or the granularity or precision for a time position."@en ;
+                   skos:note        "La pertenencia de la clase 'unidad de tiempo' está abierta, para permitir otras unidades de tiempo utilizadas en algunas aplicaciones técnicas (por ejemplo, millones de años o el mes Baha'i)."@es , "Membership of the class TemporalUnit is open, to allow for other temporal units used in some technical applications (e.g. millions of years, Baha'i month)."@en .
+
+skos:relatedMatch  rdf:type  owl:ObjectProperty , owl:SymmetricProperty , rdf:Property ;
+                   rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+                   rdfs:label          "has related match"@en ;
+                   rdfs:subPropertyOf  skos:mappingRelation , skos:related ;
+                   skos:definition     "skos:relatedMatch is used to state an associative mapping link between two conceptual resources in different concept schemes."@en .
+
+dcterms:abstract  rdf:type  rdf:Property ;
+                  rdfs:comment        "A summary of the resource."@en ;
+                  rdfs:isDefinedBy    dcterms: ;
+                  rdfs:label          "Abstract"@en ;
+                  rdfs:subPropertyOf  dc:description , dcterms:description ;
+                  dcterms:issued      "2000-07-11"^^xsd:date .
+
+dcat:dataset  rdf:type      rdf:Property , owl:ObjectProperty ;
+              rdfs:comment        "Kolekce dat, která je katalogizována v katalogu."@cs , "Una raccolta di dati che è elencata nel catalogo."@it , "تربط الفهرس بقائمة بيانات ضمنه"@ar , "Un conjunto de datos que se lista en el catálogo."@es , "En samling af data som er opført i kataloget."@da , "A collection of data that is listed in the catalog."@en , "カタログの一部であるデータセット。"@ja , "Relie un catalogue à un jeu de données faisant partie de ce catalogue."@fr , "Συνδέει έναν κατάλογο με ένα σύνολο δεδομένων το οποίο ανήκει στον εν λόγω κατάλογο."@el ;
+              rdfs:domain         dcat:Catalog ;
+              rdfs:isDefinedBy    <http://www.w3.org/TR/vocab-dcat/> ;
+              rdfs:label          "σύνολο δεδομένων"@el , "قائمة بيانات"@ar , "conjunto de datos"@es , "datová sada"@cs , "dataset"@en , "dataset"@it , "jeu de données"@fr , "データセット"@ja , "datasæt"@da ;
+              rdfs:range          dcat:Dataset ;
+              rdfs:subPropertyOf  rdfs:member , dcterms:hasPart ;
+              skos:altLabel       "har datasæt"@da , "datasamling"@da ;
+              skos:definition     "Συνδέει έναν κατάλογο με ένα σύνολο δεδομένων το οποίο ανήκει στον εν λόγω κατάλογο."@el , "カタログの一部であるデータセット。"@ja , "Kolekce dat, která je katalogizována v katalogu."@cs , "Relie un catalogue à un jeu de données faisant partie de ce catalogue."@fr , "Una raccolta di dati che è elencata nel catalogo."@it , "A collection of data that is listed in the catalog."@en , "تربط الفهرس بقائمة بيانات ضمنه"@ar , "En samling af data som er opført i kataloget."@da , "Un conjunto de datos que se lista en el catálogo."@es ;
+              skos:editorialNote  "Status: English Definition text modified by DCAT revision team, Italian, Spanish and Czech translation provided, other translations pending."@en .
+
+spdx:CreationInfo  rdf:type  owl:Class ;
+                   rdfs:comment     "One instance is required for each SPDX file produced. It provides the necessary information for forward and backward compatibility for processing tools."@en ;
+                   rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                      owl:minQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                      owl:onDataRange              xsd:string ;
+                                      owl:onProperty               spdx:creator
+                             ] ;
+                   rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                      owl:onDataRange           xsd:dateTimeStamp ;
+                                      owl:onProperty            spdx:created ;
+                                      owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                             ] ;
+                   rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                      owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                      owl:onDataRange              xsd:string ;
+                                      owl:onProperty               spdx:licenseListVersion
+                             ] ;
+                   rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                      owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                      owl:onDataRange              xsd:string ;
+                                      owl:onProperty               rdfs:comment
+                             ] ;
+                   vs:term_status   "stable"@en .
+
+spdx:isFsfLibre  rdf:type  owl:DatatypeProperty ;
+                 rdfs:domain  spdx:License ;
+                 rdfs:range   xsd:boolean .
+
+spdx:referenceCategory_other
+  rdf:type        owl:NamedIndividual , spdx:ReferenceCategory ;
+  vs:term_status  "stable"@en .
+
+spdx:relationshipType_describes
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-DOCUMENT describes SPDXRef-A."@en ;
+  vs:term_status  "stable" .
+
+vcard:Video  rdf:type     owl:Class ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "Video"@en ;
+             rdfs:subClassOf   vcard:TelephoneType .
+
+dcterms:format  rdf:type     rdf:Property ;
+                rdfs:comment         "The file format, physical medium, or dimensions of the resource."@en ;
+                rdfs:isDefinedBy     dcterms: ;
+                rdfs:label           "Format"@en ;
+                rdfs:subPropertyOf   dc:format ;
+                dcam:rangeIncludes   dcterms:Extent , dcterms:MediaType ;
+                dcterms:description  "Recommended practice is to use a controlled vocabulary where available. For example, for file formats one could use the list of Internet Media Types [[MIME](https://www.iana.org/assignments/media-types/media-types.xhtml)].  Examples of dimensions include size and duration."@en ;
+                dcterms:issued       "2008-01-14"^^xsd:date .
+
+vcard:Type  rdf:type      owl:Class ;
+            rdfs:comment      "Used for type codes. The URI of the type code must be used as the value for Type."@en ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "Type"@en .
+
+locn:addressId  rdf:type    rdf:Property ;
+                rdfs:comment        "The concept of adding a globally unique identifier for each instance of an address is a crucial part of the INSPIRE data spec. The domain of locn:addressId is locn:Address."@en ;
+                rdfs:domain         locn:Address ;
+                rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+                rdfs:label          "address ID"@en ;
+                rdfs:range          rdfs:Literal ;
+                dcterms:identifier  "locn:addressId" ;
+                vs:term_status      "unstable"@en .
+
+spdx:name  rdf:type     owl:DatatypeProperty ;
+           rdfs:comment    "Identify name of this SpdxElement."@en ;
+           rdfs:domain     spdx:SpdxElement ;
+           rdfs:range      xsd:string ;
+           vs:term_status  "stable"@en .
+
+spdx:purpose_library  rdf:type  owl:NamedIndividual , spdx:Purpose ;
+                      rdfs:comment    "The package is a software library."@en ;
+                      vs:term_status  "stable"@en .
+
+prov:wasInvalidatedBy
+  rdf:type                owl:ObjectProperty ;
+  rdfs:domain             prov:Entity ;
+  rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label              "wasInvalidatedBy" ;
+  rdfs:range              prov:Activity ;
+  rdfs:subPropertyOf      prov:wasInfluencedBy ;
+  owl:propertyChainAxiom  ( prov:qualifiedInvalidation prov:activity ) ;
+  owl:propertyChainAxiom  ( prov:qualifiedInvalidation prov:activity ) ;
+  prov:category           "expanded" ;
+  prov:component          "entities-activities" ;
+  prov:inverse            "invalidated" ;
+  prov:qualifiedForm      prov:qualifiedInvalidation , prov:Invalidation .
+
+time:months  rdf:type    owl:DatatypeProperty ;
+             rdfs:comment     "length of, or element of the length of, a temporal extent expressed in months"@en , "Longitud de, o elemento de la longitud de, una extensión temporal expresada en meses."@es ;
+             rdfs:domain      time:GeneralDurationDescription ;
+             rdfs:label       "months duration"@en , "duración en meses"@es ;
+             rdfs:range       xsd:decimal ;
+             skos:definition  "length of, or element of the length of, a temporal extent expressed in months"@en , "Longitud de, o elemento de la longitud de, una extensión temporal expresada en meses."@es .
+
+dcterms:subject  rdf:type    rdf:Property ;
+                 rdfs:comment         "A topic of the resource."@en ;
+                 rdfs:isDefinedBy     dcterms: ;
+                 rdfs:label           "Subject"@en ;
+                 rdfs:subPropertyOf   dc:subject ;
+                 dcterms:description  "Recommended practice is to refer to the subject with a URI. If this is not possible or feasible, a literal value that identifies the subject may be provided. Both should preferably refer to a subject in a controlled vocabulary."@en ;
+                 dcterms:issued       "2008-01-14"^^xsd:date .
+
+dcterms:SizeOrDuration
+  rdf:type             rdfs:Class ;
+  rdfs:comment         "A dimension or extent, or a time taken to play or execute."@en ;
+  rdfs:isDefinedBy     dcterms: ;
+  rdfs:label           "Size or Duration"@en ;
+  rdfs:subClassOf      dcterms:MediaTypeOrExtent ;
+  dcterms:description  "Examples include a number of pages, a specification of length, width, and breadth, or a period in hours, minutes, and seconds."@en ;
+  dcterms:issued       "2008-01-14"^^xsd:date .
+
+dcterms:LocationPeriodOrJurisdiction
+  rdf:type          rdfs:Class ;
+  rdfs:comment      "A location, period of time, or jurisdiction."@en ;
+  rdfs:isDefinedBy  dcterms: ;
+  rdfs:label        "Location, Period, or Jurisdiction"@en ;
+  dcterms:issued    "2008-01-14"^^xsd:date .
+
+spdx:releaseDate  rdf:type  owl:DatatypeProperty ;
+                  rdfs:comment        "This field provides a place for recording the date the package was released."@en ;
+                  rdfs:domain         spdx:Package ;
+                  rdfs:range          xsd:dateTime ;
+                  rdfs:subPropertyOf  spdx:date ;
+                  vs:term_status      "stable"@en .
+
+time:Monday  rdf:type   time:DayOfWeek ;
+             rdfs:label      "Monday"@en ;
+             skos:prefLabel  "Monday"@en , "Lunes"@es , "Lundi"@fr , "Montag"@de , "الاثنين"@ar , "月曜日"@ja , "Lunedì"@it , "Понедельник"@ru , "Maandag"@nl , "Poniedziałek"@pl , "星期一"@zh , "Segunda-feira"@pt .
+
+vcard:postal-code  rdf:type  owl:DatatypeProperty ;
+                   rdfs:comment      "The postal code associated with the address of the object"@en ;
+                   rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                   rdfs:label        "postal code"@en ;
+                   rdfs:range        xsd:string .
+
+spdx:licenseConcluded
+  rdf:type        owl:ObjectProperty , owl:FunctionalProperty ;
+  rdfs:comment    "The licensing that the preparer of this SPDX document has concluded, based on the evidence, actually applies to the SPDX Item.\n\nIf the licenseConcluded field is not present for an SPDX Item, it implies an equivalent meaning to NOASSERTION."@en ;
+  rdfs:domain     spdx:SpdxItem ;
+  rdfs:range      [ rdf:type     owl:Class ;
+                    owl:unionOf  ( spdx:AnyLicenseInfo
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:noassertion ;
+                                     owl:onProperty  spdx:licenseConcluded
+                                   ]
+                                   [ rdf:type        owl:Restriction ;
+                                     owl:hasValue    spdx:none ;
+                                     owl:onProperty  spdx:licenseConcluded
+                                   ]
+                                 )
+                  ] ;
+  vs:term_status  "stable"@en .
+
+dcat:Relationship  rdf:type  owl:Class ;
+                   rdfs:comment     "Una clase de asociación para adjuntar información adicional a una relación entre recursos DCAT."@es , "Asociační třída pro připojení dodatečných informací ke vztahu mezi zdroji DCAT."@cs , "An association class for attaching additional information to a relationship between DCAT Resources."@en , "En associationsklasse til brug for tilknytning af yderligere information til en relation mellem DCAT-ressourcer."@da , "Una classe di associazione per il collegamento di informazioni aggiuntive a una relazione tra le risorse DCAT."@it ;
+                   rdfs:label       "Relazione"@it , "Relation"@da , "Vztah"@cs , "Relación"@es , "Relationship"@en ;
+                   skos:changeNote  "Nueva clase añadida en DCAT 2.0."@es , "Nuova classe aggiunta in DCAT 2.0."@it , "Nová třída přidaná ve verzi DCAT 2.0."@cs , "New class added in DCAT 2.0."@en , "Ny klasse i DCAT 2.0."@da ;
+                   skos:definition  "An association class for attaching additional information to a relationship between DCAT Resources."@en , "Una classe di associazione per il collegamento di informazioni aggiuntive a una relazione tra le risorse DCAT."@it , "En associationsklasse til brug for tilknytning af yderligere information til en relation mellem DCAT-ressourcer."@da , "Asociační třída pro připojení dodatečných informací ke vztahu mezi zdroji DCAT."@cs , "Una clase de asociación para adjuntar información adicional a una relación entre recursos DCAT."@es ;
+                   skos:scopeNote   "Se usa para caracterizar la relación entre conjuntos de datos, y potencialmente otros recursos, donde la naturaleza de la relación se conoce pero no está caracterizada adecuadamente con propiedades del estándar 'Dublin Core' (dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy) or PROV-O properties (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf)."@es , "Use to characterize a relationship between datasets, and potentially other resources, where the nature of the relationship is known but is not adequately characterized by the standard Dublin Core properties (dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy) or PROV-O properties (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf)."@en , "Anvendes til at karakterisere en relation mellem datasæt, og potentielt andre ressourcer, hvor relationen er kendt men ikke tilstrækkeligt beskrevet af de standardiserede egenskaber i Dublin Core (dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy) eller PROV-O-egenskaber (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf)."@da , "Používá se pro charakterizaci vztahu mezi datovými sadami a případně i jinými zdroji, kde druh vztahu je sice znám, ale není přiměřeně charakterizován standardními vlastnostmi slovníku Dublin Core (dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy) či vlastnostmi slovníku PROV-O (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf)."@cs , "Viene utilizzato per caratterizzare la relazione tra insiemi di dati, e potenzialmente altri tipi di risorse, nei casi in cui la natura della relazione è nota ma non adeguatamente caratterizzata dalle proprietà dello standard 'Dublin Core' (dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:require, dct:isRequiredBy) o dalle propietà fornite da PROV-O  (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov: hadPrimarySource, prov:alternateOf, prov:specializationOf)."@it .
+
+prov:qualifiedAssociation
+  rdf:type                   owl:ObjectProperty ;
+  rdfs:comment               "If this Activity prov:wasAssociatedWith Agent :ag, then it can qualify the Association using prov:qualifiedAssociation [ a prov:Association;  prov:agent :ag; :foo :bar ]."@en ;
+  rdfs:domain                prov:Activity ;
+  rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label                 "qualifiedAssociation" ;
+  rdfs:range                 prov:Association ;
+  rdfs:subPropertyOf         prov:qualifiedInfluence ;
+  prov:category              "qualified" ;
+  prov:component             "agents-responsibility" ;
+  prov:inverse               "qualifiedAssociationOf" ;
+  prov:sharesDefinitionWith  prov:Association ;
+  prov:unqualifiedForm       prov:wasAssociatedWith .
+
+dcterms:accrualPolicy
+  rdf:type             rdf:Property ;
+  rdfs:comment         "The policy governing the addition of items to a collection."@en ;
+  rdfs:domain          dctype:Collection ;
+  rdfs:isDefinedBy     dcterms: ;
+  rdfs:label           "Accrual Policy"@en ;
+  dcam:rangeIncludes   dcterms:Policy ;
+  dcterms:description  "Recommended practice is to use a value from the Collection Description Accrual Policy Vocabulary [[DCMI-ACCRUALPOLICY](https://dublincore.org/groups/collections/accrual-policy/)]."@en ;
+  dcterms:issued       "2005-06-13"^^xsd:date .
+
+spdx:checksumAlgorithm_md2
+  rdf:type        owl:NamedIndividual , spdx:ChecksumAlgorithm ;
+  rdfs:comment    "Indicates the algorithm used was MD2" ;
+  vs:term_status  "stable" .
+
+spdx:externalDocumentId
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "externalDocumentId is a string containing letters, numbers, ., - and/or + which uniquely identifies an external document within this document."@en ;
+  rdfs:domain     spdx:ExternalDocumentRef ;
+  rdfs:range      xsd:anyURI ;
+  vs:term_status  "stable"@en .
+
+vcard:BBS  rdf:type       owl:Class ;
+           rdfs:comment      "This class is deprecated"@en ;
+           rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label        "BBS"@en ;
+           rdfs:subClassOf   vcard:TelephoneType ;
+           owl:deprecated    true .
+
+spdx:sourceInfo  rdf:type  owl:DatatypeProperty ;
+                 rdfs:comment    "Allows the producer(s) of the SPDX document to describe how the package was acquired and/or changed from the original source."@en ;
+                 rdfs:domain     spdx:Package ;
+                 rdfs:range      xsd:string ;
+                 vs:term_status  "stable"@en .
+
+vcard:Home  rdf:type      owl:Class ;
+            rdfs:comment      "This implies that the property is related to an individual's personal life"@en ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "Home"@en ;
+            rdfs:subClassOf   vcard:Type .
+
+adms:schemeAgency  rdf:type     owl:DatatypeProperty ;
+                   rdfs:comment            "The name of the agency that issued the identifier."@en , "This property is deprecated because in in HTML specification another URI was used." ;
+                   rdfs:domain             adms:Identifier ;
+                   rdfs:isDefinedBy        <http://www.w3.org/ns/adms> ;
+                   rdfs:label              "schema agency"@en ;
+                   rdfs:range              rdfs:Literal ;
+                   dcterms:isReplacedBy    adms:schemaAgency ;
+                   owl:deprecated          "true" ;
+                   owl:equivalentProperty  adms:schemaAgency .
+
+spdx:relationshipType_hasPrerequisite
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A has as a prerequisite SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+<http://data.europa.eu/r5r#CategoryScheme_Shape>
+  rdf:type        sh:NodeShape ;
+  sh:name         "Category Scheme"@en ;
+  sh:property     [ sh:minCount  1 ;
+                    sh:nodeKind  sh:Literal ;
+                    sh:path      dcterms:title ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:targetClass  skos:ConceptScheme .
+
+dcterms:Period  rdf:type  rdfs:Datatype ;
+                rdfs:comment      "The set of time intervals defined by their limits according to the DCMI Period Encoding Scheme."@en ;
+                rdfs:isDefinedBy  dcterms: ;
+                rdfs:label        "DCMI Period"@en ;
+                rdfs:seeAlso      <https://www.dublincore.org/specifications/dublin-core/dcmi-period/> ;
+                dcterms:issued    "2000-07-11"^^xsd:date .
+
+vcard:hasHonorificPrefix
+  rdf:type          owl:ObjectProperty ;
+  rdfs:comment      "Used to support property parameters for the honorific prefix data property"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "has honorific prefix"@en .
+
+dcterms:MESH  rdf:type    dcam:VocabularyEncodingScheme ;
+              rdfs:comment      "The set of labeled concepts specified by the Medical Subject Headings."@en ;
+              rdfs:isDefinedBy  dcterms: ;
+              rdfs:label        "MeSH"@en ;
+              rdfs:seeAlso      <http://www.nlm.nih.gov/mesh/meshhome.html> ;
+              dcterms:issued    "2000-07-11"^^xsd:date .
+
+prov:Attribution  rdf:type    owl:Class ;
+                  rdfs:comment          "An instance of prov:Attribution provides additional descriptions about the binary prov:wasAttributedTo relation from an prov:Entity to some prov:Agent that had some responsible for it. For example, :cake prov:wasAttributedTo :baker; prov:qualifiedAttribution [ a prov:Attribution; prov:entity :baker; :foo :bar ]."@en ;
+                  rdfs:isDefinedBy      <http://www.w3.org/ns/prov-o#> ;
+                  rdfs:label            "Attribution" ;
+                  rdfs:subClassOf       prov:AgentInfluence ;
+                  prov:category         "qualified" ;
+                  prov:component        "agents-responsibility" ;
+                  prov:constraints      "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+                  prov:definition       "Attribution is the ascribing of an entity to an agent.\n\nWhen an entity e is attributed to agent ag, entity e was generated by some unspecified activity that in turn was associated to agent ag. Thus, this relation is useful when the activity is not known, or irrelevant."@en ;
+                  prov:dm               "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-attribution"^^xsd:anyURI ;
+                  prov:n                "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-attribution"^^xsd:anyURI ;
+                  prov:unqualifiedForm  prov:wasAttributedTo .
+
+vcard:hasStreetAddress
+  rdf:type          owl:ObjectProperty ;
+  rdfs:comment      "Used to support property parameters for the street address data property"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "has street address"@en .
+
+time:numericDuration  rdf:type  owl:DatatypeProperty ;
+                      rdfs:comment     "Value of a temporal extent expressed as a decimal number scaled by a temporal unit"@en , "Valor de una extensión temporal expresada como un número decimal escalado por una unidad de tiempo."@es ;
+                      rdfs:domain      time:Duration ;
+                      rdfs:label       "Numeric value of temporal duration"@en , "valor numérico de duración temporal"@es ;
+                      rdfs:range       xsd:decimal ;
+                      skos:definition  "Value of a temporal extent expressed as a decimal number scaled by a temporal unit"@en , "Valor de una extensión temporal expresada como un número decimal escalado por una unidad de tiempo."@es .
+
+prov:hadUsage  rdf:type            owl:ObjectProperty ;
+               rdfs:comment               "The _optional_ Usage involved in an Entity's Derivation."@en ;
+               rdfs:domain                prov:Derivation ;
+               rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+               rdfs:label                 "hadUsage" ;
+               rdfs:range                 prov:Usage ;
+               prov:category              "qualified" ;
+               prov:component             "derivations" ;
+               prov:inverse               "wasUsedInDerivation" ;
+               prov:sharesDefinitionWith  prov:Usage .
+
+vcard:hasPhoto  rdf:type        owl:ObjectProperty ;
+                rdfs:comment            "To specify an image or photograph information that annotates some aspect of the object"@en ;
+                rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+                rdfs:label              "has photo"@en ;
+                owl:equivalentProperty  vcard:photo .
+
+adms:prev  rdf:type         owl:ObjectProperty ;
+           rdfs:comment        "A link to the previous version of the Asset."@en ;
+           rdfs:domain         rdfs:Resource ;
+           rdfs:isDefinedBy    <http://www.w3.org/ns/adms> ;
+           rdfs:label          "prev"@en ;
+           rdfs:range          rdfs:Resource ;
+           rdfs:subPropertyOf  <http://www.w3.org/1999/xhtml/vocab#prev> .
+
+spdx:fileContributor  rdf:type  owl:DatatypeProperty ;
+                      rdfs:comment    "This field provides a place for the SPDX file creator to record file contributors. Contributors could include names of copyright holders and/or authors who may not be copyright holders yet contributed to the file content."@en ;
+                      rdfs:domain     spdx:File ;
+                      rdfs:range      xsd:string ;
+                      vs:term_status  "stable"@en .
+
+spdx:fileType_source  rdf:type  owl:NamedIndividual , spdx:FileType ;
+                      rdfs:comment    "Indicates the file is a source code file."@en ;
+                      vs:term_status  "stable"@en .
+
+time:TimePosition  rdf:type  owl:Class ;
+                   rdfs:comment     "A temporal position described using either a (nominal) value from an ordinal reference system, or a (numeric) value in a temporal coordinate system. "@en , "Una posición temporal descrita utilizando bien un valor (nominal) de un sistema de referencia ordinal, o un valor (numérico) en un sistema de coordenadas temporales."@es ;
+                   rdfs:label       "Time position"@en , "posición de tiempo"@es ;
+                   rdfs:subClassOf  time:TemporalPosition ;
+                   rdfs:subClassOf  [ rdf:type     owl:Class ;
+                                      owl:unionOf  ( [ rdf:type         owl:Restriction ;
+                                                       owl:cardinality  "1"^^xsd:nonNegativeInteger ;
+                                                       owl:onProperty   time:numericPosition
+                                                     ]
+                                                     [ rdf:type         owl:Restriction ;
+                                                       owl:cardinality  "1"^^xsd:nonNegativeInteger ;
+                                                       owl:onProperty   time:nominalPosition
+                                                     ]
+                                                   )
+                             ] ;
+                   skos:definition  "A temporal position described using either a (nominal) value from an ordinal reference system, or a (numeric) value in a temporal coordinate system. "@en , "Una posición temporal descrita utilizando bien un valor (nominal) de un sistema de referencia ordinal, o un valor (numérico) en un sistema de coordenadas temporales."@es .
+
+time:intervalMetBy  rdf:type  owl:ObjectProperty ;
+                    rdfs:comment     "Si un intervalo propio T1 es 'intervalo encontrado por' otro intervalo propio T2, entonces el principio de T1 coincide con el final de T2."@es , "If a proper interval T1 is intervalMetBy another proper interval T2, then the beginning of T1 is coincident with the end of T2."@en ;
+                    rdfs:domain      time:ProperInterval ;
+                    rdfs:label       "intervalo encontrado por"@es , "interval met by"@en ;
+                    rdfs:range       time:ProperInterval ;
+                    owl:inverseOf    time:intervalMeets ;
+                    skos:definition  "If a proper interval T1 is intervalMetBy another proper interval T2, then the beginning of T1 is coincident with the end of T2."@en , "Si un intervalo propio T1 es 'intervalo encontrado por' otro intervalo propio T2, entonces el principio de T1 coincide con el final de T2."@es .
+
+vcard:hasCategory  rdf:type  owl:ObjectProperty ;
+                   rdfs:comment      "Used to support property parameters for the category data property"@en ;
+                   rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                   rdfs:label        "has category"@en .
+
+time:inXSDgYear  rdf:type  owl:DatatypeProperty ;
+                 rdfs:comment     "Position of an instant, expressed using xsd:gYear"@en , "Posición de un instante, expresado utilizando xsd:gYear."@es ;
+                 rdfs:domain      time:Instant ;
+                 rdfs:label       "in XSD g-Year"@en , "en año gregoriano XSD"@es ;
+                 rdfs:range       xsd:gYear ;
+                 skos:definition  "Position of an instant, expressed using xsd:gYear"@en , "Posición de un instante, expresado utilizando xsd:gYear."@es .
+
+<http://data.europa.eu/r5r#Distribution_Shape>
+  rdf:type        sh:NodeShape ;
+  sh:name         "Distribution"@en ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      adms:status ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcterms:license ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcatap:availability ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      odrl:hasPolicy ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:datatype  xsd:decimal ;
+                    sh:maxCount  1 ;
+                    sh:path      dcat:spatialResolutionInMeters ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcterms:rights ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:node      <http://data.europa.eu/r5r#DateOrDateTimeDataType_Shape> ;
+                    sh:path      dcterms:modified ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:language ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      foaf:page ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcterms:format ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:minCount  1 ;
+                    sh:nodeKind  sh:BlankNodeOrIRI ;
+                    sh:path      dcat:accessURL ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:nodeKind  sh:Literal ;
+                    sh:path      dcterms:title ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:node      <http://data.europa.eu/r5r#DateOrDateTimeDataType_Shape> ;
+                    sh:path      dcterms:issued ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcat:packageFormat ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:datatype  xsd:decimal ;
+                    sh:maxCount  1 ;
+                    sh:path      dcat:byteSize ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcat:mediaType ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:nodeKind  sh:BlankNodeOrIRI ;
+                    sh:path      dcat:downloadURL ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      spdx:checksum ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcat:compressFormat ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:nodeKind  sh:Literal ;
+                    sh:path      dcterms:description ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:conformsTo ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:datatype  xsd:duration ;
+                    sh:maxCount  1 ;
+                    sh:path      dcat:temporalResolution ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcat:accessService ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:targetClass  dcat:Distribution .
+
+<http://data.europa.eu/r5r#DataService_Shape>
+  rdf:type        sh:NodeShape ;
+  sh:name         "Data Service"@en ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcterms:accessRights ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:nodeKind  sh:BlankNodeOrIRI ;
+                    sh:path      dcat:endpointDescription ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcat:servesDataset ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:nodeKind  sh:Literal ;
+                    sh:path      dcterms:description ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:minCount  1 ;
+                    sh:nodeKind  sh:Literal ;
+                    sh:path      dcterms:title ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:minCount  1 ;
+                    sh:nodeKind  sh:BlankNodeOrIRI ;
+                    sh:path      dcat:endpointURL ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcterms:license ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:targetClass  dcat:DataService .
+
+vcard:VCard  rdf:type        owl:Class ;
+             rdfs:comment         "The vCard class is  equivalent to the new Kind class, which is the parent for the four explicit types of vCards (Individual, Organization, Location, Group)"@en ;
+             rdfs:isDefinedBy     <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label           "VCard"@en ;
+             owl:equivalentClass  vcard:Kind .
+
+prov:InstantaneousEvent
+  rdf:type          owl:Class ;
+  rdfs:comment      "An instantaneous event, or event for short, happens in the world and marks a change in the world, in its activities and in its entities. The term 'event' is commonly used in process algebra with a similar meaning. Events represent communications or interactions; they are assumed to be atomic and instantaneous."@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+  rdfs:label        "InstantaneousEvent" ;
+  prov:category     "qualified" ;
+  prov:component    "entities-activities" ;
+  prov:constraints  "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#dfn-event"^^xsd:anyURI ;
+  prov:definition   "The PROV data model is implicitly based on a notion of instantaneous events (or just events), that mark transitions in the world. Events include generation, usage, or invalidation of entities, as well as starting or ending of activities. This notion of event is not first-class in the data model, but it is useful for explaining its other concepts and its semantics."@en .
+
+prov:startedAtTime  rdf:type  owl:DatatypeProperty ;
+                    rdfs:comment        "The time at which an activity started. See also prov:endedAtTime."@en ;
+                    rdfs:domain         prov:Activity ;
+                    rdfs:isDefinedBy    <http://www.w3.org/ns/prov-o#> ;
+                    rdfs:label          "startedAtTime" ;
+                    rdfs:range          xsd:dateTime ;
+                    prov:category       "starting-point" ;
+                    prov:component      "entities-activities" ;
+                    prov:editorialNote  "It is the intent that the property chain holds: (prov:qualifiedStart o prov:atTime) rdfs:subPropertyOf prov:startedAtTime."@en ;
+                    prov:qualifiedForm  prov:Start , prov:atTime .
+
+dcterms:isFormatOf  rdf:type  rdf:Property ;
+                    rdfs:comment         "A pre-existing related resource that is substantially the same as the described resource, but in another format."@en ;
+                    rdfs:isDefinedBy     dcterms: ;
+                    rdfs:label           "Is Format Of"@en ;
+                    rdfs:subPropertyOf   dc:relation , dcterms:relation ;
+                    dcterms:description  "This property is intended to be used with non-literal values. This property is an inverse property of Has Format."@en ;
+                    dcterms:issued       "2000-07-11"^^xsd:date .
+
+spdx:referenceLocator
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "The unique string with no spaces necessary to access the package-specific information, metadata, or content within the target location. The format of the locator is subject to constraints defined by the <type>."@en ;
+  rdfs:domain     spdx:ExternalRef ;
+  rdfs:range      xsd:anyURI ;
+  vs:term_status  "stable"@en .
+
+prov:Organization  rdf:type  owl:Class ;
+                   rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+                   rdfs:label        "Organization" ;
+                   rdfs:subClassOf   prov:Agent ;
+                   prov:category     "expanded" ;
+                   prov:component    "agents-responsibility" ;
+                   prov:definition   "An organization is a social or legal institution such as a company, society, etc." ;
+                   prov:dm           "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-agent"^^xsd:anyURI ;
+                   prov:n            "http://www.w3.org/TR/2013/REC-prov-n-20130430/#expression-types"^^xsd:anyURI .
+
+vcard:hasCountryName  rdf:type  owl:ObjectProperty ;
+                      rdfs:comment      "Used to support property parameters for the country name data property"@en ;
+                      rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                      rdfs:label        "has country name"@en .
+
+spdx:externalDocumentRef
+  rdf:type        owl:ObjectProperty ;
+  rdfs:comment    "Identify any external SPDX documents referenced within this SPDX document."@en ;
+  rdfs:domain     spdx:SpdxDocument ;
+  rdfs:range      spdx:ExternalDocumentRef ;
+  vs:term_status  "stable"@en .
+
+dcterms:Jurisdiction  rdf:type  rdfs:Class ;
+                      rdfs:comment      "The extent or range of judicial, law enforcement, or other authority."@en ;
+                      rdfs:isDefinedBy  dcterms: ;
+                      rdfs:label        "Jurisdiction"@en ;
+                      rdfs:subClassOf   dcterms:LocationPeriodOrJurisdiction ;
+                      dcterms:issued    "2008-01-14"^^xsd:date .
+
+vcard:ISDN  rdf:type      owl:Class ;
+            rdfs:comment      "This class is deprecated"@en ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "ISDN"@en ;
+            rdfs:subClassOf   vcard:Type ;
+            owl:deprecated    true .
+
+<http://www.w3.org/ns/adms>
+  rdf:type          owl:Ontology ;
+  rdfs:label        "adms"@en , "adms"@nl ;
+  dcterms:issued    "2023-04-05" ;
+  dcterms:license   <https://creativecommons.org/licenses/by/4.0/> ;
+  dcterms:mediator  [ foaf:homepage  <https://semic.eu> ;
+                      foaf:name      "Semantic Interoperability Community (SEMIC)"
+                    ] ;
+  rec:editor        [ rdf:type         foaf:Person ;
+                      foaf:firstName   "Bert" ;
+                      foaf:lastName    "Van Nuffelen" ;
+                      foaf:mbox        <mailto:bert.van.nuffelen@tenforce.com> ;
+                      j.0:affiliation  [ foaf:name  "TenForce" ]
+                    ] ;
+  rec:editor        [ rdf:type         foaf:Person ;
+                      foaf:firstName   "Pavlina" ;
+                      foaf:lastName    "Fragkou" ;
+                      j.0:affiliation  [ foaf:name  "SEMIC EU" ]
+                    ] ;
+  rec:editor        [ rdf:type        foaf:Person ;
+                      foaf:firstName  "Natasa" ;
+                      foaf:lastName   "Sofou"
+                    ] ;
+  rec:editor        [ rdf:type        foaf:Person ;
+                      foaf:firstName  "Makx" ;
+                      foaf:lastName   "Dekkers"
+                    ] ;
+  foaf:maker        [ rdf:type         foaf:Person ;
+                      foaf:firstName   "Pavlina" ;
+                      foaf:lastName    "Fragkou" ;
+                      j.0:affiliation  [ foaf:name  "SEMIC EU" ]
+                    ] .
+
+time:TemporalDuration
+  rdf:type         owl:Class ;
+  rdfs:comment     "Time extent; duration of a time interval separate from its particular start position"@en , "Extensión de tiempo; duración de un intervalo de tiempo independiente de su posición de inicio particular."@es ;
+  rdfs:label       "Temporal duration"@en , "duración temporal"@es ;
+  skos:definition  "Time extent; duration of a time interval separate from its particular start position"@en , "Extensión de tiempo; duración de un intervalo de tiempo independiente de su posición de inicio particular."@es .
+
+vcard:Gender  rdf:type    owl:Class ;
+              rdfs:comment      "Used for gender codes. The URI of the gender code must be used as the value for Gender."@en ;
+              rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+              rdfs:label        "Gender"@en .
+
+adms:representationTechnique
+  rdf:type          owl:ObjectProperty ;
+  rdfs:comment      "More information about the format in which an Asset Distribution is released. This is different from the file format as, for example, a ZIP file (file format) could contain an XML schema (representation technique)."@en ;
+  rdfs:domain       rdfs:Resource ;
+  rdfs:isDefinedBy  <http://www.w3.org/ns/adms> ;
+  rdfs:label        "representation technique"@en ;
+  rdfs:range        skos:Concept .
+
+vcard:Coworker  rdf:type  owl:Class ;
+                rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                rdfs:label        "Coworker"@en ;
+                rdfs:subClassOf   vcard:RelatedType .
+
+locn:geometry  rdf:type     rdf:Property ;
+               rdfs:comment        "Associates any resource with the corresponding geometry."@en ;
+               rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+               rdfs:label          "geometry"@en ;
+               rdfs:range          locn:Geometry ;
+               dcterms:identifier  "locn:geometry" ;
+               vann:example        "\nThe following are examples of equivalent statements using different geometry encodings. In the examples, prefix gsp is used for namespace URI http://www.opengis.net/ont/geosparql#, whereas prefix sf is used for namespace URI http://www.opengis.net/ont/sf#.\n- WKT (GeoSPARQL)\n:Resource locn:geometry\n  \"<http://www.opengis.net/def/crs/OGC/1.3/CRS84> Point(-0.001475 51.477811)\"^^gsp:wktLiteral .\n- GML\n:Resource locn:geometry\n  \"<gml:Point srsName='http://www.opengis.net/def/crs/OGC/1.3/CRS84'>\n  <gml:coordinates>-0.001475, 51.477811</gml:coordinates></gml:Point>\"^^gsp:gmlLiteral .\n- RDF+WKT (GeoSPARQL)\n:Resource locn:geometry\n  [ a sf:Point; gsp:asWKT \"<http://www.opengis.net/def/crs/OGC/1.3/CRS84> Point(-0.001475 51.477811)\"^^gsp:wktLiteral ] .\n- RDF+GML (GeoSPARQL)\n:Resource locn:geometry\n  [ a sf:Point; gsp:asGML\n     \"<gml:Point srsName='http://www.opengis.net/def/crs/OGC/1.3/CRS84'>\n      <gml:coordinates>-0.001475, 51.477811</gml:coordinates></gml:Point>\"^^gsp:gmlLiteral ] .\n- RDF (WGS84 lat/long)\n:Resource locn:geometry [ a geo:Point; geo:lat \"51.477811\"; geo:long \"-0.001475\" ] .\n- RDF (schema.org)\n:Resource locn:geometry [ a schema:GeoCoordinates; schema:latitude \"51.477811\"; schema:longitude \"-0.001475\" ] .\n- geo URI\n:Resource locn:geometry <geo:51.477811,-0.001475;u=0;crs=wgs84> .\n- GeoHash URI\n:Resource locn:geometry <http://geohash.org/gcpuzgnzvxkp> .\n    "@en ;
+               vann:usageNote      "\nDepending on how a geometry is encoded, the range of this property may be one of the following:\n- a literal (e.g., WKT - string literal -, GML, KML - XML literal)\n- a geometry class, as those defined in the OGC's GeoSPARQL specification, in the W3C's Basic Geo (WGS84 lat/long) vocabulary, and at schema.org;\n- geocoded URIs, as geo or GeoHash URIs, treated as URI references.\nFor interoperability reasons, it is recommended using one of the following:\n- Any geometry:\n  - WKT, GML, and RDF+WKT/GML, as per the GeoSPARQL specification.\n  - KML (Keyhole Markup Language) - note that KML supports the following geometries only: point, line string, linear ring, and polygon.\n  - RDF as per the schema.org vocabulary (see classes schema:GeoCoordinates and schema:GeoShape).\n- Points: one of the above, or:\n  - RDF as per the W3C Basic Geo (WGS84 lat/long) vocabulary.\n  - GeoHash URIs.\n  - geo URIs.\n    "@en ;
+               vs:term_status      "testing"@en ;
+               wdsr:describedby    <https://joinup.ec.europa.eu/node/55858> .
+
+time:intervalStarts  rdf:type  owl:ObjectProperty ;
+                     rdfs:comment        "Si un intervalo propio T1 empieza otro intervalo propio T2, entonces del principio de T1 con el principio de T2, y el final de T1 es anterior al final de T2."@es , "If a proper interval T1 is intervalStarts another proper interval T2, then the beginning of T1 is coincident with the beginning of T2, and the end of T1 is before the end of T2."@en ;
+                     rdfs:domain         time:ProperInterval ;
+                     rdfs:label          "interval starts"@en , "intervalo empieza"@es ;
+                     rdfs:range          time:ProperInterval ;
+                     rdfs:subPropertyOf  time:intervalIn ;
+                     owl:inverseOf       time:intervalStartedBy ;
+                     skos:definition     "If a proper interval T1 is intervalStarts another proper interval T2, then the beginning of T1 is coincident with the beginning of T2, and the end of T1 is before the end of T2."@en , "Si un intervalo propio T1 empieza otro intervalo propio T2, entonces del principio de T1 con el final de T2, y el final de T1 es anterior al final de T2."@es .
+
+vcard:Pager  rdf:type     owl:Class ;
+             rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label        "Pager"@en ;
+             rdfs:subClassOf   vcard:TelephoneType .
+
+<http://data.europa.eu/r5r#PeriodOfTime_Shape>
+  rdf:type        sh:NodeShape ;
+  sh:name         "PeriodOfTime"@en ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:node      <http://data.europa.eu/r5r#DateOrDateTimeDataType_Shape> ;
+                    sh:path      dcat:startDate ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      time:hasEnd ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      time:hasBeginning ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:node      <http://data.europa.eu/r5r#DateOrDateTimeDataType_Shape> ;
+                    sh:path      dcat:endDate ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:targetClass  dcterms:PeriodOfTime .
+
+spdx:relationshipType_devToolOf
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A is a development dependency of SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+vcard:hasLocality  rdf:type  owl:ObjectProperty ;
+                   rdfs:comment      "Used to support property parameters for the locality data property"@en ;
+                   rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                   rdfs:label        "has locality"@en .
+
+<http://www.w3.org/2004/02/skos/core>
+  rdf:type             owl:Ontology ;
+  rdfs:seeAlso         <http://www.w3.org/TR/skos-reference/> ;
+  dcterms:contributor  "Dave Beckett" , "Nikki Rogers" , "Participants in W3C's Semantic Web Deployment Working Group." ;
+  dcterms:creator      "Alistair Miles" , "Sean Bechhofer" ;
+  dcterms:description  "An RDF vocabulary for describing the basic structure and content of concept schemes such as thesauri, classification schemes, subject heading lists, taxonomies, 'folksonomies', other types of controlled vocabulary, and also concept schemes embedded in glossaries and terminologies."@en ;
+  dcterms:title        "SKOS Vocabulary"@en .
+
+dcterms:Point  rdf:type   rdfs:Datatype ;
+               rdfs:comment      "The set of points in space defined by their geographic coordinates according to the DCMI Point Encoding Scheme."@en ;
+               rdfs:isDefinedBy  dcterms: ;
+               rdfs:label        "DCMI Point"@en ;
+               rdfs:seeAlso      <https://www.dublincore.org/specifications/dublin-core/dcmi-point/> ;
+               dcterms:issued    "2000-07-11"^^xsd:date .
+
+vcard:photo  rdf:type           owl:ObjectProperty ;
+             rdfs:comment            "This object property has been mapped"@en ;
+             rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+             rdfs:label              "photo"@en ;
+             owl:equivalentProperty  vcard:hasPhoto .
+
+<http://www.w3.org/ns/locn.html>
+  rdfs:label      "HTML version of the ISA Programme Location Core Vocabulary"@en ;
+  dcat:mediaType  "text/html"^^dcterms:IMT .
+
+vcard:additional-name
+  rdf:type          owl:DatatypeProperty ;
+  rdfs:comment      "The additional name associated with the object"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "additional name"@en ;
+  rdfs:range        xsd:string .
+
+spdx:licenseInfoInFile
+  rdf:type            owl:ObjectProperty ;
+  rdfs:comment        "Licensing information that was discovered directly in the subject file. This is also considered a declared license for the file.\n\nIf the licenseInfoInFile field is not present for a file, it implies an equivalent meaning to NOASSERTION."@en ;
+  rdfs:domain         spdx:File ;
+  rdfs:range          [ rdf:type     owl:Class ;
+                        owl:unionOf  ( spdx:AnyLicenseInfo
+                                       [ rdf:type        owl:Restriction ;
+                                         owl:hasValue    spdx:noassertion ;
+                                         owl:onProperty  spdx:licenseInfoInFile
+                                       ]
+                                       [ rdf:type        owl:Restriction ;
+                                         owl:hasValue    spdx:none ;
+                                         owl:onProperty  spdx:licenseInfoInFile
+                                       ]
+                                     )
+                      ] ;
+  rdfs:subPropertyOf  spdx:licenseInfoFromFiles ;
+  vs:term_status      "stable" .
+
+vcard:Friend  rdf:type    owl:Class ;
+              rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+              rdfs:label        "Friend"@en ;
+              rdfs:subClassOf   vcard:RelatedType .
+
+prov:hadPlan  rdf:type             owl:ObjectProperty ;
+              rdfs:comment               "The _optional_ Plan adopted by an Agent in Association with some Activity. Plan specifications are out of the scope of this specification."@en ;
+              rdfs:domain                prov:Association ;
+              rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+              rdfs:label                 "hadPlan" ;
+              rdfs:range                 prov:Plan ;
+              prov:category              "qualified" ;
+              prov:component             "agents-responsibility" ;
+              prov:inverse               "wasPlanOf" ;
+              prov:sharesDefinitionWith  prov:Plan .
+
+spdx:LicenseException
+  rdf:type         owl:Class ;
+  rdfs:comment     "An exception to a license."@en ;
+  rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                     owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                     owl:onDataRange              xsd:anyURI ;
+                     owl:onProperty               rdfs:seeAlso
+                   ] ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onDataRange           xsd:string ;
+                     owl:onProperty            rdfs:comment ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onDataRange           xsd:string ;
+                     owl:onProperty            spdx:name ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                     owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onDataRange              xsd:string ;
+                     owl:onProperty               spdx:example
+                   ] ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onDataRange           xsd:string ;
+                     owl:onProperty            spdx:licenseExceptionId ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                     owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                     owl:onDataRange              xsd:string ;
+                     owl:onProperty               spdx:licenseExceptionTemplate
+                   ] ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onDataRange           xsd:string ;
+                     owl:onProperty            spdx:licenseExceptionText ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  vs:term_status   "stable"@en .
+
+<https://joinup.ec.europa.eu/category/licence/isa-open-metadata-licence-v11>
+  cc:attributionName  "European Commission"@en ;
+  cc:attributionURL   <http://ec.europa.eu/> ;
+  dcterms:title       "ISA Open Metadata Licence v1.1" .
+
+time:inside  rdf:type    owl:ObjectProperty ;
+             rdfs:comment     "An instant that falls inside the interval. It is not intended to include beginnings and ends of intervals."@en , "Un instante que cae dentro del intervalo. Se asume que no es ni el principio ni el final de ningún intervalo."@es ;
+             rdfs:domain      time:Interval ;
+             rdfs:label       "has time instant inside"@en , "tiene instante de tiempo dentro"@es ;
+             rdfs:range       time:Instant ;
+             skos:definition  "An instant that falls inside the interval. It is not intended to include beginnings and ends of intervals."@en , "Un instante que cae dentro del intervalo. Se asume que no es ni el principio ni el final de ningún intervalo."@es .
+
+prov:atTime  rdf:type              owl:DatatypeProperty ;
+             rdfs:comment               "The time at which an InstantaneousEvent occurred, in the form of xsd:dateTime."@en ;
+             rdfs:domain                prov:InstantaneousEvent ;
+             rdfs:isDefinedBy           <http://www.w3.org/ns/prov-o#> ;
+             rdfs:label                 "atTime" ;
+             rdfs:range                 xsd:dateTime ;
+             prov:category              "qualified" ;
+             prov:component             "entities-activities" ;
+             prov:sharesDefinitionWith  prov:InstantaneousEvent ;
+             prov:unqualifiedForm       prov:invalidatedAtTime , prov:startedAtTime , prov:generatedAtTime , prov:endedAtTime .
+
+prov:actedOnBehalfOf  rdf:type  owl:ObjectProperty ;
+                      rdfs:comment            "An object property to express the accountability of an agent towards another agent. The subordinate agent acted on behalf of the responsible agent in an actual activity. "@en ;
+                      rdfs:domain             prov:Agent ;
+                      rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+                      rdfs:label              "actedOnBehalfOf" ;
+                      rdfs:range              prov:Agent ;
+                      rdfs:subPropertyOf      prov:wasInfluencedBy ;
+                      owl:propertyChainAxiom  ( prov:qualifiedDelegation prov:agent ) ;
+                      owl:propertyChainAxiom  ( prov:qualifiedDelegation prov:agent ) ;
+                      prov:category           "starting-point" ;
+                      prov:component          "agents-responsibility" ;
+                      prov:inverse            "hadDelegate" ;
+                      prov:qualifiedForm      prov:qualifiedDelegation , prov:Delegation .
+
+<http://www.w3.org/2009/pointers#LineCharPointer>
+  rdf:type         owl:Class ;
+  rdfs:subClassOf  <http://www.w3.org/2009/pointers#OffsetPointer> ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onDataRange           xsd:positiveInteger ;
+                     owl:onProperty            <http://www.w3.org/2009/pointers#lineNumber> ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  vs:term_status   "stable" .
+
+dcat:startDate  rdf:type  rdf:Property , owl:DatatypeProperty ;
+                rdfs:domain      dcterms:PeriodOfTime ;
+                rdfs:label       "data di inizio"@it , "datum začátku"@cs , "start date"@en , "startdato"@da ;
+                rdfs:range       rdfs:Literal ;
+                skos:altLabel    "starttidspunkt"@da ;
+                skos:changeNote  "Nová vlastnost přidaná ve verzi DCAT 2.0."@cs , "New property added in DCAT 2.0."@en , "Ny egenskab tilføjet i DCAT 2.0."@da , "Nuova proprietà aggiunta in DCAT 2.0."@it , "Nueva propiedad agregada en DCAT 2.0."@es ;
+                skos:definition  "El comienzo del período"@es , "Začátek doby trvání"@cs , "The start of the period"@en , "Start på perioden."@da , "L'inizio del periodo"@it ;
+                skos:scopeNote   "Rækkeviden for denne egenskab er bevidst generisk defineret med det formål at tillade forskellige niveauer af tidslig præcision ifm. angivelse af startdatoen for en periode. Den kan eksempelvis udtrykkes som en dato (xsd:date), en dato og et tidspunkt (xsd:dateTime), eller et årstal (xsd:gYear)."@da , "The range of this property is intentionally generic, with the purpose of allowing different level of temporal precision for specifying the start of a period. E.g., it can be expressed with a date (xsd:date), a date and time (xsd:dateTime), or a year (xsd:gYear)."@en , "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé úrovně časového rozlišení pro specifikaci začátku doby trvání. Ten může být kupříkladu vyjádřen datumem (xsd:date), datumem a časem (xsd:dateTime) či rokem (xsd:gYear)."@cs , "Il range di questa proprietà è volutamente generico, con lo scopo di consentire diversi livelli di precisione temporale per specificare l'inizio di un periodo. Ad esempio, può essere espresso con una data (xsd:date), una data e un'ora (xsd:dateTime), o un anno (xsd:gYear)."@it , "El rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintos niveles de precisión temporal para especificar el comienzo de un período. Por ejemplo, puede expresarse como una fecha (xsd:date), una fecha y un tiempo (xsd:dateTime), o un año (xsd:gYear)."@es .
+
+spdx:checksum  rdf:type  owl:ObjectProperty ;
+               rdfs:comment    "The checksum property provides a mechanism that can be used to verify that the contents of a File or Package have not changed."@en ;
+               rdfs:domain     [ rdf:type     owl:Class ;
+                                 owl:unionOf  ( spdx:File spdx:Package )
+                         ] ;
+               rdfs:range      spdx:Checksum ;
+               vs:term_status  "stable"@en .
+
+<http://www.w3.org/2009/pointers#SinglePointer>
+  rdf:type         owl:Class ;
+  rdfs:subClassOf  <http://www.w3.org/2009/pointers#Pointer> ;
+  rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                     owl:onClass               spdx:File ;
+                     owl:onProperty            <http://www.w3.org/2009/pointers#reference> ;
+                     owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                   ] ;
+  vs:term_status   "stable" .
+
+dcterms:requires  rdf:type   rdf:Property ;
+                  rdfs:comment         "A related resource that is required by the described resource to support its function, delivery, or coherence."@en ;
+                  rdfs:isDefinedBy     dcterms: ;
+                  rdfs:label           "Requires"@en ;
+                  rdfs:subPropertyOf   dc:relation , dcterms:relation ;
+                  dcterms:description  "This property is intended to be used with non-literal values. This property is an inverse property of Is Required By."@en ;
+                  dcterms:issued       "2000-07-11"^^xsd:date .
+
+spdx:packageVerificationCodeExcludedFile
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "A file that was excluded when calculating the package verification code. This is usually a file containing SPDX data regarding the package. If a package contains more than one SPDX file all SPDX files must be excluded from the package verification code. If this is not done it would be impossible to correctly calculate the verification codes in both files."@en ;
+  rdfs:domain     spdx:PackageVerificationCode ;
+  rdfs:range      xsd:string ;
+  vs:term_status  "stable"@en .
+
+skos:closeMatch  rdf:type   owl:ObjectProperty , owl:SymmetricProperty , rdf:Property ;
+                 rdfs:isDefinedBy    <http://www.w3.org/2004/02/skos/core> ;
+                 rdfs:label          "has close match"@en ;
+                 rdfs:subPropertyOf  skos:mappingRelation ;
+                 skos:definition     "skos:closeMatch is used to link two concepts that are sufficiently similar that they can be used interchangeably in some information retrieval applications. In order to avoid the possibility of \"compound errors\" when combining mappings across more than two concept schemes, skos:closeMatch is not declared to be a transitive property."@en .
+
+spdx:fileType_archive
+  rdf:type        owl:NamedIndividual , spdx:FileType ;
+  rdfs:comment    "Indicates the file is an archive file."@en ;
+  vs:term_status  "stable"@en .
+
+locn:poBox  rdf:type        rdf:Property ;
+            rdfs:comment        "The Post Office Box number. The domain of locn:poBox is locn:Address."@en ;
+            rdfs:domain         locn:Address ;
+            rdfs:isDefinedBy    <http://www.w3.org/ns/locn> ;
+            rdfs:label          "PO box"@en ;
+            rdfs:range          rdfs:Literal ;
+            dcterms:identifier  "locn:poBox" ;
+            vs:term_status      "testing"@en .
+
+dcterms:Frequency  rdf:type  rdfs:Class ;
+                   rdfs:comment      "A rate at which something recurs."@en ;
+                   rdfs:isDefinedBy  dcterms: ;
+                   rdfs:label        "Frequency"@en ;
+                   dcterms:issued    "2008-01-14"^^xsd:date .
+
+<http://data.europa.eu/r5r#Catalog_Shape>
+  rdf:type        sh:NodeShape ;
+  sh:name         "Catalog"@en ;
+  sh:property     [ sh:minCount  1 ;
+                    sh:nodeKind  sh:Literal ;
+                    sh:path      dcterms:description ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:language ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:hasPart ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcterms:isPartOf ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:node      <http://data.europa.eu/r5r#DateOrDateTimeDataType_Shape> ;
+                    sh:path      dcterms:modified ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcterms:license ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:minCount  1 ;
+                    sh:path      dcterms:publisher ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      foaf:homepage ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:node      <http://data.europa.eu/r5r#DateOrDateTimeDataType_Shape> ;
+                    sh:path      dcterms:issued ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcterms:rights ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcat:record ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:spatial ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcat:themeTaxonomy ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcat:service ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:minCount  1 ;
+                    sh:nodeKind  sh:Literal ;
+                    sh:path      dcterms:title ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcat:catalog ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcat:dataset ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:creator ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:targetClass  dcat:Catalog .
+
+adms:next  rdf:type         owl:ObjectProperty ;
+           rdfs:comment        "A link to the next version of the Asset."@en ;
+           rdfs:domain         rdfs:Resource ;
+           rdfs:isDefinedBy    <http://www.w3.org/ns/adms> ;
+           rdfs:label          "next"@en ;
+           rdfs:range          rdfs:Resource ;
+           rdfs:subPropertyOf  <http://www.w3.org/1999/xhtml/vocab#next> .
+
+spdx:referencesFile  rdf:type  owl:ObjectProperty ;
+                     rdfs:comment    "Indicates that a particular file belongs as part of the set of analyzed files in the SpdxDocument."@en , "This property has been replaced by a relationship between the SPDX document and file with a \"contains\" relationship type."@en ;
+                     rdfs:domain     spdx:SpdxDocument ;
+                     rdfs:range      spdx:File ;
+                     owl:deprecated  true ;
+                     vs:term_status  "deprecated"@en .
+
+owl:versionInfo  rdf:type  owl:AnnotationProperty .
+
+[ rdf:type               owl:Axiom ;
+  rdfs:comment           "Quotation is a particular case of derivation (see http://www.w3.org/TR/prov-dm/#term-quotation) in which an entity is derived from an original entity by copying, or \"quoting\", some or all of it. " ;
+  owl:annotatedProperty  rdfs:subPropertyOf ;
+  owl:annotatedSource    prov:wasQuotedFrom ;
+  owl:annotatedTarget    prov:wasDerivedFrom
+] .
+
+vcard:honorific-prefix
+  rdf:type          owl:DatatypeProperty ;
+  rdfs:comment      "The honorific prefix of the name associated with the object"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "honorific prefix"@en ;
+  rdfs:range        xsd:string .
+
+time:MonthOfYear  rdf:type  owl:Class ;
+                  rdfs:comment        "El mes del año."@es , "The month of the year"@en ;
+                  rdfs:label          "Month of year"@en , "mes del año"@es ;
+                  rdfs:subClassOf     time:DateTimeDescription ;
+                  rdfs:subClassOf     [ rdf:type         owl:Restriction ;
+                                        owl:cardinality  "0"^^xsd:nonNegativeInteger ;
+                                        owl:onProperty   time:second
+                            ] ;
+                  rdfs:subClassOf     [ rdf:type         owl:Restriction ;
+                                        owl:cardinality  "0"^^xsd:nonNegativeInteger ;
+                                        owl:onProperty   time:hour
+                            ] ;
+                  rdfs:subClassOf     [ rdf:type         owl:Restriction ;
+                                        owl:cardinality  "1"^^xsd:nonNegativeInteger ;
+                                        owl:onProperty   time:month
+                            ] ;
+                  rdfs:subClassOf     [ rdf:type        owl:Restriction ;
+                                        owl:hasValue    time:unitMonth ;
+                                        owl:onProperty  time:unitType
+                            ] ;
+                  rdfs:subClassOf     [ rdf:type         owl:Restriction ;
+                                        owl:cardinality  "0"^^xsd:nonNegativeInteger ;
+                                        owl:onProperty   time:week
+                            ] ;
+                  rdfs:subClassOf     [ rdf:type         owl:Restriction ;
+                                        owl:cardinality  "0"^^xsd:nonNegativeInteger ;
+                                        owl:onProperty   time:year
+                            ] ;
+                  rdfs:subClassOf     [ rdf:type         owl:Restriction ;
+                                        owl:cardinality  "0"^^xsd:nonNegativeInteger ;
+                                        owl:onProperty   time:day
+                            ] ;
+                  rdfs:subClassOf     [ rdf:type         owl:Restriction ;
+                                        owl:cardinality  "0"^^xsd:nonNegativeInteger ;
+                                        owl:onProperty   time:minute
+                            ] ;
+                  skos:definition     "The month of the year"@en , "El mes del año."@es ;
+                  skos:editorialNote  "Característica en riesgo - añadida en la revisión de 2017, y no utilizada todavía de forma amplia."@es , "Feature at risk - added in 2017 revision, and not yet widely used. "@en ;
+                  skos:note           "Membership of the class :MonthOfYear is open, to allow for alternative annual calendars and different month names."@en , "La pertenencia a la clase 'mes del año' está abierta, a permitir calendarios anuales alternativos y diferentes nombres de meses."@es .
+
+vcard:Emergency  rdf:type  owl:Class ;
+                 rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                 rdfs:label        "Emergency"@en ;
+                 rdfs:subClassOf   vcard:RelatedType .
+
+vcard:hasHonorificSuffix
+  rdf:type          owl:ObjectProperty ;
+  rdfs:comment      "Used to support property parameters for the honorific suffix data property"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "has honorific suffix"@en .
+
+dcat:Resource  rdf:type  owl:Class ;
+               rdfs:comment     "Ressource udgivet eller udvalgt og arrangeret af en enkelt aktør."@da , "Recurso publicado o curado por un agente único."@es , "Risorsa pubblicata o curata da un singolo agente."@it , "Resource published or curated by a single agent."@en , "Zdroj publikovaný či řízený jediným činitelem."@cs ;
+               rdfs:label       "Katalogizovaný zdroj"@cs , "Recurso catalogado"@es , "Risorsa catalogata"@it , "Katalogiseret ressource"@da , "Catalogued resource"@en ;
+               skos:changeNote  "New class added in DCAT 2.0."@en , "Nuova classe aggiunta in DCAT 2.0."@it , "Ny klasse i DCAT 2.0."@da , "Nová třída přidaná ve verzi DCAT 2.0."@cs , "Nueva clase agregada en DCAT 2.0."@es ;
+               skos:definition  "Resource published or curated by a single agent."@en , "Risorsa pubblicata o curata da un singolo agente."@it , "Ressource udgivet eller udvalgt og arrangeret af en enkelt aktør."@da , "Recurso publicado o curado por un agente único."@es , "Zdroj publikovaný či řízený jediným činitelem."@cs ;
+               skos:scopeNote   "dcat:Resource es un punto de extensión que permite la definición de cualquier tipo de catálogo. Se pueden definir subclases adicionales en perfil de DCAT o una aplicación para catálogos de otro tipo de recursos."@es , "dcat:Resource je bod pro rozšíření umožňující definici různých druhů katalogů. Další podtřídy lze definovat v profilech DCAT či aplikacích pro katalogy zdrojů jiných druhů."@cs , "Třída všech katalogizovaných zdrojů, nadtřída dcat:Dataset, dcat:DataService, dcat:Catalog a všech ostatních členů dcat:Catalog. Tato třída nese vlastnosti společné všem katalogizovaným zdrojům včetně datových sad a datových služeb. Je silně doporučeno používat specifičtější podtřídy, pokud je to možné. Při popisu zdroje, který není ani dcat:Dataset, ani dcat:DataService se doporučuje vytvořit odpovídající podtřídu dcat:Resrouce a nebo použít dcat:Resource s vlastností dct:type pro určení konkrétního typu."@cs , "Klassen for alle katalogiserede ressourcer, den overordnede klasse for dcat:Dataset, dcat:DataService, dcat:Catalog og enhvert medlem af et dcat:Catalog. Denne klasse bærer egenskaber der gælder alle katalogiserede ressourcer, herunder dataset og datatjenester. Det anbefales kraftigt at mere specifikke subklasser oprettes. Når der beskrives ressourcer der ikke er dcat:Dataset eller dcat:DataService, anbefales det at oprette passende subklasser af dcat:Resource eller at dcat:Resource anvendes sammen med egenskaben dct:type til opmærkning med en specifik typeangivelse."@da , "dcat:Resource è un punto di estensione che consente la definizione di qualsiasi tipo di catalogo. Sottoclassi aggiuntive possono essere definite in un profilo DCAT o in un'applicazione per cataloghi di altri tipi di risorse."@it , "La classe di tutte le risorse catalogate, la Superclasse di dcat:Dataset, dcat:DataService, dcat:Catalog e qualsiasi altro membro di dcat:Catalog. Questa classe porta proprietà comuni a tutte le risorse catalogate, inclusi set di dati e servizi dati. Si raccomanda vivamente di utilizzare una sottoclasse più specifica. Quando si descrive una risorsa che non è un dcat:Dataset o dcat:DataService, si raccomanda di creare una sottoclasse di dcat:Resource appropriata, o utilizzare dcat:Resource con la proprietà dct:type per indicare il tipo specifico."@it , "The class of all catalogued resources, the Superclass of dcat:Dataset, dcat:DataService, dcat:Catalog and any other member of a dcat:Catalog. This class carries properties common to all catalogued resources, including datasets and data services. It is strongly recommended to use a more specific sub-class. When describing a resource which is not a dcat:Dataset or dcat:DataService, it is recommended to create a suitable sub-class of dcat:Resource, or use dcat:Resource with the dct:type property to indicate the specific type."@en , "La clase de todos los recursos catalogados, la superclase de dcat:Dataset, dcat:DataService, dcat:Catalog y cualquier otro miembro de un dcat:Catalog. Esta clase tiene propiedades comunes a todos los recursos catalogados, incluyendo conjuntos de datos y servicios de datos. Se recomienda fuertemente que se use una clase más específica. Cuando se describe un recurso que no es un dcat:Dataset o dcat:DataService, se recomienda crear una sub-clase apropiada de dcat:Resource, o usar dcat:Resource con la propiedad dct:type to indicar el tipo específico."@es , "dcat:Resource is an extension point that enables the definition of any kind of catalog. Additional subclasses may be defined in a DCAT profile or application for catalogs of other kinds of resources."@en , "dcat:Resource er et udvidelsespunkt der tillader oprettelsen af enhver type af kataloger. Yderligere subklasser kan defineres i en DCAT-profil eller i en applikation til kataloger med andre typer af ressourcer."@da .
+
+prov:EmptyCollection  rdf:type  owl:Class , owl:NamedIndividual ;
+                      rdfs:isDefinedBy  <http://www.w3.org/ns/prov-o#> ;
+                      rdfs:label        "EmptyCollection"@en ;
+                      rdfs:subClassOf   prov:Collection ;
+                      prov:category     "expanded" ;
+                      prov:component    "collections" ;
+                      prov:definition   "An empty collection is a collection without members."@en .
+
+spdx:summary  rdf:type  owl:DatatypeProperty ;
+              rdfs:comment    "Provides a short description of the package."@en ;
+              rdfs:domain     spdx:Package ;
+              rdfs:range      xsd:string ;
+              vs:term_status  "stable"@en .
+
+spdx:downloadLocation
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "The URI at which this package is available for download. Private (i.e., not publicly reachable) URIs are acceptable as values of this property. The values http://spdx.org/rdf/terms#none and http://spdx.org/rdf/terms#noassertion may be used to specify that the package is not downloadable or that no attempt was made to determine its download location, respectively."@en ;
+  rdfs:domain     spdx:Package ;
+  rdfs:range      xsd:anyURI ;
+  vs:term_status  "stable"@en .
+
+spdx:purpose_archive  rdf:type  owl:NamedIndividual , spdx:Purpose ;
+                      rdfs:comment    "The package refers to an archived collection of files (.tar, .zip, etc)."@en ;
+                      vs:term_status  "stable"@en .
+
+prov:wasStartedBy  rdf:type     owl:ObjectProperty ;
+                   rdfs:comment            "Start is when an activity is deemed to have started. A start may refer to an entity, known as trigger, that initiated the activity."@en ;
+                   rdfs:domain             prov:Activity ;
+                   rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+                   rdfs:label              "wasStartedBy" ;
+                   rdfs:range              prov:Entity ;
+                   rdfs:subPropertyOf      prov:wasInfluencedBy ;
+                   owl:propertyChainAxiom  ( prov:qualifiedStart prov:entity ) ;
+                   owl:propertyChainAxiom  ( prov:qualifiedStart prov:entity ) ;
+                   prov:category           "expanded" ;
+                   prov:component          "entities-activities" ;
+                   prov:inverse            "started" ;
+                   prov:qualifiedForm      prov:qualifiedStart , prov:Start .
+
+prov:wasDerivedFrom  rdf:type   owl:ObjectProperty ;
+                     rdfs:comment            "The more specific subproperties of prov:wasDerivedFrom (i.e., prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource) should be used when applicable."@en ;
+                     rdfs:domain             prov:Entity ;
+                     rdfs:isDefinedBy        <http://www.w3.org/ns/prov-o#> ;
+                     rdfs:label              "wasDerivedFrom" ;
+                     rdfs:range              prov:Entity ;
+                     rdfs:subPropertyOf      prov:wasInfluencedBy ;
+                     owl:propertyChainAxiom  ( prov:qualifiedDerivation prov:entity ) ;
+                     owl:propertyChainAxiom  ( prov:qualifiedDerivation prov:entity ) ;
+                     prov:category           "starting-point" ;
+                     prov:component          "derivations" ;
+                     prov:definition         "A derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity."@en ;
+                     prov:inverse            "hadDerivation" ;
+                     prov:qualifiedForm      prov:Derivation , prov:qualifiedDerivation .
+
+vcard:region  rdf:type    owl:DatatypeProperty ;
+              rdfs:comment      "The region (e.g. state or province) associated with the address of the object"@en ;
+              rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+              rdfs:label        "region"@en ;
+              rdfs:range        xsd:string .
+
+spdx:ReferenceCategory
+  rdf:type        owl:Class ;
+  rdfs:comment    "Category used for ExternalRef"@en ;
+  vs:term_status  "stable"@en .
+
+vcard:TelephoneType  rdf:type  owl:Class ;
+                     rdfs:comment      "Used for telephone type codes. The URI of the telephone type code must be used as the value for the Telephone Type."@en ;
+                     rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                     rdfs:label        "Phone"@en .
+
+dcterms:TGN  rdf:type     dcam:VocabularyEncodingScheme ;
+             rdfs:comment      "The set of places specified by the Getty Thesaurus of Geographic Names."@en ;
+             rdfs:isDefinedBy  dcterms: ;
+             rdfs:label        "TGN"@en ;
+             rdfs:seeAlso      <http://www.getty.edu/research/tools/vocabulary/tgn/index.html> ;
+             dcterms:issued    "2000-07-11"^^xsd:date .
+
+spdx:relationshipType_fileAdded
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "A Relationship of relationshipType_fileAdded expresses that the SPDXElement is a file which has been added to the relatedSPDXElement package.  For example, a package (the relatedSPDXElement) has been patched to remove a file (the SPDXElement).  This relationship is typically used to express the result of a patched package when the actual patchfile is not present."@en ;
+  vs:term_status  "stable"@en .
+
+time:inDateTime  rdf:type   owl:ObjectProperty ;
+                 rdfs:comment        "Position of an instant, expressed using a structured description"@en , "Posición de un instante, expresada utilizando una descripción estructurada."@es ;
+                 rdfs:domain         time:Instant ;
+                 rdfs:label          "in date-time description"@en , "en descripción de fecha-hora"@es ;
+                 rdfs:range          time:GeneralDateTimeDescription ;
+                 rdfs:subPropertyOf  time:inTemporalPosition ;
+                 skos:definition     "Posición de un instante, expresada utilizando una descripción estructurada."@es , "Position of an instant, expressed using a structured description"@en .
+
+spdx:relationshipType_generatedFrom
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "A Relationship of relationshipType_generatedFrom expresses that an SPDXElement was generated from the relatedSPDXElement.  For example, a binary File might have been generated from a source File."@en ;
+  vs:term_status  "stable"@en .
+
+xsd:date  rdf:type  rdfs:Datatype .
+
+vcard:hasKey  rdf:type          owl:ObjectProperty ;
+              rdfs:comment            "To specify a public key or authentication certificate associated with the object"@en ;
+              rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+              rdfs:label              "has key"@en ;
+              owl:equivalentProperty  vcard:key .
+
+spdx:Package  rdf:type   owl:Class ;
+              rdfs:comment     "A Package represents a collection of software files that are delivered as a single functional component."@en ;
+              rdfs:subClassOf  spdx:SpdxItem ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                                 owl:onClass                  spdx:File ;
+                                 owl:onProperty               spdx:hasFile
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:boolean ;
+                                 owl:onProperty               spdx:filesAnalyzed
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:string ;
+                                 owl:onProperty               spdx:originator
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                                 owl:onClass                  spdx:Checksum ;
+                                 owl:onProperty               spdx:checksum
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:anyURI ;
+                                 owl:onProperty               doap:homepage
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:date ;
+                                 owl:onProperty               spdx:validUntilDate
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:string ;
+                                 owl:onProperty               spdx:summary
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:string ;
+                                 owl:onProperty               spdx:sourceInfo
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onClass                  spdx:PackageVerificationCode ;
+                                 owl:onProperty               spdx:packageVerificationCode
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:string ;
+                                 owl:onProperty               spdx:packageFileName
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:string ;
+                                 owl:onProperty               spdx:description
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                 owl:onDataRange           xsd:anyURI ;
+                                 owl:onProperty            spdx:downloadLocation ;
+                                 owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:string ;
+                                 owl:onProperty               spdx:supplier
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:minQualifiedCardinality  "0"^^xsd:nonNegativeInteger ;
+                                 owl:onClass                  spdx:ExternalRef ;
+                                 owl:onProperty               spdx:externalRef
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onClass                  spdx:Purpose ;
+                                 owl:onProperty               spdx:primaryPackagePurpose
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:string ;
+                                 owl:onProperty               spdx:versionInfo
+                         ] ;
+              rdfs:subClassOf  [ rdf:type     owl:Class ;
+                                 owl:unionOf  ( [ rdf:type        owl:Restriction ;
+                                                  owl:hasValue    spdx:noassertion ;
+                                                  owl:onProperty  spdx:licenseDeclared
+                                                ]
+                                                [ rdf:type        owl:Restriction ;
+                                                  owl:hasValue    spdx:none ;
+                                                  owl:onProperty  spdx:licenseDeclared
+                                                ]
+                                                [ rdf:type                     owl:Restriction ;
+                                                  owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                                  owl:onClass                  spdx:AnyLicenseInfo ;
+                                                  owl:onProperty               spdx:licenseDeclared
+                                                ]
+                                              )
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:date ;
+                                 owl:onProperty               spdx:builtDate
+                         ] ;
+              rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                 owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                 owl:onDataRange              xsd:date ;
+                                 owl:onProperty               spdx:releaseDate
+                         ] ;
+              vs:term_status   "stable"@en .
+
+<http://data.europa.eu/r5r>
+  rdf:type     owl:Ontology ;
+  owl:imports  <https://spdx.org/rdf/terms/spdx-ontology.owl.xml> , <http://www.w3.org/2006/time.ttl> , <https://www.w3.org/ns/locn.ttl> , <http://www.w3.org/ns/prov-o.ttl> , <https://schema.org/version/latest/schema.ttl> , <http://www.w3.org/ns/adms.ttl> , <http://www.w3.org/2006/vcard/ns.ttl> , <http://xmlns.com/foaf/spec/index.rdf> , <http://dublincore.org/2020/01/20/dublin_core_terms.ttl> , <https://www.w3.org/ns/dcat2.ttl> .
+
+prov:unqualifiedForm  rdf:type  owl:AnnotationProperty ;
+                      rdfs:comment        "Classes and properties used to qualify relationships are annotated with prov:unqualifiedForm to indicate the property used to assert an unqualified provenance relation."@en ;
+                      rdfs:isDefinedBy    <http://www.w3.org/ns/prov-o#> ;
+                      rdfs:subPropertyOf  rdfs:seeAlso .
+
+spdx:relationshipType_specificationFor
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "Is to be used when SPDXRef-A describes, illustrates, or defines a design specification for SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:crossRef  rdf:type  owl:ObjectProperty ;
+               rdfs:comment  "Cross Reference Detail for a license SeeAlso URL"@en ;
+               rdfs:range    spdx:SimpleLicensingInfo .
+
+vcard:Internet  rdf:type  owl:Class ;
+                rdfs:comment      "This class is deprecated"@en ;
+                rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                rdfs:label        "Internet"@en ;
+                rdfs:subClassOf   vcard:Type ;
+                owl:deprecated    true .
+
+<http://data.europa.eu/r5r#Dataset_Shape>
+  rdf:type        sh:NodeShape ;
+  sh:name         "Dataset"@en ;
+  sh:property     [ sh:path      dcterms:isVersionOf ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:nodeKind  sh:BlankNodeOrIRI ;
+                    sh:path      dcterms:relation ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:datatype  xsd:decimal ;
+                    sh:maxCount  1 ;
+                    sh:path      dcat:spatialResolutionInMeters ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:creator ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:nodeKind  sh:BlankNodeOrIRI ;
+                    sh:path      dc:isReferencedBy ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcterms:accessRights ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:provenance ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcterms:publisher ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:spatial ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:hasVersion ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcat:distribution ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      adms:identifier ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:node      <http://data.europa.eu/r5r#DateOrDateTimeDataType_Shape> ;
+                    sh:path      dcterms:modified ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:conformsTo ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:path      dcterms:accrualPeriodicity ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:type ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      adms:sample ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:source ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcat:theme ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:temporal ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:nodeKind  sh:Literal ;
+                    sh:path      dcat:keyword ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      foaf:page ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcterms:language ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:nodeKind  sh:Literal ;
+                    sh:path      adms:versionNotes ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcat:contactPoint ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:node      <http://data.europa.eu/r5r#DateOrDateTimeDataType_Shape> ;
+                    sh:path      dcterms:issued ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:datatype  xsd:duration ;
+                    sh:maxCount  1 ;
+                    sh:path      dcat:temporalResolution ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:nodeKind  sh:Literal ;
+                    sh:path      dcterms:identifier ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      prov:qualifiedAttribution ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      prov:wasGeneratedBy ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:maxCount  1 ;
+                    sh:nodeKind  sh:Literal ;
+                    sh:path      owl:versionInfo ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:minCount  1 ;
+                    sh:nodeKind  sh:Literal ;
+                    sh:path      dcterms:title ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:minCount  1 ;
+                    sh:nodeKind  sh:Literal ;
+                    sh:path      dcterms:description ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcat:landingPage ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:property     [ sh:path      dcat:qualifiedRelation ;
+                    sh:severity  sh:Violation
+                  ] ;
+  sh:targetClass  dcat:Dataset .
+
+vcard:TextPhone  rdf:type  owl:Class ;
+                 rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+                 rdfs:label        "Text phone"@en ;
+                 rdfs:subClassOf   vcard:TelephoneType .
+
+vcard:Date  rdf:type      owl:Class ;
+            rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+            rdfs:label        "Date"@en ;
+            rdfs:subClassOf   vcard:RelatedType .
+
+vcard:hasURL  rdf:type          owl:ObjectProperty ;
+              rdfs:comment            "To specify a uniform resource locator associated with the object"@en ;
+              rdfs:isDefinedBy        <http://www.w3.org/2006/vcard/ns> ;
+              rdfs:label              "has url"@en ;
+              owl:equivalentProperty  vcard:url .
+
+spdx:licenseExceptionTemplate
+  rdf:type        owl:DatatypeProperty ;
+  rdfs:comment    "Template for matching license exception text"@en ;
+  rdfs:domain     spdx:LicenseException ;
+  rdfs:range      xsd:string ;
+  vs:term_status  "stable"@en .
+
+spdx:relationshipType_documentation
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "To be used when SPDXRef-A provides documentation of SPDXRef-B."@en ;
+  vs:term_status  "stable"@en .
+
+spdx:relationshipType_containedBy
+  rdf:type        owl:NamedIndividual , spdx:RelationshipType ;
+  rdfs:comment    "A Relationship of relationshipType_containedBy expresses that an SPDXElement is contained by the relatedSPDXElement.  For example, a File contained by a Package. "@en ;
+  vs:term_status  "stable"@en .
+
+vcard:extended-address
+  rdf:type          owl:DatatypeProperty ;
+  rdfs:comment      "This data property has been deprecated"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "extended address"@en ;
+  owl:deprecated    true .
+
+vcard:Dom  rdf:type       owl:Class ;
+           rdfs:comment      "This class is deprecated"@en ;
+           rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+           rdfs:label        "Dom"@en ;
+           rdfs:subClassOf   vcard:Type ;
+           owl:deprecated    true .
+
+spdx:attributionText  rdf:type  owl:DatatypeProperty ;
+                      rdfs:comment    "This field provides a place for the SPDX data creator to record acknowledgements that may be required to be communicated in some contexts. This is not meant to include the actual complete license text (see licenseConculded and licenseDeclared), and may or may not include copyright notices (see also copyrightText). The SPDX data creator may use this field to record other acknowledgements, such as particular clauses from license texts, which may be necessary or desirable to reproduce."@en ;
+                      rdfs:domain     spdx:SpdxItem ;
+                      rdfs:range      xsd:string ;
+                      vs:term_status  "stable"@en .
+
+time:inXSDgYearMonth  rdf:type  owl:DatatypeProperty ;
+                      rdfs:comment     "Position of an instant, expressed using xsd:gYearMonth"@en , "Posición de un instante, expresado utilizando xsd:gYearMonth."@es ;
+                      rdfs:domain      time:Instant ;
+                      rdfs:label       "in XSD g-YearMonth"@en , "en año-mes gregoriano XSD"@es ;
+                      rdfs:range       xsd:gYearMonth ;
+                      skos:definition  "Position of an instant, expressed using xsd:gYearMonth"@en , "Posición de un instante, expresado utilizando xsd:gYearMonth."@es .
+
+prov:Derivation  rdf:type     owl:Class ;
+                 rdfs:comment          "An instance of prov:Derivation provides additional descriptions about the binary prov:wasDerivedFrom relation from some derived prov:Entity to another prov:Entity from which it was derived. For example, :chewed_bubble_gum prov:wasDerivedFrom :unwrapped_bubble_gum; prov:qualifiedDerivation [ a prov:Derivation; prov:entity :unwrapped_bubble_gum; :foo :bar ]."@en , "The more specific forms of prov:Derivation (i.e., prov:Revision, prov:Quotation, prov:PrimarySource) should be asserted if they apply."@en ;
+                 rdfs:isDefinedBy      <http://www.w3.org/ns/prov-o#> ;
+                 rdfs:label            "Derivation" ;
+                 rdfs:subClassOf       prov:EntityInfluence ;
+                 prov:category         "qualified" ;
+                 prov:component        "derivations" ;
+                 prov:constraints      "http://www.w3.org/TR/2013/REC-prov-constraints-20130430/#prov-dm-constraints-fig"^^xsd:anyURI ;
+                 prov:definition       "A derivation is a transformation of an entity into another, an update of an entity resulting in a new one, or the construction of a new entity based on a pre-existing entity."@en ;
+                 prov:dm               "http://www.w3.org/TR/2013/REC-prov-dm-20130430/#term-Derivation"^^xsd:anyURI ;
+                 prov:n                "http://www.w3.org/TR/2013/REC-prov-n-20130430/#Derivation-Relation"^^xsd:anyURI ;
+                 prov:unqualifiedForm  prov:wasDerivedFrom .
+
+spdx:Relationship  rdf:type  owl:Class ;
+                   rdfs:comment     "A Relationship represents a relationship between two SpdxElements."@en ;
+                   rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                      owl:onClass               spdx:SpdxElement ;
+                                      owl:onProperty            spdx:relatedSpdxElement ;
+                                      owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                             ] ;
+                   rdfs:subClassOf  [ rdf:type                  owl:Restriction ;
+                                      owl:onClass               spdx:RelationshipType ;
+                                      owl:onProperty            spdx:relationshipType ;
+                                      owl:qualifiedCardinality  "1"^^xsd:nonNegativeInteger
+                             ] ;
+                   rdfs:subClassOf  [ rdf:type                     owl:Restriction ;
+                                      owl:maxQualifiedCardinality  "1"^^xsd:nonNegativeInteger ;
+                                      owl:onDataRange              xsd:string ;
+                                      owl:onProperty               rdfs:comment
+                             ] ;
+                   vs:term_status   "stable"@en .
+
+dcterms:dateCopyrighted
+  rdf:type             rdf:Property ;
+  rdfs:comment         "Date of copyright of the resource."@en ;
+  rdfs:isDefinedBy     dcterms: ;
+  rdfs:label           "Date Copyrighted"@en ;
+  rdfs:range           rdfs:Literal ;
+  rdfs:subPropertyOf   dc:date , dcterms:date ;
+  dcterms:description  "Typically a year.  Recommended practice is to describe the date, date/time, or period of time as recommended for the property Date, of which this is a subproperty."@en ;
+  dcterms:issued       "2002-07-13"^^xsd:date .
+
+time:years  rdf:type  owl:DatatypeProperty ;
+            rdfs:comment  "length of, or element of the length of, a temporal extent expressed in years"@en , "Longitud de, o elemento de la longitud de, una extensión temporal expresada en años."@es ;
+            rdfs:domain   time:GeneralDurationDescription ;
+            rdfs:label    "years duration"@en , "duración en años"@es ;
+            rdfs:range    xsd:decimal .
+
+vcard:hasOrganizationName
+  rdf:type          owl:ObjectProperty ;
+  rdfs:comment      "Used to support property parameters for the organization name data property"@en ;
+  rdfs:isDefinedBy  <http://www.w3.org/2006/vcard/ns> ;
+  rdfs:label        "has organization name"@en .
+
+prov:constraints  rdf:type  owl:AnnotationProperty ;
+                  rdfs:comment        "A reference to the principal section of the PROV-CONSTRAINTS document that describes this concept."@en ;
+                  rdfs:isDefinedBy    <http://www.w3.org/ns/prov-o#> ;
+                  rdfs:subPropertyOf  rdfs:seeAlso .
+
+<http://spdx.org/rdf/terms>
+  rdf:type         owl:Ontology ;
+  rdfs:comment     "This specification describes the SPDX® language, defined as a dictionary of named properties and classes using W3C's RDF Technology.\n\nSPDX® is an open standard for communicating software bill of material information, including components, licenses, copyrights, and security references. SPDX reduces redundant work by providing a common format for companies and communities to share important data, thereby streamlining and improving compliance.\n.\nKnown issues:\n- rdfs:comment and rdfs:seeAlso are used within the SPDX classes and causes a redefinition of these standard terms"@en ;
+  rdfs:label       "SPDX 2.3" ;
+  owl:versionIRI   <http://spdx.org/rdf/terms/2.3> ;
+  owl:versionInfo  2.3 .

--- a/src/test/resources/shacl/dcat-ap-ch-shapes.ttl
+++ b/src/test/resources/shacl/dcat-ap-ch-shapes.ttl
@@ -1,0 +1,83 @@
+@prefix sh:     <http://www.w3.org/ns/shacl#> .
+@prefix rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:   <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcat:   <http://www.w3.org/ns/dcat#> .
+@prefix dct:    <http://purl.org/dc/terms/> .
+@prefix foaf:   <http://xmlns.com/foaf/0.1/> .
+@prefix vcard:  <http://www.w3.org/2006/vcard/ns#> .
+
+# ==============================================================
+# DCAT-AP-CH SPECIFIC SHACL Shapes
+# Rules specific to the Swiss National Open Data Portal (opendata.swiss)
+# that go beyond or differ from DCAT-AP 2.1.1.
+#
+# Used together with: shacl/dcat-ap-2.1.1-base-SHACL.ttl
+# Reference: https://handbook.opendata.swiss/de/content/glossar/bibliothek/dcat-ap-ch.html
+# ==============================================================
+
+# ==============================================================
+# dcat:Dataset — CH-specific constraints
+# ==============================================================
+
+<#DatasetShapeCH>
+  a sh:NodeShape ;
+  sh:targetClass dcat:Dataset ;
+  sh:name "DCAT-AP-CH Dataset (Swiss-specific)" ;
+
+  # dct:accrualPeriodicity — MANDATORY in DCAT-AP-CH (only recommended in DCAT-AP 2.1.1)
+  sh:property [
+    sh:path dct:accrualPeriodicity ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:nodeKind sh:IRI ;
+    sh:message "dct:accrualPeriodicity is mandatory in DCAT-AP-CH (exactly 1 IRI from EU frequency vocabulary)" ;
+    sh:severity sh:Violation ;
+  ] ;
+
+  # dcat:contactPoint — MANDATORY in DCAT-AP-CH
+  sh:property [
+    sh:path dcat:contactPoint ;
+    sh:minCount 1 ;
+    sh:message "dcat:contactPoint is mandatory in DCAT-AP-CH (at least 1)" ;
+    sh:severity sh:Violation ;
+  ] ;
+
+  # dct:relation — geocat.ch permalink, recommended
+  sh:property [
+    sh:path dct:relation ;
+    sh:nodeKind sh:BlankNodeOrIRI ;
+    sh:message "dct:relation must be a blank node or IRI" ;
+    sh:severity sh:Warning ;
+  ] ;
+
+.
+
+# ==============================================================
+# dcat:Distribution — CH-specific constraints
+# ==============================================================
+
+<#DistributionShapeCH>
+  a sh:NodeShape ;
+  sh:targetClass dcat:Distribution ;
+  sh:name "DCAT-AP-CH Distribution (Swiss-specific)" ;
+
+  # dct:license — MANDATORY in DCAT-AP-CH, must use opendata.swiss vocabulary or CC
+  sh:property [
+    sh:path dct:license ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:nodeKind sh:IRI ;
+    sh:message "dct:license is mandatory in DCAT-AP-CH (exactly 1 IRI)" ;
+    sh:severity sh:Violation ;
+  ] ;
+
+  # dct:issued — MANDATORY in DCAT-AP-CH
+  sh:property [
+    sh:path dct:issued ;
+    sh:minCount 1 ;
+    sh:message "dct:issued is mandatory on distributions in DCAT-AP-CH" ;
+    sh:severity sh:Violation ;
+  ] ;
+
+.


### PR DESCRIPTION
### DCAT-AP-CH formatter: fixes and SHACL validation tests

## Formatter fixes ([dcat-ap-ch-core-dataset.xsl](vscode-file://vscode-app/snap/code/225/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html))

1. dcat:Distribution URI — each distribution now carries a stable rdf:about URI built from the record UUID and distribution position (https://www.geocat.ch/geonetwork/srv/api/records/{uuid}/distributions/{n})
2. foaf:page links — online resources with protocol WWW:LINK and function information are now mapped to foaf:page / foaf:Document on the dataset
3. dcat:contactPoint — skip empty contacts — the XPath selector for mdb:contact and mri:pointOfContact now requires a cit:CI_Responsibility child, preventing empty xlink:show="embed" stubs from being selected and silently swallowing the real contact
5. dct:issued on distributions — revision date fallback — when no publication or creation date is present, the revision date is now used as a fallback so that distributions always carry a dct:issued value
6. Partial dates — dates with year-only (yyyy) or year-month (yyyy-MM) precision are now padded to yyyy-01-01 and yyyy-MM-01 before appending the time component, producing valid xsd:dateTime literals instead of malformed values like 2024-08T00:00:00
7. Date formatting consolidation — duplicated inline date-formatting logic in add-dates and the distribution block is replaced by calls to the existing local:format-datetime() function

## CSW presenter fixes (present/csw/)
dcat-ap-ch-brief.xsl, dcat-ap-ch-full.xsl, dcat-ap-ch-summary.xsl — added missing xmlns:rdf namespace declaration and wrapped output in <rdf:RDF> with the shared create-namespaces-dcat-ap-ch template, so responses are valid RDF/XML documents

## SHACL validation tests (new)

1. Added ShaclDcatApChTest (17 test methods, one per sample metadata file) that transforms each record via view.xsl and validates the resulting RDF/XML graph against:
- dcat-ap-2.1.1-base-SHACL.ttl — official DCAT-AP 2.1.1 shapes from the EU Publications Office
- dcat-ap-ch-shapes.ttl — CH-specific supplements: dct:accrualPeriodicity mandatory on datasets, dcat:contactPoint mandatory on datasets, dct:license mandatory on distributions, dct:issued mandatory on distributions
2. Added jena-shacl:4.10.0 dependency (test scope) to [pom.xml](vscode-file://vscode-app/snap/code/225/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
