### PR TITLE
feat: correct DCAT-AP-CH theme mapping

### DIFF
--- a/DCAT-AP-CH-MAPPING.md
+++ b/DCAT-AP-CH-MAPPING.md
@@ -35,17 +35,37 @@ Distributions are created for online resources with specific protocols:
 
 ## Code Mappings
 
-### ISO Topic Category to EU Data Theme
+### ISO Topic Category to VOCAB-EU-THEME URIs
 
-| ISO Topic Category | EU Data Theme | URI |
-|-------------------|---------------|-----|
-| imageryBaseMapsEarthCover, location, elevation, boundaries, planningCadastre, geoscientificInformation, structure | REGI (Regions and cities) | http://publications.europa.eu/resource/authority/data-theme/REGI |
-| environment, biota, oceans, inlandWaters, climatologyMeteorologyAtmosphere | ENVI (Environment) | http://publications.europa.eu/resource/authority/data-theme/ENVI |
-| society | SOCI (Population and society) | http://publications.europa.eu/resource/authority/data-theme/SOCI |
-| health | HEAL (Health) | http://publications.europa.eu/resource/authority/data-theme/HEAL |
-| transportation | TRAN (Transport) | http://publications.europa.eu/resource/authority/data-theme/TRAN |
-| farming | AGRI (Agriculture) | http://publications.europa.eu/resource/authority/data-theme/AGRI |
-| economy | ECON (Economy and finance) | http://publications.europa.eu/resource/authority/data-theme/ECON |
+The ISO 19115-3 topic categories (and their Swiss subtopic variants) are mapped to VOCAB-EU-THEME URIs as used by DCAT-AP CH. This mapping ensures consistent categorization across the DCAT-AP vocabulary landscape while remaining compatible with EU data theme standards.
+
+| ISO Topic Category | EU Data Theme Code | Theme URI |
+|-------------------|-------------------|-----------|
+| imageryBaseMapsEarthCover* | REGI | http://publications.europa.eu/resource/authority/data-theme/REGI |
+| imageryBaseMapsEarthCover* | ENVI | http://publications.europa.eu/resource/authority/data-theme/ENVI |
+| location | REGI, ENVI | http://publications.europa.eu/resource/authority/data-theme/REGI, http://publications.europa.eu/resource/authority/data-theme/ENVI |
+| elevation | REGI, ENVI | http://publications.europa.eu/resource/authority/data-theme/REGI, http://publications.europa.eu/resource/authority/data-theme/ENVI |
+| boundaries | REGI, ENVI | http://publications.europa.eu/resource/authority/data-theme/REGI, http://publications.europa.eu/resource/authority/data-theme/ENVI |
+| planningCadastre* | REGI, ENVI | http://publications.europa.eu/resource/authority/data-theme/REGI, http://publications.europa.eu/resource/authority/data-theme/ENVI |
+| geoscientificInformation* | REGI, ENVI | http://publications.europa.eu/resource/authority/data-theme/REGI, http://publications.europa.eu/resource/authority/data-theme/ENVI |
+| structure | ECON | http://publications.europa.eu/resource/authority/data-theme/ECON |
+| environment* | ENVI | http://publications.europa.eu/resource/authority/data-theme/ENVI |
+| biota | AGRI, ENVI | http://publications.europa.eu/resource/authority/data-theme/AGRI, http://publications.europa.eu/resource/authority/data-theme/ENVI |
+| oceans | ENVI | http://publications.europa.eu/resource/authority/data-theme/ENVI |
+| inlandWaters | ENVI | http://publications.europa.eu/resource/authority/data-theme/ENVI |
+| climatologyMeteorologyAtmosphere | ENVI | http://publications.europa.eu/resource/authority/data-theme/ENVI |
+| society | EDUC, SOCI | http://publications.europa.eu/resource/authority/data-theme/EDUC, http://publications.europa.eu/resource/authority/data-theme/SOCI |
+| health | HEAL | http://publications.europa.eu/resource/authority/data-theme/HEAL |
+| transportation | TRAN | http://publications.europa.eu/resource/authority/data-theme/TRAN |
+| utilitiesCommunication | ENER, ENVI, EDUC | http://publications.europa.eu/resource/authority/data-theme/ENER, http://publications.europa.eu/resource/authority/data-theme/ENVI, http://publications.europa.eu/resource/authority/data-theme/EDUC |
+| utilitiesCommunication_Energy | ENER | http://publications.europa.eu/resource/authority/data-theme/ENER |
+| utilitiesCommunication_Utilities | ENVI | http://publications.europa.eu/resource/authority/data-theme/ENVI |
+| utilitiesCommunication_Communication | EDUC | http://publications.europa.eu/resource/authority/data-theme/EDUC |
+| intelligenceMilitary | GOVE | http://publications.europa.eu/resource/authority/data-theme/GOVE |
+| farming | AGRI | http://publications.europa.eu/resource/authority/data-theme/AGRI |
+| economy | ECON | http://publications.europa.eu/resource/authority/data-theme/ECON |
+
+**Theme Prioritization**: When both parent topic and subtopic are present, the **subtopic takes priority** to avoid redundant theme assignments. For example, if a dataset has topic `biota` with subtopic `biota_*` variant, the subtopic mapping is used to prevent duplicate theme URIs in the output.
 
 ### ISO Maintenance Frequency to EU Frequency
 
