### PR TITLE
Feature dcat ap ch v5

### DIFF
--- a/DCAT-AP-CH-MAPPING.md
+++ b/DCAT-AP-CH-MAPPING.md
@@ -109,10 +109,11 @@ The ISO 19115-3 topic categories (and their Swiss subtopic variants) are mapped 
 | *.gml | GML | http://publications.europa.eu/resource/authority/file-type/GML |
 | *.kml | KML | http://publications.europa.eu/resource/authority/file-type/KML |
 | *.csv | CSV | http://publications.europa.eu/resource/authority/file-type/CSV |
-| *.xml | XML | http://publications.europa.eu/resource/authority/file-type/XML |
+| *.xml, *.ili, *.xtf, *.itf | XML | http://publications.europa.eu/resource/authority/file-type/XML |
 | *.zip | ZIP | http://publications.europa.eu/resource/authority/file-type/ZIP |
 | *.pdf | PDF | http://publications.europa.eu/resource/authority/file-type/PDF |
 | *.html, *.htm | HTML | http://publications.europa.eu/resource/authority/file-type/HTML |
+| WWW:DOWNLOAD* (no extension) | HTML | http://publications.europa.eu/resource/authority/file-type/HTML |
 | (unknown) | UNSPECIFIED | http://publications.europa.eu/resource/authority/file-type/UNSPECIFIED |
 
 ### License Mapping
@@ -263,6 +264,8 @@ The transformation ensures all mandatory DCAT-AP CH properties are present:
 - **New mapping function**: Implemented `local:map-topic-to-dcat-ch-themes()` function based on legacy ISO 19139-che `swisstopo_to_ogdch_group_mapping`
 - **Subtopic priority logic**: When both parent topic and subtopic are present, subtopic takes priority to avoid redundant theme outputs
 - **Duplicate prevention**: Parent topics are excluded if they have corresponding subtopics
+- **INTERLIS format support**: Added mapping for Swiss INTERLIS formats (*.ili, *.xtf, *.itf) → XML format
+- **WWW:DOWNLOAD fallback**: Resources with `WWW:DOWNLOAD*` protocol but no file extension now default to HTML format (web page/download form)
 - All SHACL validation tests pass (16/16 conforming to DCAT-AP 2.1.1 base and DCAT-AP-CH shapes)
 
 **May 2026** (`feature-dcat-ap-ch-v3`):

--- a/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
+++ b/src/main/plugin/iso19115-3.2018.che/formatter/dcat-ap-ch/dcat-ap-ch-core-dataset.xsl
@@ -593,10 +593,10 @@
 
   <!-- 16. ADD DOCUMENTATION -->
   <xsl:template name="add-documentation">
-    <!-- foaf:page: WWW:LINK with function 'information' -->
+    <!-- foaf:page: WWW:LINK or WWW:DOWNLOAD with function 'information' -->
     <xsl:for-each select="
       mdb:distributionInfo//mrd:onLine[
