### PR TITLE
DCAT-AP-CH formatter: support ISO19139 lang, SHACL tests, fix contact…

### DIFF
--- a/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
+++ b/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
@@ -220,6 +220,7 @@
     <!-- Filter online resources based on protocol -->
     <xsl:for-each select="mdb:distributionInfo//mrd:onLine">
       <xsl:variable name="protocol" select="normalize-space((*/cit:protocol/*/text())[1])"/>
+      <xsl:variable name="protocolLower" select="lower-case($protocol)"/>
       <xsl:variable name="url" select="normalize-space((*/cit:linkage/*/text())[1])"/>
       <!-- Check if this should be a DCAT distribution -->
       <xsl:if test="
@@ -229,12 +230,35 @@
         starts-with($protocol, 'OGC:WMS') or
         starts-with($protocol, 'ESRI:REST') or
         starts-with($protocol, 'LINKED:DATA') or
-        starts-with($protocol, 'MAP:Preview')
+        starts-with($protocol, 'MAP:Preview') or
+        contains($protocolLower, 'wms') or
+        contains($protocolLower, 'wfs') or
+        contains($protocolLower, 'web portal') or
+        contains($protocolLower, 'web atlas') or
+        contains($protocolLower, 'csv') or
+        contains($protocolLower, 'gdb') or
+        contains($protocolLower, 'geodatabase') or
+        contains($protocolLower, 'gml') or
+        contains($protocolLower, 'kml') or
+        contains($protocolLower, 'shp') or
+        contains($protocolLower, 'shapefile') or
+        contains($protocolLower, 'gpkg') or
+        contains($protocolLower, 'geopackage') or
+        contains($protocolLower, 'geojson') or
+        contains($protocolLower, 'geotiff') or
+        contains($protocolLower, 'tiff') or
+        contains($protocolLower, 'tif') or
+        contains($protocolLower, 'pdf') or
+        contains($protocolLower, 'dxf') or
+        contains($protocolLower, 'dwg') or
+        contains($protocolLower, 'xtf') or
+        contains($protocolLower, 'itf') or
+        contains($protocolLower, 'interlis') or
+        contains($protocolLower, 'geoparquet') or
+        contains($protocolLower, 'txt')
       ">
-        <xsl:variable name="datasetUuid" select="ancestor::che:CHE_MD_Metadata/mdb:metadataIdentifier/*/mcc:code/*/text()"/>
-        <xsl:variable name="distributionUri" select="concat($geonetworkBaseUrl, 'srv/api/records/', $datasetUuid, '/distributions/', position())"/>
         <dcat:distribution>
-          <dcat:Distribution rdf:about="{$distributionUri}">
+          <dcat:Distribution>
             <!-- Access URL -->
             <dcat:accessURL rdf:resource="{$url}"/>
             <!-- Download URL for download protocols -->
@@ -601,30 +625,43 @@
   <xsl:template name="add-format">
     <xsl:param name="protocol"/>
     <xsl:param name="url"/>