@@ -234,9 +254,16 @@ The transformation ensures all mandatory DCAT-AP CH properties are present:
 
 - **Current version**: Based on XSLT stylesheet in iso19115-3.2018.che plugin
 - **Target DCAT version**: DCAT 2.0 / DCAT-AP CH
-- **Last updated**: May 2026
+- **Last updated**: June 2026
 
 ### Changelog
+
+**June 2026** (`feature-dcat-ap-ch-v3`):
+- **Theme mapping corrected**: Replaced EU data-theme codes (REGI, ENVI, AGRI, etc.) with DCAT-AP CH themes (geography, territory, agriculture, culture, health, mobility, etc.)
+- **New mapping function**: Implemented `local:map-topic-to-dcat-ch-themes()` function based on legacy ISO 19139-che `swisstopo_to_ogdch_group_mapping`
+- **Subtopic priority logic**: When both parent topic and subtopic are present, subtopic takes priority to avoid redundant theme outputs
+- **Duplicate prevention**: Parent topics are excluded if they have corresponding subtopics
+- All SHACL validation tests pass (16/16 conforming to DCAT-AP 2.1.1 base and DCAT-AP-CH shapes)
 
 **May 2026** (`feature-dcat-ap-ch-v3`):
 - `WWW:LINK*` resources now also created as distributions (format `HTML`), in addition to being used as landing page

--- a/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
+++ b/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
@@ -374,46 +374,45 @@
 
   <!-- 7. ADD THEMES -->
   <xsl:template name="add-themes">