-        starts-with((*/cit:protocol/*/text())[1], 'WWW:LINK') and
+        (starts-with((*/cit:protocol/*/text())[1], 'WWW:LINK') or starts-with((*/cit:protocol/*/text())[1], 'WWW:DOWNLOAD')) and
         */cit:function/*/@codeListValue = 'information'
       ]
     ">
@@ -661,7 +661,7 @@
         <xsl:when test="starts-with($protocol, 'ESRI:REST') or contains($protocolLower, 'restful') or contains($protocolLower, 'arcgis rest') or contains($protocolLower, 'rest api')">
           <xsl:text>http://publications.europa.eu/resource/authority/file-type/REST</xsl:text>
         </xsl:when>
-        <xsl:when test="starts-with($protocol, 'WWW:LINK') or contains($protocolLower, 'web portal') or contains($protocolLower, 'web atlas')">
+        <xsl:when test="starts-with($protocol, 'WWW:LINK') or starts-with($protocol, 'WWW:DOWNLOAD-APP') or contains($protocolLower, 'web portal') or contains($protocolLower, 'web atlas')">
           <xsl:text>http://publications.europa.eu/resource/authority/file-type/HTML</xsl:text>
         </xsl:when>
         <xsl:when test="starts-with($protocol, 'MAP:Preview')">
@@ -679,6 +679,7 @@
         <xsl:when test="contains($protocolLower, 'gpkg') or contains($protocolLower, 'geopackage')">http://publications.europa.eu/resource/authority/file-type/GPKG</xsl:when>
         <xsl:when test="contains($protocolLower, 'shp') or contains($protocolLower, 'shapefile')">http://publications.europa.eu/resource/authority/file-type/SHP</xsl:when>
         <xsl:when test="contains($protocolLower, 'txt')">http://publications.europa.eu/resource/authority/file-type/TXT</xsl:when>
+        <xsl:when test="contains($protocolLower, 'interlis') or contains($protocolLower, 'ili') or contains($protocolLower, 'xtf') or contains($protocolLower, 'itf')">http://publications.europa.eu/resource/authority/file-type/XML</xsl:when>
 
         <!-- File formats by URL extension (fallback) -->
         <xsl:when test="ends-with($urlBase, '.shp')">http://publications.europa.eu/resource/authority/file-type/SHP</xsl:when>
@@ -688,10 +689,13 @@
         <xsl:when test="ends-with($urlBase, '.gml')">http://publications.europa.eu/resource/authority/file-type/GML</xsl:when>
         <xsl:when test="ends-with($urlBase, '.kml')">http://publications.europa.eu/resource/authority/file-type/KML</xsl:when>
         <xsl:when test="ends-with($urlBase, '.csv')">http://publications.europa.eu/resource/authority/file-type/CSV</xsl:when>
-        <xsl:when test="ends-with($urlBase, '.xml')">http://publications.europa.eu/resource/authority/file-type/XML</xsl:when>
+        <xsl:when test="ends-with($urlBase, '.xml') or ends-with($urlBase, '.ili') or ends-with($urlBase, '.xtf') or ends-with($urlBase, '.itf')">http://publications.europa.eu/resource/authority/file-type/XML</xsl:when>
         <xsl:when test="ends-with($urlBase, '.zip')">http://publications.europa.eu/resource/authority/file-type/ZIP</xsl:when>
         <xsl:when test="ends-with($urlBase, '.pdf')">http://publications.europa.eu/resource/authority/file-type/PDF</xsl:when>
         <xsl:when test="ends-with($urlBase, '.html') or ends-with($urlBase, '.htm')">http://publications.europa.eu/resource/authority/file-type/HTML</xsl:when>
+        
+        <!-- Fallback: WWW:DOWNLOAD* resources without file extension are typically web pages or forms -->
+        <xsl:when test="starts-with($protocol, 'WWW:DOWNLOAD')">http://publications.europa.eu/resource/authority/file-type/HTML</xsl:when>
         
         <!-- Default -->
         <xsl:otherwise>http://publications.europa.eu/resource/authority/file-type/UNSPECIFIED</xsl:otherwise>
@@ -817,7 +821,7 @@
     <xsl:variable name="mediaType">
       <xsl:choose>
         <!-- HTML pages and web links -->
-        <xsl:when test="starts-with($protocol, 'WWW:LINK') or contains($protocolLowerMT, 'web portal') or contains($protocolLowerMT, 'web atlas')">text/html</xsl:when>
+        <xsl:when test="starts-with($protocol, 'WWW:LINK') or starts-with($protocol, 'WWW:DOWNLOAD-APP') or contains($protocolLowerMT, 'web portal') or contains($protocolLowerMT, 'web atlas')">text/html</xsl:when>
         <!-- Service protocols: no media type (XML envelope differs per service) -->
         <xsl:when test="starts-with($protocol, 'OGC:') or starts-with($protocol, 'ESRI:') or contains($protocolLowerMT, 'wms') or contains($protocolLowerMT, 'wmts') or contains($protocolLowerMT, 'wfs') or contains($protocolLowerMT, 'restful') or contains($protocolLowerMT, 'arcgis rest')"></xsl:when>
         <!-- Downloads: derive media type from protocol name or URL extension -->
@@ -834,7 +838,7 @@
             <xsl:when test="contains($protocolLowerMT, 'shp') or contains($protocolLowerMT, 'shapefile') or ends-with($urlBaseMT, '.shp')">application/octet-stream</xsl:when>
             <xsl:when test="ends-with($urlBaseMT, '.zip') or contains($protocolLowerMT, 'zip')">application/zip</xsl:when>
             <xsl:when test="ends-with($urlBaseMT, '.html') or ends-with($urlBaseMT, '.htm')">text/html</xsl:when>
-            <xsl:when test="ends-with($urlBaseMT, '.xml')">application/xml</xsl:when>
+            <xsl:when test="ends-with($urlBaseMT, '.xml') or ends-with($urlBaseMT, '.ili') or ends-with($urlBaseMT, '.xtf') or ends-with($urlBaseMT, '.itf')">application/xml</xsl:when>
           </xsl:choose>
         </xsl:when>
         <!-- Other known formats -->


### PR DESCRIPTION
- Add support for INTERLIS file formats (.ili, .xtf, .itf) → XML format
- Add media-type application/xml for INTERLIS files
- Add fallback to HTML format for WWW:DOWNLOAD* resources without file extension
- Update DCAT-AP-CH-MAPPING.md documentation with new format mappings
- Resolve issue where INTERLIS and web-download resources returned UNSPECIFIED