-    
+
+    <xsl:variable name="protocolLower" select="lower-case($protocol)"/>
     <!-- Strip URL fragment (#...) and query string (?...) before extension detection -->
     <xsl:variable name="urlBase" select="lower-case(tokenize($url, '[#?]')[1])"/>
     
     <xsl:variable name="formatUri">
       <xsl:choose>
         <!-- Service protocols (full URIs) -->
-        <xsl:when test="starts-with($protocol, 'OGC:WMS')">
+        <xsl:when test="starts-with($protocol, 'OGC:WMS') or contains($protocolLower, 'wms')">
           <xsl:text>http://publications.europa.eu/resource/authority/file-type/WMS_SRVC</xsl:text>
         </xsl:when>
         <xsl:when test="starts-with($protocol, 'OGC:WMTS')">
           <xsl:text>http://publications.europa.eu/resource/authority/file-type/WMTS_SRVC</xsl:text>
         </xsl:when>
-        <xsl:when test="starts-with($protocol, 'OGC:WFS')">
+        <xsl:when test="starts-with($protocol, 'OGC:WFS') or contains($protocolLower, 'wfs')">
           <xsl:text>http://publications.europa.eu/resource/authority/file-type/WFS_SRVC</xsl:text>
         </xsl:when>
         <xsl:when test="starts-with($protocol, 'ESRI:REST')">
           <xsl:text>http://publications.europa.eu/resource/authority/file-type/REST</xsl:text>
         </xsl:when>
-        <xsl:when test="starts-with($protocol, 'MAP:Preview')">
+        <xsl:when test="starts-with($protocol, 'MAP:Preview') or contains($protocolLower, 'web portal') or contains($protocolLower, 'web atlas')">
           <xsl:text>http://publications.europa.eu/resource/authority/file-type/HTML</xsl:text>
         </xsl:when>
-        
-        <!-- File formats by extension (code only) -->
+
+        <!-- Format protocols identified by name (case-insensitive) -->
+        <xsl:when test="contains($protocolLower, 'csv')">http://publications.europa.eu/resource/authority/file-type/CSV</xsl:when>
+        <xsl:when test="contains($protocolLower, 'geojson')">http://publications.europa.eu/resource/authority/file-type/GEOJSON</xsl:when>
+        <xsl:when test="contains($protocolLower, 'gml')">http://publications.europa.eu/resource/authority/file-type/GML</xsl:when>
+        <xsl:when test="contains($protocolLower, 'kml')">http://publications.europa.eu/resource/authority/file-type/KML</xsl:when>
+        <xsl:when test="contains($protocolLower, 'geotiff')">http://publications.europa.eu/resource/authority/file-type/GEOTIFF</xsl:when>
+        <xsl:when test="contains($protocolLower, 'tiff') or contains($protocolLower, 'tif')">http://publications.europa.eu/resource/authority/file-type/TIFF</xsl:when>
+        <xsl:when test="contains($protocolLower, 'pdf')">http://publications.europa.eu/resource/authority/file-type/PDF</xsl:when>
+        <xsl:when test="contains($protocolLower, 'gpkg') or contains($protocolLower, 'geopackage')">http://publications.europa.eu/resource/authority/file-type/GPKG</xsl:when>
+        <xsl:when test="contains($protocolLower, 'shp') or contains($protocolLower, 'shapefile')">http://publications.europa.eu/resource/authority/file-type/SHP</xsl:when>
+        <xsl:when test="contains($protocolLower, 'txt')">http://publications.europa.eu/resource/authority/file-type/TXT</xsl:when>
+
+        <!-- File formats by URL extension (fallback) -->
         <xsl:when test="ends-with($urlBase, '.shp')">http://publications.europa.eu/resource/authority/file-type/SHP</xsl:when>
         <xsl:when test="ends-with($urlBase, '.gpkg')">http://publications.europa.eu/resource/authority/file-type/GPKG</xsl:when>
         <xsl:when test="ends-with($urlBase, '.geojson')">http://publications.europa.eu/resource/authority/file-type/GEOJSON</xsl:when>
@@ -753,13 +790,21 @@
   <!-- 21. ADD MEDIA TYPE (for distributions) -->
   <xsl:template name="add-media-type">
     <xsl:param name="protocol"/>
-    
+
+    <xsl:variable name="protocolLower" select="lower-case($protocol)"/>
     <xsl:variable name="mediaType">
       <xsl:choose>
-        <xsl:when test="starts-with($protocol, 'MAP:Preview') or starts-with($protocol, 'WWW:LINK')">text/html</xsl:when>
+        <xsl:when test="starts-with($protocol, 'MAP:Preview') or starts-with($protocol, 'WWW:LINK') or contains($protocolLower, 'web portal') or contains($protocolLower, 'web atlas')">text/html</xsl:when>
         <xsl:when test="starts-with($protocol, 'WWW:DOWNLOAD')">application/octet-stream</xsl:when>
-        <xsl:when test="starts-with($protocol, 'OGC:') or starts-with($protocol, 'ESRI:')">application/xml</xsl:when>
-        <xsl:otherwise>application/octet-stream</xsl:otherwise>
+        <xsl:when test="starts-with($protocol, 'OGC:') or starts-with($protocol, 'ESRI:') or contains($protocolLower, 'wms') or contains($protocolLower, 'wfs')">application/xml</xsl:when>
+        <xsl:when test="contains($protocolLower, 'csv')">text/csv</xsl:when>
+        <xsl:when test="contains($protocolLower, 'gml')">application/gml+xml</xsl:when>
+        <xsl:when test="contains($protocolLower, 'kml')">application/vnd.google-earth.kml+xml</xsl:when>
+        <xsl:when test="contains($protocolLower, 'geojson')">application/geo+json</xsl:when>
+        <xsl:when test="contains($protocolLower, 'geotiff') or contains($protocolLower, 'tiff') or contains($protocolLower, 'tif')">image/tiff</xsl:when>
+        <xsl:when test="contains($protocolLower, 'pdf')">application/pdf</xsl:when>
+        <xsl:when test="contains($protocolLower, 'txt')">text/plain</xsl:when>
+        <xsl:otherwise>application/zip</xsl:otherwise>
       </xsl:choose>
     </xsl:variable>
     

--- a/src/test/resources/dcat/amphibians-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/amphibians-dcat-ap-ch.xml
@@ -24,7 +24,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/distributions/1">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dct:title xml:lang="de">Datenbeschreibung_AmphibienAckerland.pdf</dct:title>
@@ -43,7 +43,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce/distributions/2">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/DescriptionDonnees_BatrachiensAgricole.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/DescriptionDonnees_BatrachiensAgricole.pdf" />
         <dct:title xml:lang="de">DescriptionDonnees_BatrachiensAgricole.pdf</dct:title>

--- a/src/test/resources/dcat/conventionDesAlpesTousLesChamps-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/conventionDesAlpesTousLesChamps-dcat-ap-ch.xml
@@ -28,7 +28,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/2">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="http://data.geo.admin.ch/ch.are.alpenkonvention/data.zip" />
         <dcat:downloadURL rdf:resource="http://data.geo.admin.ch/ch.are.alpenkonvention/data.zip" />
         <dct:description xml:lang="de">Download von data.geo.admin.ch</dct:description>
@@ -51,7 +51,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/3">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="http://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.are.alpenkonvention</dct:title>
         <dct:description xml:lang="de">WMS Dienst von geo.admin.ch</dct:description>
@@ -74,7 +74,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/4">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://www.are.admin.ch/are/de/home/raumentwicklung-und-raumplanung/grundlagen-und-daten/minimale-geodatenmodelle/alpenkonvention.html" />
         <dcat:downloadURL rdf:resource="https://www.are.admin.ch/are/de/home/raumentwicklung-und-raumplanung/grundlagen-und-daten/minimale-geodatenmodelle/alpenkonvention.html" />
         <dct:description xml:lang="de">Minimales Geodatenmodell in INTERLIS 2.3</dct:description>
@@ -95,7 +95,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/fbafbbd4-4622-445f-8e07-1ad4f6a61c55/distributions/6">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="http://wmts.geo.admin.ch" />
         <dct:title xml:lang="de">ch.are.alpenkonvention</dct:title>
         <dct:description xml:lang="de">WMTS für das Nationale Geoportal</dct:description>

--- a/src/test/resources/dcat/fiktiverDarstellungskatalogMitURL-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/fiktiverDarstellungskatalogMitURL-dcat-ap-ch.xml
@@ -27,7 +27,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/3">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.bafu.fauna-steinbockkolonien/data.zip" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.bafu.fauna-steinbockkolonien/data.zip" />
         <dct:title xml:lang="de">Download-Server von geo.admin.ch</dct:title>
@@ -51,7 +51,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/4">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.bafu.fauna-steinbockkolonien</dct:title>
         <dct:description xml:lang="de">WMS-BGDI Dienst, Layer "Steinbockkolonien"</dct:description>
@@ -74,7 +74,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/5">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="http://www.bafu.admin.ch/geodaten" />
         <dcat:downloadURL rdf:resource="http://www.bafu.admin.ch/geodaten" />
         <dct:title xml:lang="de">Download ESRI Shapefile</dct:title>
@@ -82,7 +82,7 @@
         <dct:description xml:lang="fr">Lien vers la distribution des données ESRI Shapefile (.shp)</dct:description>
         <dct:description xml:lang="it">Link per le fonti dei dati ESRI Shapefile (.shp)</dct:description>
         <dct:description xml:lang="en">Link for download ESRI Shapefile (.shp)</dct:description>
-        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/UNSPECIFIED" />
+        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/SHP" />
         <dcat:mediaType rdf:resource="http://www.iana.org/assignments/media-types/application/octet-stream" />
         <dct:license rdf:resource="http://dcat-ap.ch/vocabulary/licenses/terms_by" />
         <dct:rights>
@@ -98,7 +98,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/6">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="http://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml" />
         <dct:title xml:lang="de">ch.bafu.fauna-steinbockkolonien</dct:title>
         <dct:description xml:lang="de">WMTS für das Nationale Geoportal</dct:description>
@@ -120,7 +120,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0e5a8467-bf17-4d4d-aab4-3ba49417cedc/distributions/7">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.bafu.fauna-steinbockkolonien" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/dcat/grundwasserschutzzonen-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/grundwasserschutzzonen-dcat-ap-ch.xml
@@ -18,7 +18,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/4">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://ows.geo.tg.ch/geofy_access_proxy/gewaesserschutzkarte?Service=WMS&amp;Version=1.3.0&amp;Request=GetCapabilities" />
         <dct:title xml:lang="de">Grundwasserschutzzonen</dct:title>
         <dct:description xml:lang="de">Grundwasserschutzzonen</dct:description>
@@ -37,7 +37,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/5">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://ows.geo.tg.ch/geofy_access_proxy/gewaesserschutzkarte?Service=WFS&amp;Version=2.0.0&amp;Request=GetCapabilities" />
         <dct:description xml:lang="de">Grundwasserschutzzonen</dct:description>
         <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/WFS_SRVC" />
@@ -55,7 +55,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/f494da66-8860-48d5-9cc7-ec38b885afd1/distributions/7">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://shop.geo.tg.ch/products/gewaesserschutzkarte" />
         <dcat:downloadURL rdf:resource="https://shop.geo.tg.ch/products/gewaesserschutzkarte" />
         <dct:title xml:lang="de">shop.geo.tg.ch</dct:title>

--- a/src/test/resources/dcat/hoheitsgrenzpunkteLV-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/hoheitsgrenzpunkteLV-dcat-ap-ch.xml
@@ -28,7 +28,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/1">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.swisstopo.swisstlm3d-uebrigerverkehr" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -54,7 +54,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/2">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-uebrigerverkehr</dct:title>
         <dct:title xml:lang="fr">ch.swisstopo.swisstlm3d-uebrigerverkehr</dct:title>
@@ -82,7 +82,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/4">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-uebrigerverkehr</dct:title>
         <dct:description xml:lang="de">Seilbahnen swissTLM3D</dct:description>
@@ -102,7 +102,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/5">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://www.swisstopo.admin.ch/de/landschaftsmodell-swisstlm3d" />
         <dcat:downloadURL rdf:resource="https://www.swisstopo.admin.ch/de/landschaftsmodell-swisstlm3d" />
         <dct:description xml:lang="de">Shop</dct:description>
@@ -125,7 +125,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/ffc0267e-aca8-49ac-8f3e-86c9beca51f2/distributions/7">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.swisstopo.swisstlm3d-uebrigerverkehr" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/dcat/modellDokumentationSwissTLM3D-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/modellDokumentationSwissTLM3D-dcat-ap-ch.xml
@@ -21,7 +21,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/distributions/2">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/attachments/be4129e9-d1d6-4856-b465-8ca2803e1376.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/attachments/be4129e9-d1d6-4856-b465-8ca2803e1376.pdf" />
         <dct:description xml:lang="de">Deutsche Version</dct:description>

--- a/src/test/resources/dcat/organischenBodenInDerSchweiz-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/organischenBodenInDerSchweiz-dcat-ap-ch.xml
@@ -23,7 +23,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/2">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.agroscope.LAYERNAME" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.agroscope.LAYERNAME" />
         <dct:title xml:lang="de">STAC Browser</dct:title>
@@ -47,7 +47,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/3">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?topic=aviation&amp;lang=de&amp;bgLayer=ch.swisstopo.pixelkarte-grau&amp;layers=ch.bazl.wohngebiete-aulav&amp;catalogNodes=2863&amp;layers_opacity=0.6&amp;E=2642942.51&amp;N=1189717.47&amp;zoom=2" />
         <dct:title xml:lang="de">Vorschau der Karte</dct:title>
         <dct:title xml:lang="fr">Prévie da la carte</dct:title>
@@ -67,7 +67,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/6">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/W%C3%BCst-Galley%20Leifeld%202025%20org%20soils%20map%20SI.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/W%C3%BCst-Galley%20Leifeld%202025%20org%20soils%20map%20SI.pdf" />
         <dct:title xml:lang="de">Wüst-Galley Leifeld 2025 org soils map SI.pdf</dct:title>
@@ -93,7 +93,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/distributions/8">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/Abstract_de_engl_fr_def.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0572e842-7e34-409a-90d9-526d012a1c2d/attachments/Abstract_de_engl_fr_def.pdf" />
         <dct:title xml:lang="de">Abstract_de_engl_fr_def.pdf</dct:title>

--- a/src/test/resources/dcat/schuetzenswerte-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/schuetzenswerte-dcat-ap-ch.xml
@@ -28,7 +28,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/2">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
         <dct:title xml:lang="fr">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
@@ -55,7 +55,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/3">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
         <dct:title xml:lang="fr">ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos</dct:title>
@@ -82,7 +82,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/4">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -104,7 +104,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/5">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.bak.bundesinventar-schuetzenswerte-ortsbilder/items/bundesinventar-schuetzenswerte-ortsbilder" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/browser/index.html#/collections/ch.bak.bundesinventar-schuetzenswerte-ortsbilder/items/bundesinventar-schuetzenswerte-ortsbilder" />
         <dct:description xml:lang="de">Link zum Datenbezug</dct:description>
@@ -124,7 +124,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/b9c1d690-008f-494c-a47f-ec96d9a8d84f/distributions/7">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.bak.bundesinventar-schuetzenswerte-ortsbilder_fotos" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/dcat/swissTLM3D-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/swissTLM3D-dcat-ap-ch.xml
@@ -21,7 +21,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/eeab64f5-e878-4898-b80c-50440b89f525/distributions/1">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://models.geo.admin.ch/Swisstopo/swissTLM3D_ili2_V2_3.ili" />
         <dcat:downloadURL rdf:resource="https://models.geo.admin.ch/Swisstopo/swissTLM3D_ili2_V2_3.ili" />
         <dct:title xml:lang="de">swissTLM3D_ili2_V2_3.ili</dct:title>

--- a/src/test/resources/dcat/trees-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/trees-dcat-ap-ch.xml
@@ -21,7 +21,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/4">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportail/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dcat:downloadURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportail/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dct:description xml:lang="fr">Accès aux données (fr) : téléchargement et services web (Géoportail cantonal)</dct:description>
@@ -43,7 +43,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/5">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportal/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dcat:downloadURL rdf:resource="https://geo.fr.ch/portal/apps/sites/#/geoportal/search?q=1d177f9e-2446-428f-8740-0dbe11e4131c" />
         <dct:description xml:lang="fr">Datenzugriff (de): Download und Webservices (Kantonales Geoportal)</dct:description>
@@ -65,7 +65,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/6">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://geo.fr.ch/ags/services/OpenData/Arbres_culture/MapServer/WMSServer?request=GetCapabilities&amp;service=WMS" />
         <dct:title xml:lang="fr">0</dct:title>
         <dct:description xml:lang="fr">Arbres (culture)</dct:description>
@@ -84,7 +84,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/1d177f9e-2446-428f-8740-0dbe11e4131c/distributions/7">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://geo.fr.ch/CartoFR/?showLegend&amp;uniquelayer=https://geo.fr.ch/ags/rest/services/OpenData/Arbres_culture/MapServer/0" />
         <dct:title xml:lang="fr">Visualisation des données</dct:title>
         <dct:title xml:lang="de">Visualisierung der Daten</dct:title>

--- a/src/test/resources/dcat/veterinarians-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/veterinarians-dcat-ap-ch.xml
@@ -17,7 +17,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/8b1185b2-b14b-45b3-9814-95247c4f3d09/distributions/1">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dcat:downloadURL rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/0916243e-68d9-41c5-95f7-0f657e2ee07f/attachments/Datenbeschreibung_AmphibienAckerland.pdf" />
         <dct:title xml:lang="fr">Datenbeschreibung_AmphibienAckerland.pdf</dct:title>

--- a/src/test/resources/dcat/wanderWege-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/wanderWege-dcat-ap-ch.xml
@@ -27,7 +27,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/1">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.swisstopo.swisstlm3d-wanderwege" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -53,7 +53,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/2">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
         <dct:title xml:lang="fr">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
@@ -81,7 +81,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/3">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
         <dct:title xml:lang="fr">ch.swisstopo.swisstlm3d-wanderwege</dct:title>
@@ -109,7 +109,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/5">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.swisstopo.swisstlm3d-wanderwege/swisstlm3d-wanderwege/swisstlm3d-wanderwege_2056_5728.gpkg.zip" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.swisstopo.swisstlm3d-wanderwege/swisstlm3d-wanderwege/swisstlm3d-wanderwege_2056_5728.gpkg.zip" />
         <dct:title xml:lang="de">swisstlm3d-wanderwege</dct:title>
@@ -133,7 +133,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/97df4dcd-364c-4649-9c11-c65b3b0e9ff2/distributions/7">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.swisstopo.swisstlm3d-wanderwege" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>

--- a/src/test/resources/dcat/weatherStations-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/weatherStations-dcat-ap-ch.xml
@@ -25,7 +25,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/1">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.messwerte-aktuell/VQHA80.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.messwerte-aktuell/VQHA80.csv" />
         <dct:title xml:lang="de">Hauptparameter aller Stationen – alle 10 Minuten, aktuellste Werte</dct:title>
@@ -51,7 +51,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/2">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_parameters.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_parameters.csv" />
         <dct:title xml:lang="de">Parameter-Metadaten</dct:title>
@@ -77,7 +77,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/3">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_stations.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_stations.csv" />
         <dct:title xml:lang="de">Stations-Metadaten</dct:title>
@@ -103,7 +103,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/4">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-smn" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/api/stac/v1/collections/ch.meteoschweiz.ogd-smn" />
         <dct:title xml:lang="de">Alle Parameter einer Station – alle Auflösungen und Zeiträume</dct:title>
@@ -114,7 +114,7 @@
         <dct:description xml:lang="fr">Température, précipitations, vent, ensoleillement, humidité, rayonnement et pression – par station – valeurs toutes les 10 minutes ('t'), horaires ('h'), journalières ('d'), mensuelles ('m') et annuelles ('y') – depuis minuit ('now'), de l'année actuel jusqu'à hier ('recent'), depuis le début de mesure par incréments de dix ans ('historical'). Si vous avez besoin de valeurs horaires, journalières, mensuelles ou annuelles, nous vous recommandons vivement de télécharger la résolution correspondante.</dct:description>
         <dct:description xml:lang="it">Temperatura, precipitazioni, vento, soleggiamento, umidità, radiazione e pressione – per stazione – valori ogni 10 minuti ('t'), orari ('h'), giornalieri ('d'), mensili ('m') e annuali ('y') – dalla mezzanotte ('now'), dall'anno corrente fino a ieri ('recent'), dall'inizio delle misurazioni in incrementi di dieci anni ('historical'). Se si necessitano valori orari, giornalieri, mensili o annuali, si consiglia vivamente di scaricare la risoluzione corrispondente.</dct:description>
         <dct:description xml:lang="en">Temperature, precipitation, wind, sunshine, humidity, radiation and pressure – per station – values every 10 minutes ('t'), hourly ('h'), daily ('d'), monthly ('m') and yearly ('y') – since midnight ('now'), from the current year up to yesterday ('recent'), since the beginning of the measurement in ten-year increments ('historical'). If you require hourly, daily, monthly or yearly values, we strongly recommend that you download the corresponding resolution.</dct:description>
-        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/UNSPECIFIED" />
+        <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/CSV" />
         <dcat:mediaType rdf:resource="http://www.iana.org/assignments/media-types/application/octet-stream" />
         <dct:license rdf:resource="http://dcat-ap.ch/vocabulary/licenses/terms_by" />
         <dct:rights>
@@ -129,7 +129,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/35323752-ed32-4cc1-8a75-898c749b777b/distributions/8">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_datainventory.csv" />
         <dcat:downloadURL rdf:resource="https://data.geo.admin.ch/ch.meteoschweiz.ogd-smn/ogd-smn_meta_datainventory.csv" />
         <dct:title xml:lang="de">Dateninventar-Metadaten</dct:title>

--- a/src/test/resources/dcat/zonesDeTranquillite-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/zonesDeTranquillite-dcat-ap-ch.xml
@@ -28,7 +28,7 @@
       </vcard:Organization>
     </dcat:contactPoint>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/1">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://map.geo.admin.ch/?layers=ch.bafu.wrz-wildruhezonen_portal" />
         <dct:title xml:lang="de">Vorschau map.geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">Aperçu map.geo.admin.ch</dct:title>
@@ -54,7 +54,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/2">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://wms.geo.admin.ch/?SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetCapabilities&amp;lang=de" />
         <dct:title xml:lang="de">ch.bafu.wrz-wildruhezonen_portal</dct:title>
         <dct:title xml:lang="fr">ch.bafu.wrz-wildruhezonen_portal</dct:title>
@@ -82,7 +82,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/3">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://wmts.geo.admin.ch/EPSG/3857/1.0.0/WMTSCapabilities.xml?lang=de" />
         <dct:title xml:lang="de">ch.bafu.wrz-wildruhezonen_portal</dct:title>
         <dct:title xml:lang="fr">ch.bafu.wrz-wildruhezonen_portal</dct:title>
@@ -110,7 +110,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/6">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://www.geodienste.ch/services/wildruhezonen" />
         <dcat:downloadURL rdf:resource="https://www.geodienste.ch/services/wildruhezonen" />
         <dct:description xml:lang="de">Abteilung Biodiversität und Landschaft</dct:description>
@@ -133,7 +133,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dcat:distribution>
-      <dcat:Distribution rdf:about="https://www.geocat.ch/geonetwork/srv/api/records/4a0c8bc7-89d1-484e-a34a-454a31267c41/distributions/7">
+      <dcat:Distribution>
         <dcat:accessURL rdf:resource="https://api3.geo.admin.ch/rest/services/api/MapServer/ch.bafu.wrz-wildruhezonen_portal" />
         <dct:title xml:lang="de">RESTful API von geo.admin.ch</dct:title>
         <dct:title xml:lang="fr">RESTful API de geo.admin.ch</dct:title>


### PR DESCRIPTION
This PR brings several fixes and enhancements to the DCAT-AP-CH formatter:

Bug fixes

Remove fictitious rdf:about attributes on dcat:Distribution elements. The previous implementation generated URLs like /srv/api/records/{uuid}/distributions/1 which do not exist in GeoNetwork. Distributions are now blank nodes, which is valid DCAT-AP-CH.
New file format support

Add CSV, GML, KML, SHP, GDB and GPKG to the list of supported distribution protocols, so that datasets exposing these download links now generate proper dcat:Distribution entries.
Add correct dcat:mediaType mappings: text/csv, application/gml+xml, application/vnd.google-earth.kml+xml, application/zip (for SHP/GDB/GPKG).
Protocol-based format detection now takes precedence over URL extension detection to avoid misidentifying e.g. a .zip URL carrying CSV data.