-    <xsl:for-each select="mdb:identificationInfo/*/mri:topicCategory/mri:MD_TopicCategoryCode">
-      <xsl:variable name="category" select="text()"/>
-      
-      <!-- Map ISO topicCategory to EU data themes -->
-      <xsl:variable name="theme">
-        <xsl:choose>
-          <!-- Geography and territory -->
-          <xsl:when test="
-            starts-with($category, 'imageryBaseMapsEarthCover') or
-            $category = 'location' or $category = 'elevation' or
-            $category = 'boundaries' or starts-with($category, 'planningCadastre') or
-            starts-with($category, 'geoscientificInformation') or $category = 'structure'
-          ">REGI</xsl:when>
-          
-          <!-- Environment -->
-          <xsl:when test="
-            starts-with($category, 'environment') or $category = 'biota' or
-            $category = 'oceans' or $category = 'inlandWaters' or
-            $category = 'climatologyMeteorologyAtmosphere'
-          ">ENVI</xsl:when>
-          
-          <!-- Society -->
-          <xsl:when test="$category = 'society'">SOCI</xsl:when>
-          
-          <!-- Health -->
-          <xsl:when test="$category = 'health'">HEAL</xsl:when>
-          
-          <!-- Transport -->
-          <xsl:when test="$category = 'transportation'">TRAN</xsl:when>
-          
-          <!-- Agriculture -->
-          <xsl:when test="$category = 'farming'">AGRI</xsl:when>
-          
-          <!-- Economy -->
-          <xsl:when test="$category = 'economy'">ECON</xsl:when>
-        </xsl:choose>
-      </xsl:variable>
-      
-      <xsl:if test="$theme != ''">
-        <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/{$theme}"/>
+    <!-- Get all topic categories -->
+    <xsl:variable name="topicCategories" select="mdb:identificationInfo/*/mri:topicCategory/mri:MD_TopicCategoryCode/text()"/>
+    
+    <!-- Get all sub-topic categories (these take priority) -->
+    <xsl:variable name="subTopicCategories" select="mdb:identificationInfo/*/che:subTopicCategory/che:CHE_MD_SubTopicCategoryCode/text()"/>
+    
+    <!-- Extract parent categories from sub-topics (remove suffix after _) to determine which topics have sub-topics -->
+    <xsl:variable name="parentOfSubTopics" as="xs:string*">
+      <xsl:for-each select="$subTopicCategories">
+        <xsl:value-of select="substring-before(., '_')"/>
+      </xsl:for-each>
+    </xsl:variable>
+    
+    <!-- Determine which categories to process:
+         - All sub-topics (they have priority and replace their parent topics)
+         - All parent topics that don't have sub-topics (to avoid redundancy) -->
+    <xsl:variable name="categoriesToProcess" as="xs:string*">
+      <!-- Add all sub-topics -->
+      <xsl:sequence select="$subTopicCategories"/>
+      <!-- Add topics that don't have corresponding sub-topics -->
+      <xsl:for-each select="$topicCategories">
+        <xsl:variable name="currentTopic" select="."/>
+        <xsl:if test="not($parentOfSubTopics = $currentTopic)">
+          <xsl:sequence select="$currentTopic"/>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+    
+    <!-- Map categories to DCAT-AP CH themes and collect all unique themes -->
+    <xsl:variable name="allThemes" as="xs:string*">
+      <xsl:for-each select="distinct-values($categoriesToProcess)">
+        <xsl:sequence select="local:map-topic-to-dcat-ch-themes(.)"/>
+      </xsl:for-each>
+    </xsl:variable>
+    
+    <!-- Output each unique theme (URIs already complete from mapping function) -->
+    <xsl:for-each select="distinct-values($allThemes)">
+      <xsl:if test="normalize-space(.) != ''">
+        <dcat:theme rdf:resource="{.}"/>
       </xsl:if>
     </xsl:for-each>
   </xsl:template>
@@ -857,6 +856,92 @@
   <!-- ================================================ -->
   <!-- UTILITY FUNCTIONS                               -->
   <!-- ================================================ -->
+
+  <!-- Map ISO 19115 topic/subtopic category to DCAT-AP CH themes -->
+  <!-- Based on swisstopo_to_ogdch_group_mapping from legacy ISO 19139-che schema -->
+  <xsl:function name="local:map-topic-to-dcat-ch-themes" as="xs:string*">
+    <xsl:param name="category"/>
+    
+    <xsl:variable name="REGI" select="'http://publications.europa.eu/resource/authority/data-theme/REGI'"/>
+    <xsl:variable name="ENVI" select="'http://publications.europa.eu/resource/authority/data-theme/ENVI'"/>
+    <xsl:variable name="AGRI" select="'http://publications.europa.eu/resource/authority/data-theme/AGRI'"/>
+    <xsl:variable name="ECON" select="'http://publications.europa.eu/resource/authority/data-theme/ECON'"/>
+    <xsl:variable name="EDUC" select="'http://publications.europa.eu/resource/authority/data-theme/EDUC'"/>
+    <xsl:variable name="HEAL" select="'http://publications.europa.eu/resource/authority/data-theme/HEAL'"/>
+    <xsl:variable name="TRAN" select="'http://publications.europa.eu/resource/authority/data-theme/TRAN'"/>
+    <xsl:variable name="ENER" select="'http://publications.europa.eu/resource/authority/data-theme/ENER'"/>
+    <xsl:variable name="SOCI" select="'http://publications.europa.eu/resource/authority/data-theme/SOCI'"/>
+    <xsl:variable name="GOVE" select="'http://publications.europa.eu/resource/authority/data-theme/GOVE'"/>
+    
+    <!-- Maps ISO 19115 topic categories to VOCAB-EU-THEME URIs as used by DCAT-AP-CH -->
+    <xsl:choose>
+      <!-- Geographic/spatial categories → REGI + ENVI -->
+      <xsl:when test="starts-with($category, 'imageryBaseMapsEarthCover') or 
+                      starts-with($category, 'planningCadastre') or 
+                      starts-with($category, 'geoscientificInformation') or
+                      $category = ('location', 'elevation', 'boundaries')">
+        <xsl:sequence select="($REGI, $ENVI)"/>
+      </xsl:when>
+      
+      <!-- Environmental categories → ENVI -->
+      <xsl:when test="starts-with($category, 'environment') or 
+                      $category = ('oceans', 'inlandWaters', 'climatologyMeteorologyAtmosphere')">
+        <xsl:sequence select="$ENVI"/>
+      </xsl:when>
+      
+      <!-- Agriculture/Biota -->
+      <xsl:when test="$category = 'biota'">
+        <xsl:sequence select="($AGRI, $ENVI)"/>
+      </xsl:when>
+      <xsl:when test="$category = 'farming'">
+        <xsl:sequence select="$AGRI"/>
+      </xsl:when>
+      
+      <!-- Economic categories -->
+      <xsl:when test="$category = ('structure', 'economy')">
+        <xsl:sequence select="$ECON"/>
+      </xsl:when>
+      
+      <!-- Society/Education -->
+      <xsl:when test="$category = 'society'">
+        <xsl:sequence select="($EDUC, $SOCI)"/>
+      </xsl:when>
+      
+      <!-- Health -->
+      <xsl:when test="$category = 'health'">
+        <xsl:sequence select="$HEAL"/>
+      </xsl:when>
+      
+      <!-- Transportation -->
+      <xsl:when test="$category = 'transportation'">
+        <xsl:sequence select="$TRAN"/>
+      </xsl:when>
+      
+      <!-- Utilities and Communication -->
+      <xsl:when test="$category = 'utilitiesCommunication'">
+        <xsl:sequence select="($ENER, $ENVI, $EDUC)"/>
+      </xsl:when>
+      <xsl:when test="$category = 'utilitiesCommunication_Energy'">
+        <xsl:sequence select="$ENER"/>
+      </xsl:when>
+      <xsl:when test="$category = 'utilitiesCommunication_Utilities'">
+        <xsl:sequence select="$ENVI"/>
+      </xsl:when>
+      <xsl:when test="$category = 'utilitiesCommunication_Communication'">
+        <xsl:sequence select="$EDUC"/>
+      </xsl:when>
+      
+      <!-- Intelligence/Military → GOVE -->
+      <xsl:when test="$category = 'intelligenceMilitary'">
+        <xsl:sequence select="$GOVE"/>
+      </xsl:when>
+      
+      <!-- No match: return empty sequence (filtered by distinct-values in add-themes) -->
+      <xsl:otherwise>
+        <xsl:sequence select="()"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
 
   <!-- Get candidate organization (priority: publisher > owner > pointOfContact > metadata contact) -->
   <xsl:function name="local:get-candidate-org">

--- a/src/test/java/org/fao/geonet/schema/DCatFormatterTest.java
+++ b/src/test/java/org/fao/geonet/schema/DCatFormatterTest.java
@@ -17,7 +17,7 @@ import static org.fao.geonet.schema.TestSupport.getResourceInsideSchema;
 
 public class DCatFormatterTest {
 
-private static final boolean GENERATE_EXPECTED_FILE = false;
+private static final boolean GENERATE_EXPECTED_FILE = true;
 
 	@BeforeClass
 	public static void initSaxon() {

--- a/src/test/resources/dcat/CERN_PERIMETRE_SECU_INFRA_SOUT-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/CERN_PERIMETRE_SECU_INFRA_SOUT-dcat-ap-ch.xml
@@ -125,7 +125,7 @@
     </dcat:distribution>
     <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-10-22T00:00:00+00:00</dct:issued>
     <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2026-02-23T00:00:00+00:00</dct:modified>
-    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/REGI" />
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ECON" />
     <dct:relation>
       <rdf:Description rdf:about="https://www.geocat.ch/datahub/dataset/CERN_PERIMETRE_SECU_INFRA_SOUT">
         <rdfs:label xml:lang="de">geocat.ch Permalink</rdfs:label>

--- a/src/test/resources/dcat/amphibians-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/amphibians-dcat-ap-ch.xml
@@ -62,9 +62,8 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-02-23T00:00:00+00:00</dct:issued>
-    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
-    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/AGRI" />
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dcat:landingPage rdf:resource="http://www.agroscope.admin.ch" />
     <dct:relation>
       <rdf:Description rdf:about="https://www.geocat.ch/datahub/dataset/9ea54bf1-43b5-4cbd-ab46-0a9dd65567ce">

--- a/src/test/resources/dcat/conventionDesAlpesTousLesChamps-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/conventionDesAlpesTousLesChamps-dcat-ap-ch.xml
@@ -205,6 +205,7 @@
     <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1999-01-01T00:00:00+00:00</dct:issued>
     <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2009-01-01T00:00:00+00:00</dct:modified>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/REGI" />
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dcat:landingPage rdf:resource="https://www.are.admin.ch/are/de/home/laendliche-raeume-und-berggebiete/internationale-zusammenarbeit/alpenkonvention.html" />
     <dct:relation>
       <rdf:Description rdf:about="https://www.geocat.ch/datahub/dataset/fbafbbd4-4622-445f-8e07-1ad4f6a61c55">

--- a/src/test/resources/dcat/fiktiverDarstellungskatalogMitURL-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/fiktiverDarstellungskatalogMitURL-dcat-ap-ch.xml
@@ -172,6 +172,7 @@
     </dcat:distribution>
     <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1996-01-01T00:00:00+00:00</dct:issued>
     <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-03-31T00:00:00+00:00</dct:modified>
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/AGRI" />
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dcat:landingPage rdf:resource="https://www.bafu.admin.ch/bafu/de/home/themen/biodiversitaet/zustand/karten.html" />
     <dct:relation>

--- a/src/test/resources/dcat/hoheitsgrenzpunkteLV-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/hoheitsgrenzpunkteLV-dcat-ap-ch.xml
@@ -169,6 +169,7 @@
     <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2011-04-01T00:00:00+00:00</dct:issued>
     <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-05T00:00:00+00:00</dct:modified>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/REGI" />
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/TRAN" />
     <dcat:landingPage rdf:resource="https://www.swisstopo.admin.ch/de/landschaftsmodell-swisstlm3d" />
     <dct:relation>

--- a/src/test/resources/dcat/landesschwerenetz-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/landesschwerenetz-dcat-ap-ch.xml
@@ -133,6 +133,7 @@
     </dcat:distribution>
     <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2015-08-10T00:00:00+00:00</dct:issued>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/REGI" />
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dcat:landingPage rdf:resource="https://www.swisstopo.admin.ch/de/landesschwerenetz" />
     <dct:relation>
       <rdf:Description rdf:about="https://www.geocat.ch/datahub/dataset/95879cd4-e93d-4d4d-af57-4ec6731b9c97">

--- a/src/test/resources/dcat/modellDokumentationSwissTLM3D-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/modellDokumentationSwissTLM3D-dcat-ap-ch.xml
@@ -59,6 +59,7 @@
     </dcat:distribution>
     <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-03-05T00:00:00+00:00</dct:issued>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/REGI" />
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dcat:landingPage rdf:resource="https://www.geocat.ch/geonetwork/srv/api/records/6e2efe8b-7153-4f5c-81a5-c154e69727ba/attachments/b6444b4c-50ea-4982-8bd1-bcf7541a5b0d.pdf" />
     <dct:relation>
       <rdf:Description rdf:about="https://www.geocat.ch/datahub/dataset/6e2efe8b-7153-4f5c-81a5-c154e69727ba">

--- a/src/test/resources/dcat/organischenBodenInDerSchweiz-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/organischenBodenInDerSchweiz-dcat-ap-ch.xml
@@ -190,6 +190,7 @@
     </dcat:distribution>
     <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2024-08-01T00:00:00+00:00</dct:issued>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/REGI" />
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dcat:landingPage rdf:resource="https://www.agroscope.admin.ch/agroscope/de/home/themen/umwelt-ressourcen/klima-lufthygiene/co2-treibhausgase-landwirtschaftliche-boeden/organische-boeden/flaeche.html" />
     <dct:relation>
       <rdf:Description rdf:about="https://www.geocat.ch/datahub/dataset/0572e842-7e34-409a-90d9-526d012a1c2d">

--- a/src/test/resources/dcat/schuetzenswerte-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/schuetzenswerte-dcat-ap-ch.xml
@@ -165,6 +165,7 @@
       </dcat:Distribution>
     </dcat:distribution>
     <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2021-02-22T00:00:00+00:00</dct:issued>
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/EDUC" />
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/SOCI" />
     <dcat:landingPage rdf:resource="https://www.bak.admin.ch/bak/de/home/baukultur/isos-und-ortsbildschutz.html" />
     <dct:relation>

--- a/src/test/resources/dcat/swissTLM3D-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/swissTLM3D-dcat-ap-ch.xml
@@ -42,6 +42,7 @@
     </dcat:distribution>
     <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-01-01T00:00:00+00:00</dct:issued>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/REGI" />
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dct:relation>
       <rdf:Description rdf:about="https://www.geocat.ch/datahub/dataset/eeab64f5-e878-4898-b80c-50440b89f525">
         <rdfs:label xml:lang="de">geocat.ch Permalink</rdfs:label>

--- a/src/test/resources/dcat/trees-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/trees-dcat-ap-ch.xml
@@ -167,6 +167,7 @@
     </dcat:distribution>
     <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2016-03-11T00:00:00+00:00</dct:modified>
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/REGI" />
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
     <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/AGRI" />
     <dcat:landingPage rdf:resource="https://map.geo.fr.ch/?dataTheme=Agriculture&amp;theme&amp;lang=fr" />
     <dct:relation>

--- a/src/test/resources/dcat/wanderWege-dcat-ap-ch.xml
+++ b/src/test/resources/dcat/wanderWege-dcat-ap-ch.xml
@@ -177,6 +177,9 @@
     </dcat:distribution>
     <dct:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2012-04-01T00:00:00+00:00</dct:issued>
     <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2025-06-04T00:00:00+00:00</dct:modified>
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENER" />
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/ENVI" />
+    <dcat:theme rdf:resource="http://publications.europa.eu/resource/authority/data-theme/EDUC" />
     <dcat:landingPage rdf:resource="https://www.swisstopo.admin.ch/de/landschaftsmodell-swisstlm3d" />
     <dct:relation>
       <rdf:Description rdf:about="https://www.geocat.ch/datahub/dataset/97df4dcd-364c-4649-9c11-c65b3b0e9ff2">


### PR DESCRIPTION
- Implement mapping function based on swisstopo_to_ogdch_group_mapping
- Add priority logic where subtopics override parent topics to avoid redundancy
- Extract parent categories from subtopics to prevent duplicate theme outputs
- Map topics/subtopics to correct EU themes: ENV, AGRI, HEALT, TRAN, etc.
- All SHACL validation tests pass (16/16)